### PR TITLE
feat(server): add tick scheduler

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/tick/FixedRateTickScheduler.java
+++ b/src/main/java/io/taanielo/jmud/core/tick/FixedRateTickScheduler.java
@@ -1,0 +1,94 @@
+package io.taanielo.jmud.core.tick;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FixedRateTickScheduler implements TickScheduler {
+
+    private final TickRegistry tickRegistry;
+    private final ScheduledExecutorService executor;
+    private final ExecutorService tickExecutor;
+    private final long intervalMillis;
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private ScheduledFuture<?> task;
+
+    public FixedRateTickScheduler(TickRegistry tickRegistry) {
+        this(
+            tickRegistry,
+            TickSettings.resolveIntervalMillis(),
+            Executors.newScheduledThreadPool(1, Thread.ofVirtual().name("tick-", 0).factory()),
+            Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("tick-worker-", 0).factory())
+        );
+    }
+
+    public FixedRateTickScheduler(
+        TickRegistry tickRegistry,
+        long intervalMillis,
+        ScheduledExecutorService executor,
+        ExecutorService tickExecutor
+    ) {
+        this.tickRegistry = Objects.requireNonNull(tickRegistry, "Tick registry is required");
+        this.executor = Objects.requireNonNull(executor, "Executor is required");
+        this.tickExecutor = Objects.requireNonNull(tickExecutor, "Tick executor is required");
+        if (intervalMillis <= 0) {
+            throw new IllegalArgumentException("Tick interval must be positive");
+        }
+        this.intervalMillis = intervalMillis;
+    }
+
+    @Override
+    public void start() {
+        if (!started.compareAndSet(false, true)) {
+            return;
+        }
+        task = executor.scheduleAtFixedRate(this::runTick, 0, intervalMillis, TimeUnit.MILLISECONDS);
+        log.info("Tick scheduler started with interval {} ms", intervalMillis);
+    }
+
+    @Override
+    public void stop() {
+        if (!started.compareAndSet(true, false)) {
+            return;
+        }
+        if (task != null) {
+            task.cancel(false);
+        }
+        executor.shutdown();
+        tickExecutor.shutdown();
+        try {
+            if (!executor.awaitTermination(2, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+            if (!tickExecutor.awaitTermination(2, TimeUnit.SECONDS)) {
+                tickExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            executor.shutdownNow();
+            tickExecutor.shutdownNow();
+        }
+        log.info("Tick scheduler stopped");
+    }
+
+    private void runTick() {
+        for (Tickable tickable : tickRegistry.snapshot()) {
+            tickExecutor.execute(() -> runTickableSafely(tickable));
+        }
+    }
+
+    private void runTickableSafely(Tickable tickable) {
+        try {
+            tickable.tick();
+        } catch (Exception e) {
+            log.error("Tickable failed during tick", e);
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/tick/TickRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/tick/TickRegistry.java
@@ -1,0 +1,23 @@
+package io.taanielo.jmud.core.tick;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class TickRegistry {
+    private final CopyOnWriteArrayList<Tickable> tickables = new CopyOnWriteArrayList<>();
+
+    public void register(Tickable tickable) {
+        if (tickable == null) {
+            throw new IllegalArgumentException("Tickable is required");
+        }
+        tickables.addIfAbsent(tickable);
+    }
+
+    public void unregister(Tickable tickable) {
+        tickables.remove(tickable);
+    }
+
+    public List<Tickable> snapshot() {
+        return List.copyOf(tickables);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/tick/TickScheduler.java
+++ b/src/main/java/io/taanielo/jmud/core/tick/TickScheduler.java
@@ -1,0 +1,6 @@
+package io.taanielo.jmud.core.tick;
+
+public interface TickScheduler {
+    void start();
+    void stop();
+}

--- a/src/main/java/io/taanielo/jmud/core/tick/TickSettings.java
+++ b/src/main/java/io/taanielo/jmud/core/tick/TickSettings.java
@@ -1,0 +1,24 @@
+package io.taanielo.jmud.core.tick;
+
+public final class TickSettings {
+    public static final long DEFAULT_INTERVAL_MS = 500;
+
+    private TickSettings() {
+    }
+
+    public static long resolveIntervalMillis() {
+        String value = System.getProperty("jmud.tick.interval.ms");
+        if (value == null || value.isBlank()) {
+            return DEFAULT_INTERVAL_MS;
+        }
+        try {
+            long interval = Long.parseLong(value);
+            if (interval <= 0) {
+                throw new IllegalArgumentException("Tick interval must be positive");
+            }
+            return interval;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid tick interval value: " + value, e);
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/tick/Tickable.java
+++ b/src/main/java/io/taanielo/jmud/core/tick/Tickable.java
@@ -1,0 +1,5 @@
+package io.taanielo.jmud.core.tick;
+
+public interface Tickable {
+    void tick();
+}

--- a/src/main/java/io/taanielo/jmud/core/tick/system/CooldownSystem.java
+++ b/src/main/java/io/taanielo/jmud/core/tick/system/CooldownSystem.java
@@ -1,0 +1,40 @@
+package io.taanielo.jmud.core.tick.system;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.taanielo.jmud.core.tick.Tickable;
+
+public class CooldownSystem implements Tickable {
+
+    private final Map<String, AtomicInteger> cooldowns = new ConcurrentHashMap<>();
+
+    public void register(String key, int ticks) {
+        Objects.requireNonNull(key, "Cooldown key is required");
+        if (key.isBlank()) {
+            throw new IllegalArgumentException("Cooldown key must not be blank");
+        }
+        if (ticks <= 0) {
+            cooldowns.remove(key);
+            return;
+        }
+        cooldowns.put(key, new AtomicInteger(ticks));
+    }
+
+    public boolean isOnCooldown(String key) {
+        AtomicInteger remaining = cooldowns.get(key);
+        return remaining != null && remaining.get() > 0;
+    }
+
+    @Override
+    public void tick() {
+        for (Map.Entry<String, AtomicInteger> entry : cooldowns.entrySet()) {
+            int remaining = entry.getValue().decrementAndGet();
+            if (remaining <= 0) {
+                cooldowns.remove(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/tick/FixedRateTickSchedulerTest.java
+++ b/src/test/java/io/taanielo/jmud/core/tick/FixedRateTickSchedulerTest.java
@@ -1,0 +1,42 @@
+package io.taanielo.jmud.core.tick;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+class FixedRateTickSchedulerTest {
+
+    @Test
+    void invokesTickablesOnSchedule() throws Exception {
+        TickRegistry registry = new TickRegistry();
+        AtomicInteger ticks = new AtomicInteger();
+        CountDownLatch latch = new CountDownLatch(3);
+        registry.register(() -> {
+            ticks.incrementAndGet();
+            latch.countDown();
+        });
+
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
+            Thread.ofVirtual().name("tick-test-", 0).factory()
+        );
+        FixedRateTickScheduler scheduler = new FixedRateTickScheduler(
+            registry,
+            10,
+            executor,
+            Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("tick-worker-test-", 0).factory())
+        );
+
+        scheduler.start();
+        boolean completed = latch.await(1, TimeUnit.SECONDS);
+        scheduler.stop();
+
+        assertTrue(completed);
+        assertTrue(ticks.get() >= 3);
+    }
+}


### PR DESCRIPTION
## Summary
- add tick registry/scheduler with virtual threads and configurable interval
- introduce a tick-driven cooldown system and wire ticks into the socket server lifecycle
- run socket clients on virtual threads and add scheduler tests

## Testing
- not run (local environment)

## Related
- Closes #9