### PR TITLE
feat(world): add room navigation

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/world/Direction.java
+++ b/src/main/java/io/taanielo/jmud/core/world/Direction.java
@@ -1,0 +1,56 @@
+package io.taanielo.jmud.core.world;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+public enum Direction {
+    NORTH("north", "n"),
+    SOUTH("south", "s"),
+    EAST("east", "e"),
+    WEST("west", "w"),
+    UP("up", "u"),
+    DOWN("down", "d");
+
+    private static final Map<String, Direction> LOOKUP = Map.ofEntries(
+        Map.entry("north", NORTH),
+        Map.entry("n", NORTH),
+        Map.entry("south", SOUTH),
+        Map.entry("s", SOUTH),
+        Map.entry("east", EAST),
+        Map.entry("e", EAST),
+        Map.entry("west", WEST),
+        Map.entry("w", WEST),
+        Map.entry("up", UP),
+        Map.entry("u", UP),
+        Map.entry("down", DOWN),
+        Map.entry("d", DOWN)
+    );
+
+    private final String label;
+    private final String shortLabel;
+
+    Direction(String label, String shortLabel) {
+        this.label = label;
+        this.shortLabel = shortLabel;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public String shortLabel() {
+        return shortLabel;
+    }
+
+    public static Optional<Direction> fromInput(String input) {
+        if (input == null) {
+            return Optional.empty();
+        }
+        String key = input.trim().toLowerCase(Locale.ROOT);
+        if (key.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(LOOKUP.get(key));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/Room.java
+++ b/src/main/java/io/taanielo/jmud/core/world/Room.java
@@ -1,24 +1,38 @@
 package io.taanielo.jmud.core.world;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import lombok.Value;
+
+import io.taanielo.jmud.core.authentication.Username;
 
 @Value
 public class Room {
     RoomId id;
     String name;
     String description;
+    Map<Direction, RoomId> exits;
     List<Item> items;
+    List<Username> occupants;
 
-    public Room(RoomId id, String name, String description, List<Item> items) {
+    public Room(
+        RoomId id,
+        String name,
+        String description,
+        Map<Direction, RoomId> exits,
+        List<Item> items,
+        List<Username> occupants
+    ) {
         this.id = Objects.requireNonNull(id, "Room id is required");
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("Room name must not be blank");
         }
         this.name = name;
         this.description = Objects.requireNonNull(description, "Room description is required");
+        this.exits = Map.copyOf(Objects.requireNonNull(exits, "Room exits are required"));
         this.items = List.copyOf(Objects.requireNonNull(items, "Room items are required"));
+        this.occupants = List.copyOf(Objects.requireNonNull(occupants, "Room occupants are required"));
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/RoomService.java
+++ b/src/main/java/io/taanielo/jmud/core/world/RoomService.java
@@ -1,0 +1,127 @@
+package io.taanielo.jmud.core.world;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+public class RoomService {
+
+    public record LookResult(List<String> lines, Room room) {
+    }
+
+    public record MoveResult(boolean moved, List<String> lines, Room room) {
+    }
+
+    private final RoomRepository roomRepository;
+    private final RoomId startingRoomId;
+    private final ConcurrentHashMap<Username, RoomId> playerLocations = new ConcurrentHashMap<>();
+
+    public RoomService(RoomRepository roomRepository, RoomId startingRoomId) {
+        this.roomRepository = Objects.requireNonNull(roomRepository, "Room repository is required");
+        this.startingRoomId = Objects.requireNonNull(startingRoomId, "Starting room id is required");
+    }
+
+    public RoomId ensurePlayerLocation(Username username) {
+        Objects.requireNonNull(username, "Username is required");
+        return playerLocations.computeIfAbsent(username, ignored -> startingRoomId);
+    }
+
+    public LookResult look(Username username) {
+        Objects.requireNonNull(username, "Username is required");
+        Room room = loadRoomForPlayer(username);
+        if (room == null) {
+            return new LookResult(List.of("You are nowhere. The world feels unfinished."), null);
+        }
+        Room roomWithOccupants = withOccupants(room);
+        return new LookResult(describeRoom(roomWithOccupants, username), roomWithOccupants);
+    }
+
+    public MoveResult move(Username username, Direction direction) {
+        Objects.requireNonNull(username, "Username is required");
+        Objects.requireNonNull(direction, "Direction is required");
+        Room room = loadRoomForPlayer(username);
+        if (room == null) {
+            return new MoveResult(false, List.of("You cannot move yet. The world has no rooms."), null);
+        }
+        RoomId destinationId = room.getExits().get(direction);
+        if (destinationId == null) {
+            return new MoveResult(false, List.of("You cannot go " + direction.label() + "."), room);
+        }
+        Room destination = roomRepository.findById(destinationId).orElse(null);
+        if (destination == null) {
+            return new MoveResult(false, List.of("The way " + direction.label() + " is blocked."), room);
+        }
+        playerLocations.put(username, destinationId);
+        Room destinationWithOccupants = withOccupants(destination);
+        List<String> lines = new ArrayList<>();
+        lines.add("You move " + direction.label() + ".");
+        lines.addAll(describeRoom(destinationWithOccupants, username));
+        return new MoveResult(true, lines, destinationWithOccupants);
+    }
+
+    private Room loadRoomForPlayer(Username username) {
+        RoomId roomId = ensurePlayerLocation(username);
+        return roomRepository.findById(roomId).orElse(null);
+    }
+
+    private Room withOccupants(Room room) {
+        List<Username> occupants = playerLocations.entrySet().stream()
+            .filter(entry -> entry.getValue().equals(room.getId()))
+            .map(Entry::getKey)
+            .toList();
+        return new Room(
+            room.getId(),
+            room.getName(),
+            room.getDescription(),
+            room.getExits(),
+            room.getItems(),
+            occupants
+        );
+    }
+
+    private List<String> describeRoom(Room room, Username viewer) {
+        List<String> lines = new ArrayList<>();
+        lines.add(room.getName());
+        lines.add(room.getDescription());
+        lines.add("Exits: " + formatExits(room.getExits()));
+        lines.add("Items: " + formatItems(room.getItems()));
+        lines.add("Occupants: " + formatOccupants(room.getOccupants(), viewer));
+        return lines;
+    }
+
+    private String formatExits(java.util.Map<Direction, RoomId> exits) {
+        if (exits.isEmpty()) {
+            return "none";
+        }
+        return exits.keySet().stream()
+            .map(Direction::label)
+            .sorted()
+            .collect(Collectors.joining(", "));
+    }
+
+    private String formatItems(List<Item> items) {
+        if (items.isEmpty()) {
+            return "none";
+        }
+        return items.stream()
+            .map(Item::getName)
+            .collect(Collectors.joining(", "));
+    }
+
+    private String formatOccupants(List<Username> occupants, Username viewer) {
+        List<String> names = occupants.stream()
+            .filter(username -> !username.equals(viewer))
+            .map(Username::getValue)
+            .toList();
+        if (names.isEmpty()) {
+            return "none";
+        }
+        return String.join(", ", names);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/repository/InMemoryRoomRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/world/repository/InMemoryRoomRepository.java
@@ -1,0 +1,60 @@
+package io.taanielo.jmud.core.world.repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.taanielo.jmud.core.world.Direction;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+
+public class InMemoryRoomRepository implements RoomRepository {
+
+    private final Map<RoomId, Room> rooms;
+
+    public InMemoryRoomRepository() {
+        RoomId trainingYardId = RoomId.of("training-yard");
+        RoomId armoryId = RoomId.of("armory");
+        RoomId courtyardId = RoomId.of("courtyard");
+
+        Room trainingYard = new Room(
+            trainingYardId,
+            "Training Yard",
+            "A dusty yard with practice dummies and scattered weapons.",
+            Map.of(Direction.NORTH, armoryId, Direction.EAST, courtyardId),
+            List.of(new Item(ItemId.of("iron-sword"), "Iron Sword", "A plain iron sword with a worn leather grip.")),
+            List.of()
+        );
+
+        Room armory = new Room(
+            armoryId,
+            "Armory",
+            "A compact room lined with weapon racks and oiled leather armor.",
+            Map.of(Direction.SOUTH, trainingYardId),
+            List.of(new Item(ItemId.of("training-shield"), "Training Shield", "A wooden shield used for drills.")),
+            List.of()
+        );
+
+        Room courtyard = new Room(
+            courtyardId,
+            "Courtyard",
+            "A breezy courtyard with a stone fountain in the center.",
+            Map.of(Direction.WEST, trainingYardId),
+            List.of(),
+            List.of()
+        );
+
+        this.rooms = Map.of(
+            trainingYardId, trainingYard,
+            armoryId, armory,
+            courtyardId, courtyard
+        );
+    }
+
+    @Override
+    public Optional<Room> findById(RoomId id) {
+        return Optional.ofNullable(rooms.get(id));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/repository/RoomRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/world/repository/RoomRepository.java
@@ -6,6 +6,5 @@ import io.taanielo.jmud.core.world.Room;
 import io.taanielo.jmud.core.world.RoomId;
 
 public interface RoomRepository {
-    void save(Room room) throws RepositoryException;
-    Optional<Room> findById(RoomId id) throws RepositoryException;
+    Optional<Room> findById(RoomId id);
 }

--- a/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
@@ -1,0 +1,101 @@
+package io.taanielo.jmud.core.world;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+class RoomServiceTest {
+
+    @Test
+    void movesBetweenRoomsUsingExits() {
+        RoomId roomAId = RoomId.of("a");
+        RoomId roomBId = RoomId.of("b");
+        Room roomA = new Room(
+            roomAId,
+            "Room A",
+            "A quiet room.",
+            Map.of(Direction.NORTH, roomBId),
+            List.of(),
+            List.of()
+        );
+        Room roomB = new Room(
+            roomBId,
+            "Room B",
+            "A bright room.",
+            Map.of(Direction.SOUTH, roomAId),
+            List.of(),
+            List.of()
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA, roomBId, roomB)), roomAId);
+
+        Username player = Username.of("Bob");
+        service.ensurePlayerLocation(player);
+        RoomService.MoveResult moveResult = service.move(player, Direction.NORTH);
+
+        assertTrue(moveResult.moved());
+        assertTrue(moveResult.lines().getFirst().contains("move north"));
+    }
+
+    @Test
+    void rejectsInvalidMove() {
+        RoomId roomAId = RoomId.of("a");
+        Room roomA = new Room(
+            roomAId,
+            "Room A",
+            "A quiet room.",
+            Map.of(),
+            List.of(),
+            List.of()
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA)), roomAId);
+
+        Username player = Username.of("Bob");
+        service.ensurePlayerLocation(player);
+        RoomService.MoveResult moveResult = service.move(player, Direction.WEST);
+
+        assertFalse(moveResult.moved());
+        assertTrue(moveResult.lines().getFirst().contains("cannot go west"));
+    }
+
+    @Test
+    void lookShowsExitsItemsAndOccupants() {
+        RoomId roomAId = RoomId.of("a");
+        Item item = new Item(ItemId.of("torch"), "Torch", "A warm torch.");
+        Room roomA = new Room(
+            roomAId,
+            "Room A",
+            "A quiet room.",
+            Map.of(Direction.EAST, RoomId.of("b")),
+            List.of(item),
+            List.of()
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA)), roomAId);
+
+        Username bob = Username.of("Bob");
+        Username alice = Username.of("Alice");
+        service.ensurePlayerLocation(bob);
+        service.ensurePlayerLocation(alice);
+
+        RoomService.LookResult lookResult = service.look(bob);
+        String output = String.join("\n", lookResult.lines());
+
+        assertTrue(output.contains("Exits: east"));
+        assertTrue(output.contains("Items: Torch"));
+        assertTrue(output.contains("Occupants: Alice"));
+    }
+
+    private record TestRoomRepository(Map<RoomId, Room> rooms) implements RoomRepository {
+        @Override
+        public Optional<Room> findById(RoomId id) {
+            return Optional.ofNullable(rooms.get(id));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add room domain model with exits, items, and occupants plus in-memory fixtures
- introduce RoomService for look/move flows and wire it into socket clients
- add movement aliases, case-insensitive command parsing, and room navigation tests

## Testing
- not run (local environment)

## Related
- Closes #10