### PR TITLE
feat(output): add optional ansi styling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,9 @@ Available keys:
 - `jmud.prompt.format`
 - `jmud.effects.enabled`
 - `jmud.tick.interval.ms`
+- `jmud.output.ansi.enabled` (default ANSI colors for new players)
+
+Players can toggle ANSI output in-game with `ANSI on|off|toggle|status`.
 
 ## Basics of Java Telnet Socket Connection
 

--- a/src/main/java/io/taanielo/jmud/core/messaging/WelcomeMessage.java
+++ b/src/main/java/io/taanielo/jmud/core/messaging/WelcomeMessage.java
@@ -4,8 +4,11 @@ import java.io.IOException;
 
 import lombok.Value;
 
+import io.taanielo.jmud.core.output.TextStyler;
+
 @Value(staticConstructor = "of")
 public class WelcomeMessage implements Message {
+    TextStyler textStyler;
     int onlineCount;
 
     private static final String[] BANNER = {
@@ -25,15 +28,15 @@ public class WelcomeMessage implements Message {
         messageWriter.writeLine();
         messageWriter.writeLine();
         for (String line : BANNER) {
-            messageWriter.writeLine(line);
+            messageWriter.writeLine(textStyler.banner(line));
         }
         messageWriter.writeLine();
-        messageWriter.writeLine("Welcome to Xolo MUD!");
+        messageWriter.writeLine(textStyler.title("Welcome to Xolo MUD!"));
         for (String line : DESCRIPTION) {
-            messageWriter.writeLine(line);
+            messageWriter.writeLine(textStyler.info(line));
         }
         messageWriter.writeLine();
-        messageWriter.writeLine("Players online: " + onlineCount);
+        messageWriter.writeLine(textStyler.info("Players online: " + onlineCount));
         messageWriter.writeLine();
         messageWriter.write("Please enter your name: ");
     }

--- a/src/main/java/io/taanielo/jmud/core/output/AnsiTextStyler.java
+++ b/src/main/java/io/taanielo/jmud/core/output/AnsiTextStyler.java
@@ -1,0 +1,27 @@
+package io.taanielo.jmud.core.output;
+
+public class AnsiTextStyler implements TextStyler {
+    private static final String RESET = "\u001B[0m";
+    private static final String BOLD_CYAN = "\u001B[1;36m";
+    private static final String BOLD_GREEN = "\u001B[1;32m";
+    private static final String YELLOW = "\u001B[33m";
+
+    @Override
+    public String banner(String text) {
+        return wrap(BOLD_CYAN, text);
+    }
+
+    @Override
+    public String title(String text) {
+        return wrap(BOLD_GREEN, text);
+    }
+
+    @Override
+    public String info(String text) {
+        return wrap(YELLOW, text);
+    }
+
+    private String wrap(String prefix, String text) {
+        return prefix + text + RESET;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/output/OutputStyleSettings.java
+++ b/src/main/java/io/taanielo/jmud/core/output/OutputStyleSettings.java
@@ -1,0 +1,15 @@
+package io.taanielo.jmud.core.output;
+
+import io.taanielo.jmud.core.config.GameConfig;
+
+public final class OutputStyleSettings {
+    private static final boolean DEFAULT_ANSI_ENABLED = false;
+    private static final GameConfig CONFIG = GameConfig.load();
+
+    private OutputStyleSettings() {
+    }
+
+    public static boolean ansiEnabledByDefault() {
+        return CONFIG.getBoolean("jmud.output.ansi.enabled", DEFAULT_ANSI_ENABLED);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/output/PlainTextStyler.java
+++ b/src/main/java/io/taanielo/jmud/core/output/PlainTextStyler.java
@@ -1,0 +1,19 @@
+package io.taanielo.jmud.core.output;
+
+public class PlainTextStyler implements TextStyler {
+
+    @Override
+    public String banner(String text) {
+        return text;
+    }
+
+    @Override
+    public String title(String text) {
+        return text;
+    }
+
+    @Override
+    public String info(String text) {
+        return text;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/output/TextStyler.java
+++ b/src/main/java/io/taanielo/jmud/core/output/TextStyler.java
@@ -1,0 +1,9 @@
+package io.taanielo.jmud.core.output;
+
+public interface TextStyler {
+    String banner(String text);
+
+    String title(String text);
+
+    String info(String text);
+}

--- a/src/main/java/io/taanielo/jmud/core/output/TextStylers.java
+++ b/src/main/java/io/taanielo/jmud/core/output/TextStylers.java
@@ -1,0 +1,10 @@
+package io.taanielo.jmud.core.output;
+
+public final class TextStylers {
+    private TextStylers() {
+    }
+
+    public static TextStyler forEnabled(boolean enabled) {
+        return enabled ? new AnsiTextStyler() : new PlainTextStyler();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/player/Player.java
+++ b/src/main/java/io/taanielo/jmud/core/player/Player.java
@@ -23,9 +23,14 @@ public class Player implements EffectTarget {
     private final PlayerVitals vitals;
     private final List<EffectInstance> effects;
     private final String promptFormat;
+    private final boolean ansiEnabled;
 
     public static Player of(User user, String promptFormat) {
-        return new Player(user, 1, 0, PlayerVitals.defaults(), List.of(), promptFormat);
+        return new Player(user, 1, 0, PlayerVitals.defaults(), List.of(), promptFormat, false);
+    }
+
+    public static Player of(User user, String promptFormat, boolean ansiEnabled) {
+        return new Player(user, 1, 0, PlayerVitals.defaults(), List.of(), promptFormat, ansiEnabled);
     }
 
     @JsonCreator
@@ -35,7 +40,8 @@ public class Player implements EffectTarget {
         @JsonProperty("experience") long experience,
         @JsonProperty("vitals") PlayerVitals vitals,
         @JsonProperty("effects") List<EffectInstance> effects,
-        @JsonProperty("promptFormat") String promptFormat
+        @JsonProperty("promptFormat") String promptFormat,
+        @JsonProperty("ansiEnabled") Boolean ansiEnabled
     ) {
         this.user = Objects.requireNonNull(user, "User is required");
         this.level = level;
@@ -43,6 +49,7 @@ public class Player implements EffectTarget {
         this.vitals = Objects.requireNonNull(vitals, "Vitals are required");
         this.effects = new ArrayList<>(Objects.requireNonNullElse(effects, List.of()));
         this.promptFormat = Objects.requireNonNull(promptFormat, "Prompt format is required");
+        this.ansiEnabled = Objects.requireNonNullElse(ansiEnabled, false);
     }
 
     @JsonIgnore
@@ -57,5 +64,9 @@ public class Player implements EffectTarget {
 
     public List<EffectInstance> effects() {
         return effects;
+    }
+
+    public Player withAnsiEnabled(boolean enabled) {
+        return new Player(user, level, experience, vitals, effects, promptFormat, enabled);
     }
 }

--- a/src/main/resources/jmud.properties
+++ b/src/main/resources/jmud.properties
@@ -1,3 +1,4 @@
 jmud.prompt.format=[{hp}/{maxHp}hp {mana}/{maxMana}mn {move}/{maxMove}mv {exp}xp]
 jmud.effects.enabled=true
 jmud.tick.interval.ms=500
+jmud.output.ansi.enabled=false

--- a/src/test/java/io/taanielo/jmud/core/effects/EffectEngineTest.java
+++ b/src/test/java/io/taanielo/jmud/core/effects/EffectEngineTest.java
@@ -36,7 +36,8 @@ class EffectEngineTest {
             0,
             PlayerVitals.defaults(),
             new ArrayList<>(List.of(new EffectInstance(id, 1, 1))),
-            "HP {hp}/{maxHp}"
+            "HP {hp}/{maxHp}",
+            false
         );
 
         engine.apply(player, id, new RecordingSink());
@@ -64,7 +65,8 @@ class EffectEngineTest {
             0,
             PlayerVitals.defaults(),
             new ArrayList<>(List.of(new EffectInstance(id, 1, 1))),
-            "HP {hp}/{maxHp}"
+            "HP {hp}/{maxHp}",
+            false
         );
         RecordingSink sink = new RecordingSink();
 

--- a/src/test/java/io/taanielo/jmud/core/player/JsonPlayerRepositoryTest.java
+++ b/src/test/java/io/taanielo/jmud/core/player/JsonPlayerRepositoryTest.java
@@ -27,7 +27,7 @@ class JsonPlayerRepositoryTest {
         User user = User.of(Username.of("sparky"), Password.of("qwerty"));
         List<EffectInstance> effects = List.of(new EffectInstance(EffectId.of("stoneskin"), 5, 1));
         PlayerVitals vitals = new PlayerVitals(12, 20, 6, 10, 8, 15);
-        Player player = new Player(user, 3, 42, vitals, effects, "HP {hp}/{maxHp} Exp {exp}");
+        Player player = new Player(user, 3, 42, vitals, effects, "HP {hp}/{maxHp} Exp {exp}", true);
 
         repository.savePlayer(player);
 
@@ -39,6 +39,7 @@ class JsonPlayerRepositoryTest {
         assertEquals(12, loaded.get().getVitals().hp());
         assertEquals(20, loaded.get().getVitals().maxHp());
         assertEquals("HP {hp}/{maxHp} Exp {exp}", loaded.get().getPromptFormat());
+        assertTrue(loaded.get().isAnsiEnabled());
         assertEquals(1, loaded.get().effects().size());
         assertEquals("stoneskin", loaded.get().effects().get(0).id().getValue());
     }


### PR DESCRIPTION
## Summary
- add pluggable output stylers (plain + ANSI) with config default
- allow players to toggle ANSI with `ANSI on|off|toggle|status`
- persist player ANSI preference and style the welcome banner

## Why
- optional ANSI colors with future-friendly styling abstraction (closes #35)

## Testing
- `gradle test`

Closes #35