### PR TITLE
fix(tick): manage registry lifecycle

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketServer.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketServer.java
@@ -74,6 +74,7 @@ public class SocketServer implements Server {
             log.error("Server error", e);
         } finally {
             tickScheduler.stop();
+            tickRegistry.clear();
         }
 
     }

--- a/src/main/java/io/taanielo/jmud/core/tick/TickRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/tick/TickRegistry.java
@@ -6,6 +6,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class TickRegistry {
     private final CopyOnWriteArrayList<Tickable> tickables = new CopyOnWriteArrayList<>();
 
+    /**
+     * Register a Tickable and return a subscription that should be stored and
+     * used to unsubscribe when the Tickable lifecycle ends.
+     */
     public TickSubscription register(Tickable tickable) {
         if (tickable == null) {
             throw new IllegalArgumentException("Tickable is required");
@@ -16,6 +20,10 @@ public class TickRegistry {
 
     public void unregister(Tickable tickable) {
         tickables.remove(tickable);
+    }
+
+    public void clear() {
+        tickables.clear();
     }
 
     public List<Tickable> snapshot() {


### PR DESCRIPTION
## Summary
- document TickRegistry subscription usage
- add TickRegistry.clear()
- clear registry on server shutdown

## Why
- make tickable lifecycle explicit and avoid stale subscriptions (closes #23)

## Testing
- `gradle test`

Closes #23