### PR TITLE
feat(healing): add per-tick player healing

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/healing/HealingEngine.java
+++ b/src/main/java/io/taanielo/jmud/core/healing/HealingEngine.java
@@ -1,0 +1,79 @@
+package io.taanielo.jmud.core.healing;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.taanielo.jmud.core.effects.EffectDefinition;
+import io.taanielo.jmud.core.effects.EffectInstance;
+import io.taanielo.jmud.core.effects.EffectModifier;
+import io.taanielo.jmud.core.effects.EffectRepository;
+import io.taanielo.jmud.core.effects.EffectRepositoryException;
+import io.taanielo.jmud.core.effects.ModifierOperation;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerVitals;
+
+public class HealingEngine {
+    private final EffectRepository repository;
+
+    public HealingEngine(EffectRepository repository) {
+        this.repository = Objects.requireNonNull(repository, "Effect repository is required");
+    }
+
+    public Player apply(Player player, int baseHealPerTick) throws EffectRepositoryException {
+        Objects.requireNonNull(player, "Player is required");
+        PlayerVitals vitals = player.getVitals();
+        int effectiveMaxHp = applyModifiers(vitals.baseMaxHp(), player.effects(), HealingModifierKeys.MAX_HP);
+        if (effectiveMaxHp < 1) {
+            effectiveMaxHp = 1;
+        }
+
+        PlayerVitals updatedVitals = vitals;
+        if (effectiveMaxHp != vitals.maxHp()) {
+            updatedVitals = updatedVitals.withMaxHp(effectiveMaxHp);
+        }
+
+        int healing = applyModifiers(baseHealPerTick, player.effects(), HealingModifierKeys.HEAL_PER_TICK);
+        if (healing > 0 && updatedVitals.hp() < updatedVitals.maxHp()) {
+            updatedVitals = updatedVitals.heal(healing);
+        }
+
+        if (updatedVitals == vitals) {
+            return player;
+        }
+        return player.withVitals(updatedVitals);
+    }
+
+    private int applyModifiers(int base, List<EffectInstance> effects, String statKey) throws EffectRepositoryException {
+        int addTotal = 0;
+        int multiplyTotal = 1;
+        for (EffectInstance instance : effects) {
+            EffectDefinition definition = repository.findById(instance.id())
+                .orElseThrow(() -> new EffectRepositoryException("Unknown effect id " + instance.id().getValue()));
+            for (EffectModifier modifier : definition.modifiers()) {
+                if (!modifier.stat().equalsIgnoreCase(statKey)) {
+                    continue;
+                }
+                int stacks = Math.max(1, instance.stacks());
+                if (modifier.operation() == ModifierOperation.ADD) {
+                    addTotal += modifier.amount() * stacks;
+                    continue;
+                }
+                if (modifier.operation() == ModifierOperation.MULTIPLY) {
+                    for (int i = 0; i < stacks; i += 1) {
+                        multiplyTotal *= modifier.amount();
+                    }
+                }
+            }
+        }
+
+        long result = (long) base + addTotal;
+        result *= multiplyTotal;
+        if (result <= 0) {
+            return 0;
+        }
+        if (result > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) result;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/healing/HealingModifierKeys.java
+++ b/src/main/java/io/taanielo/jmud/core/healing/HealingModifierKeys.java
@@ -1,0 +1,9 @@
+package io.taanielo.jmud.core.healing;
+
+public final class HealingModifierKeys {
+    public static final String HEAL_PER_TICK = "heal_per_tick";
+    public static final String MAX_HP = "max_hp";
+
+    private HealingModifierKeys() {
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/healing/HealingSettings.java
+++ b/src/main/java/io/taanielo/jmud/core/healing/HealingSettings.java
@@ -1,0 +1,25 @@
+package io.taanielo.jmud.core.healing;
+
+import io.taanielo.jmud.core.config.GameConfig;
+
+public final class HealingSettings {
+    public static final boolean DEFAULT_ENABLED = true;
+    public static final int DEFAULT_BASE_HP_PER_TICK = 1;
+
+    private static final GameConfig CONFIG = GameConfig.load();
+
+    private HealingSettings() {
+    }
+
+    public static boolean enabled() {
+        return CONFIG.getBoolean("jmud.healing.enabled", DEFAULT_ENABLED);
+    }
+
+    public static int baseHpPerTick() {
+        int base = CONFIG.getInt("jmud.healing.base_hp_per_tick", DEFAULT_BASE_HP_PER_TICK);
+        if (base < 0) {
+            throw new IllegalArgumentException("Base healing per tick must be non-negative");
+        }
+        return base;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/healing/PlayerHealingTicker.java
+++ b/src/main/java/io/taanielo/jmud/core/healing/PlayerHealingTicker.java
@@ -1,0 +1,44 @@
+package io.taanielo.jmud.core.healing;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import io.taanielo.jmud.core.effects.EffectRepositoryException;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.tick.Tickable;
+
+public class PlayerHealingTicker implements Tickable {
+    private final Supplier<Player> playerSupplier;
+    private final Consumer<Player> playerUpdater;
+    private final HealingEngine engine;
+    private final int baseHealPerTick;
+
+    public PlayerHealingTicker(
+        Supplier<Player> playerSupplier,
+        Consumer<Player> playerUpdater,
+        HealingEngine engine,
+        int baseHealPerTick
+    ) {
+        this.playerSupplier = Objects.requireNonNull(playerSupplier, "Player supplier is required");
+        this.playerUpdater = Objects.requireNonNull(playerUpdater, "Player updater is required");
+        this.engine = Objects.requireNonNull(engine, "Healing engine is required");
+        this.baseHealPerTick = baseHealPerTick;
+    }
+
+    @Override
+    public void tick() {
+        Player player = playerSupplier.get();
+        if (player == null) {
+            return;
+        }
+        try {
+            Player updated = engine.apply(player, baseHealPerTick);
+            if (updated != player) {
+                playerUpdater.accept(updated);
+            }
+        } catch (EffectRepositoryException e) {
+            throw new IllegalStateException("Failed to apply healing: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/resources/jmud.properties
+++ b/src/main/resources/jmud.properties
@@ -1,4 +1,6 @@
 jmud.prompt.format=[{hp}/{maxHp}hp {mana}/{maxMana}mn {move}/{maxMove}mv {exp}xp]
 jmud.effects.enabled=true
+jmud.healing.enabled=true
+jmud.healing.base_hp_per_tick=1
 jmud.tick.interval.ms=500
 jmud.output.ansi.enabled=false

--- a/src/test/java/io/taanielo/jmud/core/healing/HealingEngineTest.java
+++ b/src/test/java/io/taanielo/jmud/core/healing/HealingEngineTest.java
@@ -1,0 +1,168 @@
+package io.taanielo.jmud.core.healing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.effects.EffectDefinition;
+import io.taanielo.jmud.core.effects.EffectId;
+import io.taanielo.jmud.core.effects.EffectInstance;
+import io.taanielo.jmud.core.effects.EffectModifier;
+import io.taanielo.jmud.core.effects.EffectRepository;
+import io.taanielo.jmud.core.effects.EffectStacking;
+import io.taanielo.jmud.core.effects.ModifierOperation;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerVitals;
+
+class HealingEngineTest {
+
+    @Test
+    void healsBaseAmount() throws Exception {
+        PlayerVitals vitals = new PlayerVitals(10, 20, 10, 20, 10, 20);
+        Player player = new Player(
+            User.of(Username.of("sparky"), Password.of("pw")),
+            1,
+            0,
+            vitals,
+            new ArrayList<>(),
+            "prompt",
+            false,
+            List.of()
+        );
+        HealingEngine engine = new HealingEngine(new StubEffectRepository(Map.of()));
+
+        Player updated = engine.apply(player, 2);
+
+        assertEquals(12, updated.getVitals().hp());
+        assertEquals(20, updated.getVitals().maxHp());
+        assertEquals(20, updated.getVitals().baseMaxHp());
+    }
+
+    @Test
+    void stacksHealingModifiers() throws Exception {
+        EffectId regenId = EffectId.of("regen");
+        EffectDefinition regen = new EffectDefinition(
+            regenId,
+            "Regen",
+            10,
+            1,
+            EffectStacking.STACK,
+            List.of(new EffectModifier(HealingModifierKeys.HEAL_PER_TICK, ModifierOperation.ADD, 2)),
+            null
+        );
+        PlayerVitals vitals = new PlayerVitals(10, 20, 10, 20, 10, 20);
+        List<EffectInstance> effects = new ArrayList<>();
+        effects.add(new EffectInstance(regenId, 10, 2));
+        Player player = new Player(
+            User.of(Username.of("sparky"), Password.of("pw")),
+            1,
+            0,
+            vitals,
+            effects,
+            "prompt",
+            false,
+            List.of()
+        );
+        HealingEngine engine = new HealingEngine(new StubEffectRepository(Map.of(regenId, regen)));
+
+        Player updated = engine.apply(player, 1);
+
+        assertEquals(15, updated.getVitals().hp());
+    }
+
+    @Test
+    void respectsMaxHpModifiersAndRevertsWhenEffectExpires() throws Exception {
+        EffectId fortifyId = EffectId.of("fortify");
+        EffectDefinition fortify = new EffectDefinition(
+            fortifyId,
+            "Fortify",
+            10,
+            1,
+            EffectStacking.REFRESH,
+            List.of(new EffectModifier(HealingModifierKeys.MAX_HP, ModifierOperation.ADD, 5)),
+            null
+        );
+        PlayerVitals vitals = new PlayerVitals(20, 20, 10, 20, 10, 20);
+        List<EffectInstance> effects = new ArrayList<>();
+        effects.add(new EffectInstance(fortifyId, 10, 1));
+        Player player = new Player(
+            User.of(Username.of("sparky"), Password.of("pw")),
+            1,
+            0,
+            vitals,
+            effects,
+            "prompt",
+            false,
+            List.of()
+        );
+        HealingEngine engine = new HealingEngine(new StubEffectRepository(Map.of(fortifyId, fortify)));
+
+        Player boosted = engine.apply(player, 1);
+
+        assertEquals(25, boosted.getVitals().maxHp());
+        assertEquals(21, boosted.getVitals().hp());
+        assertEquals(20, boosted.getVitals().baseMaxHp());
+
+        boosted.effects().clear();
+        Player reverted = engine.apply(boosted, 1);
+
+        assertEquals(20, reverted.getVitals().maxHp());
+        assertEquals(20, reverted.getVitals().hp());
+        assertEquals(20, reverted.getVitals().baseMaxHp());
+    }
+
+    @Test
+    void keepsEffectsWhenHpIsMax() throws Exception {
+        EffectId regenId = EffectId.of("regen");
+        EffectDefinition regen = new EffectDefinition(
+            regenId,
+            "Regen",
+            10,
+            1,
+            EffectStacking.REFRESH,
+            List.of(new EffectModifier(HealingModifierKeys.HEAL_PER_TICK, ModifierOperation.ADD, 2)),
+            null
+        );
+        PlayerVitals vitals = new PlayerVitals(20, 20, 10, 20, 10, 20);
+        List<EffectInstance> effects = new ArrayList<>();
+        effects.add(new EffectInstance(regenId, 10, 1));
+        Player player = new Player(
+            User.of(Username.of("sparky"), Password.of("pw")),
+            1,
+            0,
+            vitals,
+            effects,
+            "prompt",
+            false,
+            List.of()
+        );
+        HealingEngine engine = new HealingEngine(new StubEffectRepository(Map.of(regenId, regen)));
+
+        Player updated = engine.apply(player, 2);
+
+        assertSame(player.effects(), updated.effects());
+        assertEquals(1, updated.effects().size());
+    }
+
+    private static class StubEffectRepository implements EffectRepository {
+        private final Map<EffectId, EffectDefinition> definitions;
+
+        private StubEffectRepository(Map<EffectId, EffectDefinition> definitions) {
+            this.definitions = definitions;
+        }
+
+        @Override
+        public Optional<EffectDefinition> findById(EffectId id) {
+            return Optional.ofNullable(definitions.get(id));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add healing engine + ticker using effect modifiers for heal rate and max HP
- store base max HP in vitals to support temporary max HP modifiers
- register healing tick via socket client with config toggles

## Testing
- gradle test

Closes #24