### PR TITLE
feat(ability): add data-driven ability messages

### DIFF
--- a/data/skills/skill.bash.json
+++ b/data/skills/skill.bash.json
@@ -19,5 +19,10 @@
       "operation": "DECREASE",
       "amount": 4
     }
-  ]
+  ],
+  "messages": {
+    "self": "You bash {target}.",
+    "target": "{source} bashes you.",
+    "room": "{source} bashes {target}."
+  }
 }

--- a/data/skills/spell.fireball.greater.json
+++ b/data/skills/spell.fireball.greater.json
@@ -19,5 +19,10 @@
       "operation": "DECREASE",
       "amount": 9
     }
-  ]
+  ],
+  "messages": {
+    "self": "You cast {ability} at {target}.",
+    "target": "{source} casts {ability} at you.",
+    "room": "{source} casts {ability} at {target}."
+  }
 }

--- a/data/skills/spell.fireball.json
+++ b/data/skills/spell.fireball.json
@@ -19,5 +19,10 @@
       "operation": "DECREASE",
       "amount": 6
     }
-  ]
+  ],
+  "messages": {
+    "self": "You cast {ability} at {target}.",
+    "target": "{source} casts {ability} at you.",
+    "room": "{source} casts {ability} at {target}."
+  }
 }

--- a/data/skills/spell.heal.json
+++ b/data/skills/spell.heal.json
@@ -19,5 +19,10 @@
       "operation": "INCREASE",
       "amount": 6
     }
-  ]
+  ],
+  "messages": {
+    "self": "You cast {ability} on {target}.",
+    "target": "{source} casts {ability} on you.",
+    "room": "{source} casts {ability} on {target}."
+  }
 }

--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -79,6 +79,13 @@ Ability example (`data/skills/spell.heal.json`):
       "operation": "INCREASE",
       "amount": 6
     }
-  ]
+  ],
+  "messages": {
+    "self": "You cast {ability} on {target}.",
+    "target": "{source} casts {ability} on you.",
+    "room": "{source} casts {ability} on {target}."
+  }
 }
 ```
+
+Message templates support `{source}`, `{target}`, and `{ability}` placeholders.

--- a/docs/schemas/ability.v1.json
+++ b/docs/schemas/ability.v1.json
@@ -100,6 +100,24 @@
           }
         ]
       }
+    },
+    "messages": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "self": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "room": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
     }
   }
 }

--- a/src/main/java/io/taanielo/jmud/core/ability/Ability.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/Ability.java
@@ -21,6 +21,8 @@ public interface Ability {
 
     List<AbilityEffect> effects();
 
+    AbilityMessages messages();
+
     default boolean canUse(AbilityContext context) {
         return true;
     }

--- a/src/main/java/io/taanielo/jmud/core/ability/AbilityDefinition.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/AbilityDefinition.java
@@ -13,6 +13,7 @@ public class AbilityDefinition implements Ability {
     private final AbilityTargeting targeting;
     private final List<String> aliases;
     private final List<AbilityEffect> effects;
+    private final AbilityMessages messages;
 
     public AbilityDefinition(
         AbilityId id,
@@ -23,7 +24,8 @@ public class AbilityDefinition implements Ability {
         AbilityCooldown cooldown,
         AbilityTargeting targeting,
         List<String> aliases,
-        List<AbilityEffect> effects
+        List<AbilityEffect> effects,
+        AbilityMessages messages
     ) {
         this.id = Objects.requireNonNull(id, "Ability id is required");
         this.name = validateText(name, "Ability name");
@@ -37,6 +39,7 @@ public class AbilityDefinition implements Ability {
         this.targeting = Objects.requireNonNull(targeting, "Ability targeting is required");
         this.aliases = List.copyOf(Objects.requireNonNullElse(aliases, List.of()));
         this.effects = List.copyOf(Objects.requireNonNullElse(effects, List.of()));
+        this.messages = messages;
         if (this.effects.isEmpty()) {
             throw new IllegalArgumentException("Ability must define at least one effect");
         }
@@ -85,6 +88,11 @@ public class AbilityDefinition implements Ability {
     @Override
     public List<AbilityEffect> effects() {
         return effects;
+    }
+
+    @Override
+    public AbilityMessages messages() {
+        return messages;
     }
 
     private String validateText(String value, String label) {

--- a/src/main/java/io/taanielo/jmud/core/ability/AbilityMessageSink.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/AbilityMessageSink.java
@@ -1,0 +1,11 @@
+package io.taanielo.jmud.core.ability;
+
+import io.taanielo.jmud.core.player.Player;
+
+public interface AbilityMessageSink {
+    void sendToSource(Player source, String message);
+
+    void sendToTarget(Player target, String message);
+
+    void sendToRoom(Player source, Player target, String message);
+}

--- a/src/main/java/io/taanielo/jmud/core/ability/AbilityMessages.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/AbilityMessages.java
@@ -1,0 +1,4 @@
+package io.taanielo.jmud.core.ability;
+
+public record AbilityMessages(String self, String target, String room) {
+}

--- a/src/main/java/io/taanielo/jmud/core/ability/dto/AbilityDto.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/dto/AbilityDto.java
@@ -15,6 +15,7 @@ public record AbilityDto(
     AbilityCooldownDto cooldown,
     AbilityTargeting targeting,
     List<String> aliases,
-    List<AbilityEffectDto> effects
+    List<AbilityEffectDto> effects,
+    AbilityMessagesDto messages
 ) {
 }

--- a/src/main/java/io/taanielo/jmud/core/ability/dto/AbilityMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/dto/AbilityMapper.java
@@ -10,6 +10,7 @@ import io.taanielo.jmud.core.ability.AbilityDefinition;
 import io.taanielo.jmud.core.ability.AbilityEffect;
 import io.taanielo.jmud.core.ability.AbilityEffectKind;
 import io.taanielo.jmud.core.ability.AbilityId;
+import io.taanielo.jmud.core.ability.AbilityMessages;
 
 public class AbilityMapper {
 
@@ -34,7 +35,14 @@ public class AbilityMapper {
             new AbilityCooldownDto(ability.cooldown().ticks()),
             ability.targeting(),
             ability.aliases(),
-            effects
+            effects,
+            ability.messages() == null
+                ? null
+                : new AbilityMessagesDto(
+                    ability.messages().self(),
+                    ability.messages().target(),
+                    ability.messages().room()
+                )
         );
     }
 
@@ -65,7 +73,10 @@ public class AbilityMapper {
             new AbilityCooldown(cooldownDto.ticks()),
             dto.targeting(),
             dto.aliases(),
-            effects
+            effects,
+            dto.messages() == null
+                ? null
+                : new AbilityMessages(dto.messages().self(), dto.messages().target(), dto.messages().room())
         );
     }
 

--- a/src/main/java/io/taanielo/jmud/core/ability/dto/AbilityMessagesDto.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/dto/AbilityMessagesDto.java
@@ -1,0 +1,8 @@
+package io.taanielo.jmud.core.ability.dto;
+
+public record AbilityMessagesDto(
+    String self,
+    String target,
+    String room
+) {
+}

--- a/src/test/java/io/taanielo/jmud/core/ability/repository/json/JsonAbilityRepositoryTest.java
+++ b/src/test/java/io/taanielo/jmud/core/ability/repository/json/JsonAbilityRepositoryTest.java
@@ -42,7 +42,12 @@ class JsonAbilityRepositoryTest {
               \"aliases\": [\"healing\"],
               \"effects\": [
                 {\"kind\": \"VITALS\", \"stat\": \"HP\", \"operation\": \"INCREASE\", \"amount\": 6}
-              ]
+              ],
+              \"messages\": {
+                \"self\": \"You cast {ability} on {target}.\",
+                \"target\": \"{source} casts {ability} on you.\",
+                \"room\": \"{source} casts {ability} on {target}.\"
+              }
             }
             """);
 
@@ -55,6 +60,7 @@ class JsonAbilityRepositoryTest {
         assertEquals(AbilityType.SPELL, ability.type());
         assertEquals(AbilityTargeting.BENEFICIAL, ability.targeting());
         assertEquals(1, ability.effects().size());
+        assertEquals("You cast {ability} on {target}.", ability.messages().self());
         assertEquals(AbilityEffectKind.VITALS, ability.effects().getFirst().kind());
         assertEquals(AbilityStat.HP, ability.effects().getFirst().stat());
         assertEquals(AbilityOperation.INCREASE, ability.effects().getFirst().operation());


### PR DESCRIPTION
## Summary
- add ability message templates for self/target/room with placeholder tokens
- emit ability messages through a sink and send to source/target/room
- store templates in ability JSON + update schema/docs/tests

## Testing
- gradle test

Closes #40