### PR TITLE
feat(death): handle player death and respawn

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/healing/PlayerHealingTicker.java
+++ b/src/main/java/io/taanielo/jmud/core/healing/PlayerHealingTicker.java
@@ -32,6 +32,9 @@ public class PlayerHealingTicker implements Tickable {
         if (player == null) {
             return;
         }
+        if (player.isDead()) {
+            return;
+        }
         try {
             int baseHealPerTick = baseResolver.baseHpPerTick(player);
             Player updated = engine.apply(player, baseHealPerTick);

--- a/src/main/java/io/taanielo/jmud/core/player/DeathSettings.java
+++ b/src/main/java/io/taanielo/jmud/core/player/DeathSettings.java
@@ -1,0 +1,20 @@
+package io.taanielo.jmud.core.player;
+
+import io.taanielo.jmud.core.config.GameConfig;
+
+public final class DeathSettings {
+    public static final int DEFAULT_RESPAWN_TICKS = 10;
+
+    private static final GameConfig CONFIG = GameConfig.load();
+
+    private DeathSettings() {
+    }
+
+    public static int respawnTicks() {
+        int ticks = CONFIG.getInt("jmud.death.respawn_ticks", DEFAULT_RESPAWN_TICKS);
+        if (ticks < 0) {
+            throw new IllegalArgumentException("Respawn ticks must be non-negative");
+        }
+        return ticks;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/player/Player.java
+++ b/src/main/java/io/taanielo/jmud/core/player/Player.java
@@ -33,6 +33,7 @@ public class Player implements EffectTarget, Combatant {
     private final RaceId race;
     @JsonProperty("class")
     private final ClassId classId;
+    private final boolean dead;
 
     public static Player of(User user, String promptFormat) {
         return new Player(user, 1, 0, PlayerVitals.defaults(), List.of(), promptFormat, false, List.of(), null, null);
@@ -46,6 +47,21 @@ public class Player implements EffectTarget, Combatant {
         return new Player(user, 1, 0, PlayerVitals.defaults(), List.of(), promptFormat, ansiEnabled, learnedAbilities, null, null);
     }
 
+    public Player(
+        User user,
+        int level,
+        long experience,
+        PlayerVitals vitals,
+        List<EffectInstance> effects,
+        String promptFormat,
+        Boolean ansiEnabled,
+        List<AbilityId> learnedAbilities,
+        RaceId race,
+        ClassId classId
+    ) {
+        this(user, level, experience, vitals, effects, promptFormat, ansiEnabled, learnedAbilities, race, classId, false);
+    }
+
     @JsonCreator
     public Player(
         @JsonProperty("user") User user,
@@ -57,7 +73,8 @@ public class Player implements EffectTarget, Combatant {
         @JsonProperty("ansiEnabled") Boolean ansiEnabled,
         @JsonProperty("learnedAbilities") List<AbilityId> learnedAbilities,
         @JsonProperty("race") RaceId race,
-        @JsonProperty("class") ClassId classId
+        @JsonProperty("class") ClassId classId,
+        @JsonProperty("dead") Boolean dead
     ) {
         this.user = Objects.requireNonNull(user, "User is required");
         this.level = level;
@@ -69,6 +86,8 @@ public class Player implements EffectTarget, Combatant {
         this.learnedAbilities = List.copyOf(Objects.requireNonNullElse(learnedAbilities, List.of()));
         this.race = Objects.requireNonNullElse(race, RaceId.of("human"));
         this.classId = Objects.requireNonNullElse(classId, ClassId.of("adventurer"));
+        boolean resolvedDead = Objects.requireNonNullElse(dead, false) || vitals.hp() <= 0;
+        this.dead = resolvedDead;
     }
 
     @JsonIgnore
@@ -85,15 +104,36 @@ public class Player implements EffectTarget, Combatant {
         return effects;
     }
 
+    public Player die() {
+        if (dead && vitals.hp() <= 0 && effects.isEmpty()) {
+            return this;
+        }
+        PlayerVitals deadVitals = vitals.damage(vitals.hp());
+        return new Player(user, level, experience, deadVitals, List.of(), promptFormat, ansiEnabled, learnedAbilities, race, classId, true);
+    }
+
+    public Player respawn() {
+        PlayerVitals restored = vitals.respawnHalf();
+        return new Player(user, level, experience, restored, List.of(), promptFormat, ansiEnabled, learnedAbilities, race, classId, false);
+    }
+
+    public Player withoutEffects() {
+        return new Player(user, level, experience, vitals, List.of(), promptFormat, ansiEnabled, learnedAbilities, race, classId, dead);
+    }
+
     public Player withAnsiEnabled(boolean enabled) {
-        return new Player(user, level, experience, vitals, effects, promptFormat, enabled, learnedAbilities, race, classId);
+        return new Player(user, level, experience, vitals, effects, promptFormat, enabled, learnedAbilities, race, classId, dead);
     }
 
     public Player withVitals(PlayerVitals updatedVitals) {
-        return new Player(user, level, experience, updatedVitals, effects, promptFormat, ansiEnabled, learnedAbilities, race, classId);
+        return new Player(user, level, experience, updatedVitals, effects, promptFormat, ansiEnabled, learnedAbilities, race, classId, dead);
+    }
+
+    public Player withDead(boolean dead) {
+        return new Player(user, level, experience, vitals, effects, promptFormat, ansiEnabled, learnedAbilities, race, classId, dead);
     }
 
     public Player withLearnedAbilities(List<AbilityId> abilities) {
-        return new Player(user, level, experience, vitals, effects, promptFormat, ansiEnabled, abilities, race, classId);
+        return new Player(user, level, experience, vitals, effects, promptFormat, ansiEnabled, abilities, race, classId, dead);
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/player/PlayerRespawnTicker.java
+++ b/src/main/java/io/taanielo/jmud/core/player/PlayerRespawnTicker.java
@@ -1,0 +1,77 @@
+package io.taanielo.jmud.core.player;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import io.taanielo.jmud.core.tick.Tickable;
+import io.taanielo.jmud.core.world.RoomService;
+
+public class PlayerRespawnTicker implements Tickable {
+    private final Supplier<Player> playerSupplier;
+    private final Consumer<Player> playerUpdater;
+    private final RoomService roomService;
+    private final int respawnTicks;
+    private boolean scheduled;
+    private int remainingTicks;
+
+    public PlayerRespawnTicker(
+        Supplier<Player> playerSupplier,
+        Consumer<Player> playerUpdater,
+        RoomService roomService,
+        int respawnTicks
+    ) {
+        this.playerSupplier = Objects.requireNonNull(playerSupplier, "Player supplier is required");
+        this.playerUpdater = Objects.requireNonNull(playerUpdater, "Player updater is required");
+        this.roomService = Objects.requireNonNull(roomService, "Room service is required");
+        if (respawnTicks < 0) {
+            throw new IllegalArgumentException("Respawn ticks must be non-negative");
+        }
+        this.respawnTicks = respawnTicks;
+    }
+
+    public void schedule() {
+        if (scheduled) {
+            return;
+        }
+        if (respawnTicks == 0) {
+            Player player = playerSupplier.get();
+            if (player != null && player.isDead()) {
+                respawn(player);
+            }
+            return;
+        }
+        remainingTicks = respawnTicks;
+        scheduled = true;
+    }
+
+    public boolean isScheduled() {
+        return scheduled;
+    }
+
+    @Override
+    public void tick() {
+        if (!scheduled) {
+            return;
+        }
+        Player player = playerSupplier.get();
+        if (player == null) {
+            return;
+        }
+        if (!player.isDead()) {
+            scheduled = false;
+            return;
+        }
+        remainingTicks -= 1;
+        if (remainingTicks <= 0) {
+            scheduled = false;
+            respawn(player);
+        }
+    }
+
+    private void respawn(Player player) {
+        Player respawned = player.respawn();
+        playerUpdater.accept(respawned);
+        roomService.respawnPlayer(respawned.getUsername());
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/player/PlayerVitals.java
+++ b/src/main/java/io/taanielo/jmud/core/player/PlayerVitals.java
@@ -167,9 +167,25 @@ public class PlayerVitals {
         return new PlayerVitals(hp, maxHp, baseMaxHp, mana, maxMana, nextMove, maxMove);
     }
 
+    public PlayerVitals respawnHalf() {
+        return new PlayerVitals(
+            halfOf(maxHp),
+            maxHp,
+            baseMaxHp,
+            halfOf(maxMana),
+            maxMana,
+            halfOf(maxMove),
+            maxMove
+        );
+    }
+
     private void validateAmount(int amount, String label) {
         if (amount < 0) {
             throw new IllegalArgumentException(label + " amount must be non-negative");
         }
+    }
+
+    private int halfOf(int max) {
+        return Math.max(1, max / 2);
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcher.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcher.java
@@ -47,6 +47,13 @@ public class SocketCommandDispatcher {
             context.writeLineWithPrompt("Ambiguous command. Specify: " + options);
             return;
         }
-        matches.getFirst().execute(context);
+        SocketCommandMatch match = matches.getFirst();
+        if (context.getPlayer() != null && context.getPlayer().isDead()) {
+            if (!"quit".equalsIgnoreCase(match.command().name())) {
+                context.writeLineWithPrompt("You cannot act while dead.");
+                return;
+            }
+        }
+        match.execute(context);
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/tick/system/CooldownSystem.java
+++ b/src/main/java/io/taanielo/jmud/core/tick/system/CooldownSystem.java
@@ -33,6 +33,10 @@ public class CooldownSystem implements Tickable {
         return remaining == null ? 0 : remaining.get();
     }
 
+    public void clear() {
+        cooldowns.clear();
+    }
+
     @Override
     public void tick() {
         for (Map.Entry<String, AtomicInteger> entry : cooldowns.entrySet()) {

--- a/src/main/resources/jmud.properties
+++ b/src/main/resources/jmud.properties
@@ -2,6 +2,7 @@ jmud.prompt.format=[{hp}/{maxHp}hp {mana}/{maxMana}mn {move}/{maxMove}mv {exp}xp
 jmud.effects.enabled=true
 jmud.healing.enabled=true
 jmud.healing.base_hp_per_tick=1
+jmud.death.respawn_ticks=10
 jmud.combat.base_hit_chance=75
 jmud.combat.base_crit_chance=5
 jmud.combat.damage_variance_percent=0

--- a/src/test/java/io/taanielo/jmud/core/player/PlayerDeathTest.java
+++ b/src/test/java/io/taanielo/jmud/core/player/PlayerDeathTest.java
@@ -1,0 +1,66 @@
+package io.taanielo.jmud.core.player;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.effects.EffectId;
+import io.taanielo.jmud.core.effects.EffectInstance;
+
+class PlayerDeathTest {
+
+    @Test
+    void dieClearsEffectsAndMarksDead() {
+        PlayerVitals vitals = new PlayerVitals(5, 20, 10, 20, 10, 20);
+        List<EffectInstance> effects = List.of(new EffectInstance(EffectId.of("stoneskin"), 3, 1));
+        Player player = new Player(
+            User.of(Username.of("sparky"), Password.of("pw")),
+            1,
+            0,
+            vitals,
+            effects,
+            "prompt",
+            false,
+            List.of(),
+            null,
+            null
+        );
+
+        Player dead = player.die();
+
+        assertTrue(dead.isDead());
+        assertEquals(0, dead.getVitals().hp());
+        assertTrue(dead.effects().isEmpty());
+    }
+
+    @Test
+    void respawnRestoresHalfVitals() {
+        PlayerVitals vitals = new PlayerVitals(12, 20, 6, 20, 8, 20);
+        Player player = new Player(
+            User.of(Username.of("sparky"), Password.of("pw")),
+            1,
+            0,
+            vitals,
+            List.of(),
+            "prompt",
+            false,
+            List.of(),
+            null,
+            null
+        );
+
+        Player respawned = player.die().respawn();
+
+        assertFalse(respawned.isDead());
+        assertEquals(10, respawned.getVitals().hp());
+        assertEquals(10, respawned.getVitals().mana());
+        assertEquals(10, respawned.getVitals().move());
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/player/PlayerRespawnTickerTest.java
+++ b/src/test/java/io/taanielo/jmud/core/player/PlayerRespawnTickerTest.java
@@ -1,0 +1,100 @@
+package io.taanielo.jmud.core.player;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.world.Direction;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemAttributes;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+class PlayerRespawnTickerTest {
+
+    @Test
+    void respawnsAfterConfiguredTicks() {
+        RoomId startId = RoomId.of("start");
+        RoomId arenaId = RoomId.of("arena");
+        Room start = new Room(
+            startId,
+            "Start",
+            "A quiet place.",
+            Map.of(),
+            List.of(),
+            List.of()
+        );
+        Room arena = new Room(
+            arenaId,
+            "Arena",
+            "An empty arena.",
+            Map.of(Direction.SOUTH, startId),
+            List.of(new Item(ItemId.of("stone"), "Stone", "A small stone.", ItemAttributes.empty(), List.of(), 0)),
+            List.of()
+        );
+        RoomService roomService = new RoomService(new TestRoomRepository(Map.of(startId, start, arenaId, arena)), startId);
+
+        PlayerVitals vitals = new PlayerVitals(10, 20, 10, 20, 10, 20);
+        Player player = new Player(
+            User.of(Username.of("sparky"), Password.of("pw")),
+            1,
+            0,
+            vitals,
+            List.of(),
+            "prompt",
+            false,
+            List.of(),
+            null,
+            null
+        ).die();
+        AtomicReference<Player> ref = new AtomicReference<>(player);
+        PlayerRespawnTicker ticker = new PlayerRespawnTicker(ref::get, ref::set, roomService, 2);
+
+        ticker.schedule();
+        ticker.tick();
+        assertTrue(ref.get().isDead());
+
+        ticker.tick();
+        Player respawned = ref.get();
+        assertFalse(respawned.isDead());
+        assertEquals(10, respawned.getVitals().hp());
+        assertEquals(Optional.of(startId), roomService.findPlayerLocation(respawned.getUsername()));
+    }
+
+    private record TestRoomRepository(Map<RoomId, Room> rooms) implements RoomRepository {
+        private TestRoomRepository(Map<RoomId, Room> rooms) {
+            this.rooms = new ConcurrentHashMap<>(rooms);
+        }
+
+        @Override
+        public void save(Room room) throws RepositoryException {
+            if (room == null) {
+                throw new RepositoryException("Room is required");
+            }
+            rooms.put(room.getId(), room);
+        }
+
+        @Override
+        public Optional<Room> findById(RoomId id) throws RepositoryException {
+            if (id == null) {
+                throw new RepositoryException("Room id is required");
+            }
+            return Optional.ofNullable(rooms.get(id));
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
@@ -1,0 +1,180 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerVitals;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+class SocketCommandDispatcherTest {
+
+    @Test
+    void blocksCommandsWhenDead() {
+        AtomicBoolean executed = new AtomicBoolean(false);
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        registry.register(new TestCommand("look", executed));
+        SocketCommandDispatcher dispatcher = new SocketCommandDispatcher(registry);
+
+        Player deadPlayer = new Player(
+            User.of(Username.of("sparky"), Password.of("pw")),
+            1,
+            0,
+            new PlayerVitals(5, 20, 5, 20, 5, 20),
+            List.of(),
+            "prompt",
+            false,
+            List.of(),
+            null,
+            null
+        ).die();
+        TestContext context = new TestContext(deadPlayer);
+
+        dispatcher.dispatch(context, "look");
+
+        assertFalse(executed.get());
+        assertEquals("You cannot act while dead.", context.lastMessage);
+    }
+
+    @Test
+    void allowsQuitWhenDead() {
+        AtomicBoolean executed = new AtomicBoolean(false);
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        registry.register(new TestCommand("quit", executed));
+        SocketCommandDispatcher dispatcher = new SocketCommandDispatcher(registry);
+
+        Player deadPlayer = new Player(
+            User.of(Username.of("sparky"), Password.of("pw")),
+            1,
+            0,
+            new PlayerVitals(5, 20, 5, 20, 5, 20),
+            List.of(),
+            "prompt",
+            false,
+            List.of(),
+            null,
+            null
+        ).die();
+        TestContext context = new TestContext(deadPlayer);
+
+        dispatcher.dispatch(context, "quit");
+
+        assertTrue(executed.get());
+    }
+
+    private static class TestCommand implements SocketCommandHandler {
+        private final String name;
+        private final AtomicBoolean executed;
+
+        private TestCommand(String name, AtomicBoolean executed) {
+            this.name = name;
+            this.executed = executed;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public Optional<SocketCommandMatch> match(String input) {
+            if (!input.equalsIgnoreCase(name)) {
+                return Optional.empty();
+            }
+            return Optional.of(new SocketCommandMatch(this, context -> executed.set(true)));
+        }
+    }
+
+    private static class TestContext implements SocketCommandContext {
+        private final Player player;
+        private String lastMessage;
+
+        private TestContext(Player player) {
+            this.player = player;
+        }
+
+        @Override
+        public boolean isAuthenticated() {
+            return true;
+        }
+
+        @Override
+        public Player getPlayer() {
+            return player;
+        }
+
+        @Override
+        public List<Client> clients() {
+            return List.of();
+        }
+
+        @Override
+        public void sendLook() {
+        }
+
+        @Override
+        public void sendMove(Direction direction) {
+        }
+
+        @Override
+        public void useAbility(String args) {
+        }
+
+        @Override
+        public void updateAnsi(String args) {
+        }
+
+        @Override
+        public void writeLineWithPrompt(String message) {
+            lastMessage = message;
+        }
+
+        @Override
+        public void writeLineSafe(String message) {
+        }
+
+        @Override
+        public void sendPrompt() {
+        }
+
+        @Override
+        public void sendToUsername(Username username, String message) {
+        }
+
+        @Override
+        public void sendToRoom(Player source, Player target, String message) {
+        }
+
+        @Override
+        public Optional<Player> resolveTarget(Player source, String input) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void executeAttack(String args) {
+        }
+
+        @Override
+        public void sendMessage(io.taanielo.jmud.core.messaging.Message message) {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void run() {
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/tick/system/CooldownSystemTest.java
+++ b/src/test/java/io/taanielo/jmud/core/tick/system/CooldownSystemTest.java
@@ -1,0 +1,23 @@
+package io.taanielo.jmud.core.tick.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CooldownSystemTest {
+
+    @Test
+    void clearRemovesAllCooldowns() {
+        CooldownSystem system = new CooldownSystem();
+        system.register("ability", 2);
+
+        assertTrue(system.isOnCooldown("ability"));
+
+        system.clear();
+
+        assertFalse(system.isOnCooldown("ability"));
+        assertEquals(0, system.remainingTicks("ability"));
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
@@ -101,6 +101,29 @@ class RoomServiceTest {
         assertTrue(output.contains("Occupants: Alice"));
     }
 
+    @Test
+    void spawnCorpseAddsItemToRoom() {
+        RoomId roomAId = RoomId.of("a");
+        Room roomA = new Room(
+            roomAId,
+            "Room A",
+            "A quiet room.",
+            Map.of(),
+            List.of(),
+            List.of()
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA)), roomAId);
+
+        Username victim = Username.of("Bob");
+        service.ensurePlayerLocation(victim);
+        service.spawnCorpse(victim, roomAId);
+
+        RoomService.LookResult lookResult = service.look(Username.of("Alice"));
+        String output = String.join("\n", lookResult.lines());
+
+        assertTrue(output.contains("Corpse of Bob"));
+    }
+
     private record TestRoomRepository(Map<RoomId, Room> rooms) implements RoomRepository {
         private TestRoomRepository(Map<RoomId, Room> rooms) {
             this.rooms = new ConcurrentHashMap<>(rooms);


### PR DESCRIPTION
## Summary
- add dead state, respawn ticker (10 ticks), and corpse spawning
- block commands while dead except quit; clear effects/cooldowns on death
- handle death after combat/ability damage and add tests

## Testing
- not run (no gradlew in repo)

## Risks
- assumes all combatants are players (no NPC guard yet)

Closes #51