### PR TITLE
feat(items): add get/drop/quaff and poison potion

### DIFF
--- a/data/items/poisonous-potion.json
+++ b/data/items/poisonous-potion.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "poisonous-potion",
+  "name": "Poisonous Potion",
+  "description": "A cloudy green vial that smells faintly of rot.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [
+    {
+      "effect_id": "poison",
+      "duration_ticks": 10
+    }
+  ],
+  "value": 5
+}

--- a/data/rooms/training-yard.json
+++ b/data/rooms/training-yard.json
@@ -5,6 +5,7 @@
   "description": "A dusty yard with practice dummies and scattered weapons.",
   "item_ids": [
     "iron-sword",
-    "health-potion"
+    "health-potion",
+    "poisonous-potion"
   ]
 }

--- a/effects/poison.json
+++ b/effects/poison.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "poison",
+  "name": "Poison",
+  "duration_ticks": 10,
+  "tick_interval": 1,
+  "stacking": "refresh",
+  "modifiers": [
+    {
+      "stat": "damage_per_tick",
+      "op": "add",
+      "amount": 5
+    }
+  ],
+  "messages": {
+    "apply_self": "Poison burns through your veins.",
+    "expire_self": "The poison leaves your body.",
+    "examine": "{name} looks sickly."
+  }
+}

--- a/src/main/java/io/taanielo/jmud/core/healing/HealingEngine.java
+++ b/src/main/java/io/taanielo/jmud/core/healing/HealingEngine.java
@@ -37,6 +37,11 @@ public class HealingEngine {
             updatedVitals = updatedVitals.heal(healing);
         }
 
+        int damage = applyModifiers(0, player.effects(), HealingModifierKeys.DAMAGE_PER_TICK);
+        if (damage > 0) {
+            updatedVitals = updatedVitals.damage(damage);
+        }
+
         if (updatedVitals == vitals) {
             return player;
         }

--- a/src/main/java/io/taanielo/jmud/core/healing/HealingModifierKeys.java
+++ b/src/main/java/io/taanielo/jmud/core/healing/HealingModifierKeys.java
@@ -3,6 +3,7 @@ package io.taanielo.jmud.core.healing;
 public final class HealingModifierKeys {
     public static final String HEAL_PER_TICK = "heal_per_tick";
     public static final String MAX_HP = "max_hp";
+    public static final String DAMAGE_PER_TICK = "damage_per_tick";
 
     private HealingModifierKeys() {
     }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/DropCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/DropCommand.java
@@ -1,0 +1,27 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles drop commands.
+ */
+public class DropCommand extends RegistrableCommand {
+    public DropCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "drop";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"DROP".equals(parts[0])) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> context.dropItem(args)));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GetCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GetCommand.java
@@ -1,0 +1,27 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles get commands.
+ */
+public class GetCommand extends RegistrableCommand {
+    public GetCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "get";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"GET".equals(parts[0])) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> context.getItem(args)));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/QuaffCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/QuaffCommand.java
@@ -1,0 +1,27 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles quaff commands.
+ */
+public class QuaffCommand extends RegistrableCommand {
+    public QuaffCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "quaff";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"QUAFF".equals(parts[0])) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> context.quaffItem(args)));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -82,4 +82,19 @@ public interface SocketCommandContext extends Client {
      */
     void executeAttack(String args);
 
+    /**
+     * Executes a get command with the provided arguments.
+     */
+    void getItem(String args);
+
+    /**
+     * Executes a drop command with the provided arguments.
+     */
+    void dropItem(String args);
+
+    /**
+     * Executes a quaff command with the provided arguments.
+     */
+    void quaffItem(String args);
+
 }

--- a/src/main/java/io/taanielo/jmud/core/world/repository/InMemoryRoomRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/world/repository/InMemoryRoomRepository.java
@@ -8,9 +8,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import io.taanielo.jmud.core.world.Direction;
 import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.ItemAttributes;
+import io.taanielo.jmud.core.world.ItemEffect;
 import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.Room;
 import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.effects.EffectId;
 
 public class InMemoryRoomRepository implements RoomRepository {
 
@@ -33,6 +35,13 @@ public class InMemoryRoomRepository implements RoomRepository {
                 ItemAttributes.empty(),
                 List.of(),
                 25
+            ), new Item(
+                ItemId.of("poisonous-potion"),
+                "Poisonous Potion",
+                "A cloudy green vial that smells faintly of rot.",
+                ItemAttributes.empty(),
+                List.of(new ItemEffect(EffectId.of("poison"), 10)),
+                5
             )),
             List.of()
         );

--- a/src/test/java/io/taanielo/jmud/core/healing/HealingEngineTest.java
+++ b/src/test/java/io/taanielo/jmud/core/healing/HealingEngineTest.java
@@ -161,6 +161,40 @@ class HealingEngineTest {
         assertEquals(1, updated.effects().size());
     }
 
+    @Test
+    void appliesDamagePerTickModifiers() throws Exception {
+        EffectId poisonId = EffectId.of("poison");
+        EffectDefinition poison = new EffectDefinition(
+            poisonId,
+            "Poison",
+            10,
+            1,
+            EffectStacking.REFRESH,
+            List.of(new EffectModifier(HealingModifierKeys.DAMAGE_PER_TICK, ModifierOperation.ADD, 5)),
+            null
+        );
+        PlayerVitals vitals = new PlayerVitals(12, 20, 10, 20, 10, 20);
+        List<EffectInstance> effects = new ArrayList<>();
+        effects.add(new EffectInstance(poisonId, 10, 1));
+        Player player = new Player(
+            User.of(Username.of("sparky"), Password.of("pw")),
+            1,
+            0,
+            vitals,
+            effects,
+            "prompt",
+            false,
+            List.of(),
+            null,
+            null
+        );
+        HealingEngine engine = new HealingEngine(new StubEffectRepository(Map.of(poisonId, poison)));
+
+        Player updated = engine.apply(player, 0);
+
+        assertEquals(7, updated.getVitals().hp());
+    }
+
     private static class StubEffectRepository implements EffectRepository {
         private final Map<EffectId, EffectDefinition> definitions;
 

--- a/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
@@ -166,6 +166,18 @@ class SocketCommandDispatcherTest {
         }
 
         @Override
+        public void getItem(String args) {
+        }
+
+        @Override
+        public void dropItem(String args) {
+        }
+
+        @Override
+        public void quaffItem(String args) {
+        }
+
+        @Override
         public void sendMessage(io.taanielo.jmud.core.messaging.Message message) {
         }
 

--- a/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
@@ -124,6 +124,68 @@ class RoomServiceTest {
         assertTrue(output.contains("Corpse of Bob"));
     }
 
+    @Test
+    void takeItemRemovesFromRoom() {
+        RoomId roomAId = RoomId.of("a");
+        Item torch = new Item(
+            ItemId.of("torch"),
+            "Torch",
+            "A warm torch.",
+            ItemAttributes.empty(),
+            List.of(),
+            5
+        );
+        Room roomA = new Room(
+            roomAId,
+            "Room A",
+            "A quiet room.",
+            Map.of(),
+            List.of(torch),
+            List.of()
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA)), roomAId);
+
+        Username bob = Username.of("Bob");
+        service.ensurePlayerLocation(bob);
+        assertTrue(service.takeItem(bob, "torch").isPresent());
+
+        RoomService.LookResult lookResult = service.look(bob);
+        String output = String.join("\n", lookResult.lines());
+
+        assertTrue(output.contains("Items: none"));
+    }
+
+    @Test
+    void dropItemAddsToRoom() {
+        RoomId roomAId = RoomId.of("a");
+        Room roomA = new Room(
+            roomAId,
+            "Room A",
+            "A quiet room.",
+            Map.of(),
+            List.of(),
+            List.of()
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA)), roomAId);
+
+        Username bob = Username.of("Bob");
+        service.ensurePlayerLocation(bob);
+        Item apple = new Item(
+            ItemId.of("apple"),
+            "Apple",
+            "A crisp apple.",
+            ItemAttributes.empty(),
+            List.of(),
+            1
+        );
+        service.dropItem(bob, apple);
+
+        RoomService.LookResult lookResult = service.look(bob);
+        String output = String.join("\n", lookResult.lines());
+
+        assertTrue(output.contains("Apple"));
+    }
+
     private record TestRoomRepository(Map<RoomId, Room> rooms) implements RoomRepository {
         private TestRoomRepository(Map<RoomId, Room> rooms) {
             this.rooms = new ConcurrentHashMap<>(rooms);


### PR DESCRIPTION
## Summary
- add inventory-backed get/drop/quaff commands for socket clients
- add poison effect tick damage and poisonous potion in training yard
- extend room service to transfer items and add tests

## Testing
- `gradle test` (fails: libnative-platform.so missing)

Closes #55