### PR TITLE
fix(respawn): announce and show room

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/player/PlayerRespawnTicker.java
+++ b/src/main/java/io/taanielo/jmud/core/player/PlayerRespawnTicker.java
@@ -71,7 +71,7 @@ public class PlayerRespawnTicker implements Tickable {
 
     private void respawn(Player player) {
         Player respawned = player.respawn();
-        playerUpdater.accept(respawned);
         roomService.respawnPlayer(respawned.getUsername());
+        playerUpdater.accept(respawned);
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -549,6 +549,9 @@ public class SocketClient implements Client {
 
     private void applyRespawnUpdate(Player updated) {
         replacePlayer(updated);
+        writeLineSafe("You awaken in the starting room.");
+        RoomService.LookResult result = roomService.look(player.getUsername());
+        writeLinesWithPrompt(result.lines());
     }
 
     private void handleDeathState() {


### PR DESCRIPTION
## Summary
- ensure respawn location is set before updating the player
- announce respawn and show the room/prompt on wakeup

## Testing
- not run (Gradle native platform issue on this host)