### PR TITLE
fix(socket): serialize player mutations per session

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClientTickable.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClientTickable.java
@@ -1,0 +1,26 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Objects;
+
+import io.taanielo.jmud.core.tick.Tickable;
+
+/**
+ * Tick adapter that enqueues per-player tick work on the client session thread.
+ */
+public class SocketClientTickable implements Tickable {
+    private final SocketClient client;
+
+    /**
+     * Creates a tickable for the provided socket client.
+     *
+     * @param client the client to tick
+     */
+    public SocketClientTickable(SocketClient client) {
+        this.client = Objects.requireNonNull(client, "Client is required");
+    }
+
+    @Override
+    public void tick() {
+        client.enqueueTick();
+    }
+}


### PR DESCRIPTION
## Summary
- route all player state mutations through a per-session single-threaded executor
- enqueue tick work via a session tickable to avoid cross-thread mutation
- make close/idempotent and avoid executor rejection on shutdown

## Testing
-  (fails: native platform library missing)