### PR TITLE
fix(player): confine commands to tick thread

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/player/PlayerRespawnTicker.java
+++ b/src/main/java/io/taanielo/jmud/core/player/PlayerRespawnTicker.java
@@ -12,8 +12,8 @@ public class PlayerRespawnTicker implements Tickable {
     private final Consumer<Player> playerUpdater;
     private final RoomService roomService;
     private final int respawnTicks;
-    private boolean scheduled;
-    private int remainingTicks;
+    private volatile boolean scheduled;
+    private volatile int remainingTicks;
 
     public PlayerRespawnTicker(
         Supplier<Player> playerSupplier,

--- a/src/main/java/io/taanielo/jmud/core/server/socket/PlayerCommandQueue.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/PlayerCommandQueue.java
@@ -1,0 +1,30 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.taanielo.jmud.core.tick.Tickable;
+
+@Slf4j
+public class PlayerCommandQueue implements Tickable {
+    private final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<>();
+
+    public void enqueue(Runnable command) {
+        queue.add(Objects.requireNonNull(command, "Command is required"));
+    }
+
+    @Override
+    public void tick() {
+        Runnable task = queue.poll();
+        while (task != null) {
+            try {
+                task.run();
+            } catch (Exception e) {
+                log.error("Player command failed", e);
+            }
+            task = queue.poll();
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/PlayerCommandQueueTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/PlayerCommandQueueTest.java
@@ -1,0 +1,28 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class PlayerCommandQueueTest {
+
+    @Test
+    void executesCommandsInOrderAndContinuesAfterFailure() {
+        PlayerCommandQueue queue = new PlayerCommandQueue();
+        List<String> executed = new ArrayList<>();
+
+        queue.enqueue(() -> executed.add("first"));
+        queue.enqueue(() -> {
+            executed.add("boom");
+            throw new IllegalStateException("fail");
+        });
+        queue.enqueue(() -> executed.add("third"));
+
+        queue.tick();
+
+        assertEquals(List.of("first", "boom", "third"), executed);
+    }
+}


### PR DESCRIPTION
## Summary
- add per-session command queue executed on tick thread to confine player mutations
- enqueue socket command dispatch and post-auth look/respawn scheduling
- add command queue unit test and cross-thread visibility safeguards

## Testing
- gradle test --tests io.taanielo.jmud.core.server.socket.PlayerCommandQueueTest (fails: Could not load libnative-platform.so)

Fixes #61