### PR TITLE
refactor(player): decompose player aggregate

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/player/PlayerAbilities.java
+++ b/src/main/java/io/taanielo/jmud/core/player/PlayerAbilities.java
@@ -1,0 +1,22 @@
+package io.taanielo.jmud.core.player;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.taanielo.jmud.core.ability.AbilityId;
+
+public class PlayerAbilities {
+    private final List<AbilityId> learned;
+
+    public PlayerAbilities(List<AbilityId> learned) {
+        this.learned = List.copyOf(Objects.requireNonNullElse(learned, List.of()));
+    }
+
+    public List<AbilityId> learned() {
+        return learned;
+    }
+
+    public PlayerAbilities withLearned(List<AbilityId> nextLearned) {
+        return new PlayerAbilities(nextLearned);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/player/PlayerCombatState.java
+++ b/src/main/java/io/taanielo/jmud/core/player/PlayerCombatState.java
@@ -1,0 +1,57 @@
+package io.taanielo.jmud.core.player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.taanielo.jmud.core.effects.EffectInstance;
+
+public class PlayerCombatState {
+    private final PlayerVitals vitals;
+    private final List<EffectInstance> effects;
+    private final boolean dead;
+
+    public PlayerCombatState(PlayerVitals vitals, List<EffectInstance> effects, Boolean dead) {
+        this.vitals = Objects.requireNonNull(vitals, "Vitals are required");
+        this.effects = new ArrayList<>(Objects.requireNonNullElse(effects, List.of()));
+        boolean resolvedDead = Objects.requireNonNullElse(dead, false) || vitals.hp() <= 0;
+        this.dead = resolvedDead;
+    }
+
+    public PlayerVitals vitals() {
+        return vitals;
+    }
+
+    public List<EffectInstance> effects() {
+        return effects;
+    }
+
+    public boolean dead() {
+        return dead;
+    }
+
+    public PlayerCombatState die() {
+        if (dead && vitals.hp() <= 0 && effects.isEmpty()) {
+            return this;
+        }
+        PlayerVitals deadVitals = vitals.damage(vitals.hp());
+        return new PlayerCombatState(deadVitals, List.of(), true);
+    }
+
+    public PlayerCombatState respawn() {
+        PlayerVitals restored = vitals.respawnHalf();
+        return new PlayerCombatState(restored, List.of(), false);
+    }
+
+    public PlayerCombatState withoutEffects() {
+        return new PlayerCombatState(vitals, List.of(), dead);
+    }
+
+    public PlayerCombatState withVitals(PlayerVitals updatedVitals) {
+        return new PlayerCombatState(updatedVitals, effects, dead);
+    }
+
+    public PlayerCombatState withDead(boolean nextDead) {
+        return new PlayerCombatState(vitals, effects, nextDead);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/player/PlayerIdentity.java
+++ b/src/main/java/io/taanielo/jmud/core/player/PlayerIdentity.java
@@ -1,0 +1,59 @@
+package io.taanielo.jmud.core.player;
+
+import java.util.Objects;
+
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.character.ClassId;
+import io.taanielo.jmud.core.character.RaceId;
+
+public class PlayerIdentity {
+    private final User user;
+    private final int level;
+    private final long experience;
+    private final RaceId race;
+    private final ClassId classId;
+
+    public PlayerIdentity(User user, int level, long experience, RaceId race, ClassId classId) {
+        this.user = Objects.requireNonNull(user, "User is required");
+        this.level = level;
+        this.experience = experience;
+        this.race = Objects.requireNonNullElse(race, RaceId.of("human"));
+        this.classId = Objects.requireNonNullElse(classId, ClassId.of("adventurer"));
+    }
+
+    public User user() {
+        return user;
+    }
+
+    public int level() {
+        return level;
+    }
+
+    public long experience() {
+        return experience;
+    }
+
+    public RaceId race() {
+        return race;
+    }
+
+    public ClassId classId() {
+        return classId;
+    }
+
+    public PlayerIdentity withLevel(int nextLevel) {
+        return new PlayerIdentity(user, nextLevel, experience, race, classId);
+    }
+
+    public PlayerIdentity withExperience(long nextExperience) {
+        return new PlayerIdentity(user, level, nextExperience, race, classId);
+    }
+
+    public PlayerIdentity withRace(RaceId nextRace) {
+        return new PlayerIdentity(user, level, experience, nextRace, classId);
+    }
+
+    public PlayerIdentity withClassId(ClassId nextClassId) {
+        return new PlayerIdentity(user, level, experience, race, nextClassId);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/player/PlayerInventory.java
+++ b/src/main/java/io/taanielo/jmud/core/player/PlayerInventory.java
@@ -1,0 +1,40 @@
+package io.taanielo.jmud.core.player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.taanielo.jmud.core.world.Item;
+
+public class PlayerInventory {
+    private final List<Item> items;
+
+    public PlayerInventory(List<Item> items) {
+        this.items = List.copyOf(Objects.requireNonNullElse(items, List.of()));
+    }
+
+    public List<Item> items() {
+        return items;
+    }
+
+    public PlayerInventory withItems(List<Item> nextItems) {
+        return new PlayerInventory(nextItems);
+    }
+
+    public PlayerInventory addItem(Item item) {
+        Objects.requireNonNull(item, "Item is required");
+        List<Item> next = new ArrayList<>(items);
+        next.add(item);
+        return new PlayerInventory(next);
+    }
+
+    public PlayerInventory removeItem(Item item) {
+        Objects.requireNonNull(item, "Item is required");
+        List<Item> next = new ArrayList<>(items);
+        boolean removed = next.removeIf(existing -> existing.getId().equals(item.getId()));
+        if (!removed) {
+            return this;
+        }
+        return new PlayerInventory(next);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/player/PlayerPreferences.java
+++ b/src/main/java/io/taanielo/jmud/core/player/PlayerPreferences.java
@@ -1,0 +1,29 @@
+package io.taanielo.jmud.core.player;
+
+import java.util.Objects;
+
+public class PlayerPreferences {
+    private final String promptFormat;
+    private final boolean ansiEnabled;
+
+    public PlayerPreferences(String promptFormat, Boolean ansiEnabled) {
+        this.promptFormat = Objects.requireNonNull(promptFormat, "Prompt format is required");
+        this.ansiEnabled = Objects.requireNonNullElse(ansiEnabled, false);
+    }
+
+    public String promptFormat() {
+        return promptFormat;
+    }
+
+    public boolean ansiEnabled() {
+        return ansiEnabled;
+    }
+
+    public PlayerPreferences withAnsiEnabled(boolean enabled) {
+        return new PlayerPreferences(promptFormat, enabled);
+    }
+
+    public PlayerPreferences withPromptFormat(String nextFormat) {
+        return new PlayerPreferences(nextFormat, ansiEnabled);
+    }
+}


### PR DESCRIPTION
Summary:
- introduce PlayerIdentity/CombatState/Inventory/Preferences/Abilities value objects
- refactor Player to delegate behavior while preserving flat JSON fields
- keep API compatible for existing callers

Tests:
- gradle test

Risks:
- low/medium; serialization paths are touched but remain backward compatible

Closed https://github.com/taanielo/jmud/issues/64