### PR TITLE
feat(mob): weapon-based combat and NPC/monster system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(26)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(26)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/data/attacks/attack.goblin.json
+++ b/data/attacks/attack.goblin.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "attack.goblin",
+  "name": "goblin claws",
+  "min_damage": 2,
+  "max_damage": 6,
+  "hit_bonus": 0,
+  "crit_bonus": 0,
+  "damage_bonus": 0,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The goblin claws at you for {damage}."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The goblin swipes at you but misses."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The goblin savagely claws you for {damage}!"
+    }
+  ]
+}

--- a/data/attacks/attack.iron-sword.json
+++ b/data/attacks/attack.iron-sword.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 2,
+  "id": "attack.iron-sword",
+  "name": "iron sword",
+  "min_damage": 3,
+  "max_damage": 8,
+  "hit_bonus": 5,
+  "crit_bonus": 1,
+  "damage_bonus": 1,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "You slash {target} with your iron sword for {damage}."
+    },
+    {
+      "phase": "attack_hit",
+      "channel": "target",
+      "text": "{source} slashes you with an iron sword for {damage}."
+    },
+    {
+      "phase": "attack_hit",
+      "channel": "room",
+      "text": "{source} slashes {target} with an iron sword."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "You swing at {target} but miss."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "target",
+      "text": "{source} swings an iron sword at you but misses."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "room",
+      "text": "{source} swings an iron sword at {target} but misses."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "You land a devastating blow on {target} with your iron sword for {damage}!"
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "target",
+      "text": "{source} lands a devastating blow on you with an iron sword for {damage}!"
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "room",
+      "text": "{source} lands a devastating blow on {target} with an iron sword!"
+    }
+  ]
+}

--- a/data/items/iron-sword.json
+++ b/data/items/iron-sword.json
@@ -12,5 +12,6 @@
   "messages": [],
   "equip_slot": "weapon",
   "weight": 5,
-  "value": 25
+  "value": 25,
+  "attack_ref": "attack.iron-sword"
 }

--- a/data/mobs/goblin.json
+++ b/data/mobs/goblin.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "goblin",
+  "name": "Goblin",
+  "max_hp": 15,
+  "attack_id": "attack.goblin",
+  "spawn_room_id": "training-yard",
+  "max_count": 2,
+  "respawn_ticks": 30,
+  "loot": [
+    {
+      "item_id": "health-potion",
+      "drop_chance": 0.5
+    }
+  ]
+}

--- a/data/mobs/training-dummy.json
+++ b/data/mobs/training-dummy.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "id": "training-dummy",
+  "name": "Training Dummy",
+  "max_hp": 100,
+  "attack_id": null,
+  "spawn_room_id": "training-yard",
+  "max_count": 1,
+  "respawn_ticks": 10,
+  "loot": []
+}

--- a/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
+++ b/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
@@ -17,6 +17,7 @@ import io.taanielo.jmud.core.ability.AbilityRegistry;
 import io.taanielo.jmud.core.ability.AbilityTargetResolver;
 import io.taanielo.jmud.core.ability.AbilityUseResult;
 import io.taanielo.jmud.core.ability.DefaultAbilityEffectResolver;
+import io.taanielo.jmud.core.combat.AttackId;
 import io.taanielo.jmud.core.combat.CombatEngine;
 import io.taanielo.jmud.core.combat.CombatResult;
 import io.taanielo.jmud.core.combat.CombatSettings;
@@ -29,9 +30,10 @@ import io.taanielo.jmud.core.messaging.MessagePhase;
 import io.taanielo.jmud.core.player.EncumbranceService;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerEquipment;
+import io.taanielo.jmud.core.world.EquipmentSlot;
 import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.ItemEffect;
-import io.taanielo.jmud.core.world.EquipmentSlot;
+import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.Room;
 import io.taanielo.jmud.core.world.RoomService;
 
@@ -102,7 +104,7 @@ public class GameActionService {
             return GameActionResult.error("You cannot attack yourself.");
         }
         try {
-            CombatResult result = combatEngine.resolve(source, target, CombatSettings.defaultAttackId());
+            CombatResult result = combatEngine.resolve(source, target, resolveAttackId(source));
             List<GameMessage> messages = new ArrayList<>();
             if (result.sourceMessage() != null && !result.sourceMessage().isBlank()) {
                 messages.add(GameMessage.toSource(result.sourceMessage()));
@@ -425,6 +427,18 @@ public class GameActionService {
             roomMessage));
 
         return messages;
+    }
+
+    private AttackId resolveAttackId(Player attacker) {
+        ItemId weaponId = attacker.getEquipment().equipped(EquipmentSlot.WEAPON);
+        if (weaponId != null) {
+            for (Item item : attacker.getInventory()) {
+                if (item.getId().equals(weaponId) && item.getAttackRef() != null) {
+                    return item.getAttackRef();
+                }
+            }
+        }
+        return CombatSettings.defaultAttackId();
     }
 
     private Item findInventoryItem(Player player, String input) {

--- a/src/main/java/io/taanielo/jmud/core/action/PlayerEventBus.java
+++ b/src/main/java/io/taanielo/jmud/core/action/PlayerEventBus.java
@@ -1,0 +1,34 @@
+package io.taanielo.jmud.core.action;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+import io.taanielo.jmud.core.authentication.Username;
+
+/**
+ * Routes {@link GameActionResult}s produced by server-side actors (e.g. mob AI)
+ * to the appropriate connected player session.
+ *
+ * <p>Each player session registers a handler on login and unregisters on logout.
+ * Publishers (e.g. {@code MobRegistry}) call {@link #publish} without knowing
+ * anything about transport or session internals.
+ */
+public class PlayerEventBus {
+
+    private final ConcurrentHashMap<Username, Consumer<GameActionResult>> handlers = new ConcurrentHashMap<>();
+
+    public void register(Username username, Consumer<GameActionResult> handler) {
+        handlers.put(username, handler);
+    }
+
+    public void unregister(Username username) {
+        handlers.remove(username);
+    }
+
+    public void publish(Username username, GameActionResult result) {
+        Consumer<GameActionResult> handler = handlers.get(username);
+        if (handler != null) {
+            handler.accept(result);
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/LootEntry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/LootEntry.java
@@ -1,0 +1,15 @@
+package io.taanielo.jmud.core.mob;
+
+import io.taanielo.jmud.core.world.ItemId;
+
+/**
+ * Defines an item that may drop from a mob on death, with a probability.
+ */
+public record LootEntry(ItemId itemId, double dropChance) {
+
+    public LootEntry {
+        if (dropChance < 0.0 || dropChance > 1.0) {
+            throw new IllegalArgumentException("Drop chance must be between 0.0 and 1.0");
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/MobId.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobId.java
@@ -1,0 +1,27 @@
+package io.taanielo.jmud.core.mob;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Value;
+
+@Value
+public class MobId {
+    String value;
+
+    public MobId(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Mob id must not be blank");
+        }
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static MobId of(String value) {
+        return new MobId(value);
+    }
+
+    @JsonValue
+    public String jsonValue() {
+        return value;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/MobInstance.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobInstance.java
@@ -1,0 +1,71 @@
+package io.taanielo.jmud.core.mob;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * A live mob instance in the world.
+ *
+ * <p>HP is tracked via {@link AtomicInteger} so that player-thread attacks
+ * (command queue) and tick-thread AI reads are both safe. All other state
+ * mutations are confined to the tick thread.
+ */
+public class MobInstance {
+
+    private final UUID instanceId = UUID.randomUUID();
+    private final MobTemplate template;
+    private final AtomicInteger hp;
+    private final AtomicInteger respawnTicksRemaining = new AtomicInteger(0);
+
+    public MobInstance(MobTemplate template) {
+        this.template = template;
+        this.hp = new AtomicInteger(template.maxHp());
+    }
+
+    public UUID instanceId() {
+        return instanceId;
+    }
+
+    public MobTemplate template() {
+        return template;
+    }
+
+    public RoomId roomId() {
+        return template.spawnRoomId();
+    }
+
+    public boolean isAlive() {
+        return hp.get() > 0;
+    }
+
+    public int currentHp() {
+        return hp.get();
+    }
+
+    /** Applies damage and returns remaining HP (clamped to 0). */
+    public int takeDamage(int amount) {
+        return hp.updateAndGet(current -> Math.max(0, current - amount));
+    }
+
+    /** Called once when the mob dies — starts the respawn countdown. */
+    public void scheduleRespawn() {
+        respawnTicksRemaining.set(template.respawnTicks());
+    }
+
+    /**
+     * Decrements the respawn countdown.
+     *
+     * @return true when the countdown reaches zero and the mob should respawn
+     */
+    public boolean tickRespawn() {
+        return respawnTicksRemaining.decrementAndGet() <= 0;
+    }
+
+    /** Resets the mob to full HP, ready to act again. */
+    public void respawn() {
+        hp.set(template.maxHp());
+        respawnTicksRemaining.set(0);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -1,0 +1,259 @@
+package io.taanielo.jmud.core.mob;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.taanielo.jmud.core.action.GameActionResult;
+import io.taanielo.jmud.core.action.GameMessage;
+import io.taanielo.jmud.core.action.PlayerEventBus;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.combat.AttackDefinition;
+import io.taanielo.jmud.core.combat.AttackId;
+import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.combat.repository.AttackRepositoryException;
+import io.taanielo.jmud.core.combat.CombatSettings;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.tick.Tickable;
+import io.taanielo.jmud.core.world.EquipmentSlot;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.ItemRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+
+/**
+ * Manages all live mob instances and drives mob AI on each tick.
+ *
+ * <p>All state mutations happen on the tick thread. Player HP updates are
+ * delivered via {@link PlayerEventBus} so no transport code lives here.
+ */
+@Slf4j
+public class MobRegistry implements Tickable {
+
+    private final MobTemplateRepository templateRepository;
+    private final ItemRepository itemRepository;
+    private final AttackRepository attackRepository;
+    private final RoomService roomService;
+    private final PlayerRepository playerRepository;
+    private final PlayerEventBus playerEventBus;
+
+    private final ConcurrentHashMap<UUID, MobInstance> instances = new ConcurrentHashMap<>();
+
+    public MobRegistry(
+        MobTemplateRepository templateRepository,
+        ItemRepository itemRepository,
+        AttackRepository attackRepository,
+        RoomService roomService,
+        PlayerRepository playerRepository,
+        PlayerEventBus playerEventBus
+    ) {
+        this.templateRepository = Objects.requireNonNull(templateRepository, "Template repository is required");
+        this.itemRepository = Objects.requireNonNull(itemRepository, "Item repository is required");
+        this.attackRepository = Objects.requireNonNull(attackRepository, "Attack repository is required");
+        this.roomService = Objects.requireNonNull(roomService, "Room service is required");
+        this.playerRepository = Objects.requireNonNull(playerRepository, "Player repository is required");
+        this.playerEventBus = Objects.requireNonNull(playerEventBus, "Player event bus is required");
+    }
+
+    /**
+     * Spawns initial mob instances from all templates. Call once on server start.
+     */
+    public void init() {
+        List<MobTemplate> templates;
+        try {
+            templates = templateRepository.findAll();
+        } catch (MobRepositoryException e) {
+            log.error("Failed to load mob templates: {}", e.getMessage(), e);
+            return;
+        }
+        for (MobTemplate template : templates) {
+            for (int i = 0; i < template.maxCount(); i++) {
+                MobInstance mob = new MobInstance(template);
+                instances.put(mob.instanceId(), mob);
+            }
+        }
+        log.info("Spawned {} mob instance(s) from {} template(s)", instances.size(), templates.size());
+    }
+
+    @Override
+    public void tick() {
+        for (MobInstance mob : instances.values()) {
+            if (!mob.isAlive()) {
+                if (mob.tickRespawn()) {
+                    mob.respawn();
+                    log.debug("Mob {} respawned in {}", mob.template().name(), mob.roomId());
+                }
+                continue;
+            }
+            if (mob.template().attackId() == null) {
+                continue;
+            }
+            runMobAi(mob);
+        }
+    }
+
+    /**
+     * Returns all live mobs currently in the given room.
+     */
+    public List<MobInstance> getMobsInRoom(RoomId roomId) {
+        Objects.requireNonNull(roomId, "Room id is required");
+        return instances.values().stream()
+            .filter(m -> m.isAlive() && m.roomId().equals(roomId))
+            .toList();
+    }
+
+    /**
+     * Processes a player's attack against a mob in their current room.
+     *
+     * @param attacker  the attacking player
+     * @param input     raw mob name input from the player
+     * @param roomId    the room where the attack takes place
+     * @return result containing messages to deliver to the attacker
+     */
+    public GameActionResult processPlayerAttack(Player attacker, String input, RoomId roomId) {
+        if (input == null || input.isBlank()) {
+            return GameActionResult.error("Attack what?");
+        }
+        MobInstance mob = findMobByName(getMobsInRoom(roomId), input);
+        if (mob == null) {
+            return GameActionResult.error("No such target here.");
+        }
+        AttackId attackId = resolveAttackId(attacker);
+        AttackDefinition attack = loadAttack(attackId);
+        if (attack == null) {
+            return GameActionResult.error("Combat error: attack definition not found.");
+        }
+        int damage = rollDamage(attack);
+        int remaining = mob.takeDamage(damage);
+
+        List<GameMessage> messages = new ArrayList<>();
+        messages.add(GameMessage.toSource(
+            "You strike the " + mob.template().name() + " for " + damage + " damage. ("
+                + remaining + " HP remaining)"));
+
+        if (!mob.isAlive()) {
+            messages.add(GameMessage.toSource("You slay the " + mob.template().name() + "!"));
+            dropLoot(mob);
+            mob.scheduleRespawn();
+        }
+        return new GameActionResult(null, null, messages);
+    }
+
+    // ── Mob AI ────────────────────────────────────────────────────────
+
+    private void runMobAi(MobInstance mob) {
+        List<Username> players = roomService.getPlayersInRoom(mob.roomId());
+        if (players.isEmpty()) {
+            return;
+        }
+        Username targetUsername = players.get(ThreadLocalRandom.current().nextInt(players.size()));
+        Player target = playerRepository.loadPlayer(targetUsername).orElse(null);
+        if (target == null || target.isDead()) {
+            return;
+        }
+        AttackDefinition attack = loadAttack(mob.template().attackId());
+        if (attack == null) {
+            return;
+        }
+        int damage = rollDamage(attack);
+        Player damagedPlayer = target.withVitals(target.getVitals().damage(damage));
+
+        if (damagedPlayer.getVitals().hp() <= 0) {
+            handleMobKill(mob, damagedPlayer, players);
+        } else {
+            playerRepository.savePlayer(damagedPlayer);
+            String hitMsg = "The " + mob.template().name() + " hits you for " + damage + " damage!";
+            playerEventBus.publish(targetUsername,
+                new GameActionResult(damagedPlayer, null, List.of(GameMessage.toSource(hitMsg))));
+        }
+    }
+
+    private void handleMobKill(MobInstance mob, Player damagedPlayer, List<Username> roomOccupants) {
+        Player deadPlayer = damagedPlayer.die();
+        roomService.spawnCorpse(deadPlayer.getUsername(), mob.roomId());
+        roomService.clearPlayerLocation(deadPlayer.getUsername());
+        playerRepository.savePlayer(deadPlayer);
+
+        String slainMsg = "The " + mob.template().name() + " has slain you!";
+        playerEventBus.publish(deadPlayer.getUsername(),
+            new GameActionResult(deadPlayer, null, List.of(GameMessage.toSource(slainMsg))));
+
+        String roomMsg = deadPlayer.getUsername().getValue()
+            + " has been slain by the " + mob.template().name() + ".";
+        for (Username occupant : roomOccupants) {
+            if (!occupant.equals(deadPlayer.getUsername())) {
+                playerEventBus.publish(occupant,
+                    new GameActionResult(null, null, List.of(GameMessage.toSource(roomMsg))));
+            }
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────
+
+    private void dropLoot(MobInstance mob) {
+        for (LootEntry entry : mob.template().lootTable()) {
+            if (ThreadLocalRandom.current().nextDouble() <= entry.dropChance()) {
+                try {
+                    itemRepository.findById(entry.itemId()).ifPresent(item ->
+                        roomService.addItem(mob.roomId(), item));
+                } catch (RepositoryException e) {
+                    log.warn("Failed to drop loot item {}: {}", entry.itemId(), e.getMessage());
+                }
+            }
+        }
+    }
+
+    private AttackDefinition loadAttack(AttackId attackId) {
+        try {
+            return attackRepository.findById(attackId).orElse(null);
+        } catch (AttackRepositoryException e) {
+            log.warn("Failed to load attack {}: {}", attackId, e.getMessage());
+            return null;
+        }
+    }
+
+    private AttackId resolveAttackId(Player attacker) {
+        ItemId weaponId = attacker.getEquipment().equipped(EquipmentSlot.WEAPON);
+        if (weaponId != null) {
+            for (Item item : attacker.getInventory()) {
+                if (item.getId().equals(weaponId) && item.getAttackRef() != null) {
+                    return item.getAttackRef();
+                }
+            }
+        }
+        return CombatSettings.defaultAttackId();
+    }
+
+    private MobInstance findMobByName(List<MobInstance> mobs, String input) {
+        String normalized = input.trim().toLowerCase(Locale.ROOT);
+        for (MobInstance mob : mobs) {
+            String name = mob.template().name().toLowerCase(Locale.ROOT);
+            if (name.equals(normalized) || name.startsWith(normalized)) {
+                return mob;
+            }
+        }
+        return null;
+    }
+
+    private int rollDamage(AttackDefinition attack) {
+        int range = attack.maxDamage() - attack.minDamage();
+        int base = range > 0
+            ? attack.minDamage() + ThreadLocalRandom.current().nextInt(range + 1)
+            : attack.minDamage();
+        return Math.max(1, base + attack.damageBonus());
+    }
+
+    Collection<MobInstance> allInstances() {
+        return instances.values();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRepositoryException.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRepositoryException.java
@@ -1,0 +1,12 @@
+package io.taanielo.jmud.core.mob;
+
+public class MobRepositoryException extends Exception {
+
+    public MobRepositoryException(String message) {
+        super(message);
+    }
+
+    public MobRepositoryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
@@ -1,0 +1,34 @@
+package io.taanielo.jmud.core.mob;
+
+import java.util.List;
+
+import io.taanielo.jmud.core.combat.AttackId;
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * Immutable definition of a mob type loaded from data files.
+ * Separate from {@link MobInstance}, which represents a live mob in the world.
+ */
+public record MobTemplate(
+    MobId id,
+    String name,
+    int maxHp,
+    AttackId attackId,
+    List<LootEntry> lootTable,
+    RoomId spawnRoomId,
+    int maxCount,
+    int respawnTicks
+) {
+    public MobTemplate {
+        if (maxHp <= 0) {
+            throw new IllegalArgumentException("Mob maxHp must be positive");
+        }
+        if (maxCount <= 0) {
+            throw new IllegalArgumentException("Mob maxCount must be positive");
+        }
+        if (respawnTicks < 0) {
+            throw new IllegalArgumentException("Mob respawnTicks must be non-negative");
+        }
+        lootTable = List.copyOf(lootTable);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/MobTemplateRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobTemplateRepository.java
@@ -1,0 +1,11 @@
+package io.taanielo.jmud.core.mob;
+
+import java.util.List;
+
+/**
+ * Provides mob template definitions loaded from persistent storage.
+ */
+public interface MobTemplateRepository {
+
+    List<MobTemplate> findAll() throws MobRepositoryException;
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/LootEntryDto.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/LootEntryDto.java
@@ -1,0 +1,7 @@
+package io.taanielo.jmud.core.mob.dto;
+
+public record LootEntryDto(
+    String itemId,
+    double dropChance
+) {
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
@@ -1,0 +1,16 @@
+package io.taanielo.jmud.core.mob.dto;
+
+import java.util.List;
+
+public record MobTemplateDto(
+    int schemaVersion,
+    String id,
+    String name,
+    int maxHp,
+    String attackId,
+    List<LootEntryDto> loot,
+    String spawnRoomId,
+    int maxCount,
+    int respawnTicks
+) {
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
@@ -1,0 +1,32 @@
+package io.taanielo.jmud.core.mob.dto;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.taanielo.jmud.core.combat.AttackId;
+import io.taanielo.jmud.core.mob.LootEntry;
+import io.taanielo.jmud.core.mob.MobId;
+import io.taanielo.jmud.core.mob.MobTemplate;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.RoomId;
+
+public class MobTemplateDtoMapper {
+
+    public MobTemplate toDomain(MobTemplateDto dto) {
+        Objects.requireNonNull(dto, "MobTemplateDto is required");
+        AttackId attackId = dto.attackId() != null ? AttackId.of(dto.attackId()) : null;
+        List<LootEntry> loot = dto.loot() == null ? List.of() : dto.loot().stream()
+            .map(e -> new LootEntry(ItemId.of(e.itemId()), e.dropChance()))
+            .toList();
+        return new MobTemplate(
+            MobId.of(dto.id()),
+            dto.name(),
+            dto.maxHp(),
+            attackId,
+            loot,
+            RoomId.of(dto.spawnRoomId()),
+            dto.maxCount(),
+            dto.respawnTicks()
+        );
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/repository/json/JsonDataMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/repository/json/JsonDataMapper.java
@@ -1,0 +1,20 @@
+package io.taanielo.jmud.core.mob.repository.json;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+final class JsonDataMapper {
+    private JsonDataMapper() {
+    }
+
+    static ObjectMapper create() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        return mapper;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/repository/json/JsonMobTemplateRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/repository/json/JsonMobTemplateRepository.java
@@ -1,0 +1,75 @@
+package io.taanielo.jmud.core.mob.repository.json;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.taanielo.jmud.core.mob.MobRepositoryException;
+import io.taanielo.jmud.core.mob.MobTemplate;
+import io.taanielo.jmud.core.mob.MobTemplateRepository;
+import io.taanielo.jmud.core.mob.dto.MobTemplateDto;
+import io.taanielo.jmud.core.mob.dto.MobTemplateDtoMapper;
+
+public class JsonMobTemplateRepository implements MobTemplateRepository {
+
+    private static final int SCHEMA_VERSION = 1;
+    private static final String MOBS_DIR = "mobs";
+
+    private final ObjectMapper objectMapper;
+    private final MobTemplateDtoMapper mapper;
+    private final Path mobsDirPath;
+
+    public JsonMobTemplateRepository() throws MobRepositoryException {
+        this(Path.of("data"));
+    }
+
+    public JsonMobTemplateRepository(Path dataRoot) throws MobRepositoryException {
+        this.objectMapper = JsonDataMapper.create();
+        this.mapper = new MobTemplateDtoMapper();
+        this.mobsDirPath = Objects.requireNonNull(dataRoot, "Data root is required").resolve(MOBS_DIR);
+        ensureDirectory(mobsDirPath);
+    }
+
+    @Override
+    public List<MobTemplate> findAll() throws MobRepositoryException {
+        List<MobTemplate> templates = new ArrayList<>();
+        try (var stream = Files.list(mobsDirPath)) {
+            for (Path path : stream.filter(p -> p.toString().endsWith(".json")).toList()) {
+                MobTemplateDto dto = readDto(path);
+                if (dto.schemaVersion() != SCHEMA_VERSION) {
+                    throw new MobRepositoryException(
+                        "Unsupported mob schema version " + dto.schemaVersion() + " in " + path);
+                }
+                try {
+                    templates.add(mapper.toDomain(dto));
+                } catch (IllegalArgumentException e) {
+                    throw new MobRepositoryException("Invalid mob data in " + path + ": " + e.getMessage(), e);
+                }
+            }
+        } catch (IOException e) {
+            throw new MobRepositoryException("Failed to list mob data files: " + e.getMessage(), e);
+        }
+        return List.copyOf(templates);
+    }
+
+    private MobTemplateDto readDto(Path path) throws MobRepositoryException {
+        try {
+            return objectMapper.readValue(path.toFile(), MobTemplateDto.class);
+        } catch (IOException e) {
+            throw new MobRepositoryException("Failed to read mob data from " + path + ": " + e.getMessage(), e);
+        }
+    }
+
+    private void ensureDirectory(Path path) throws MobRepositoryException {
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new MobRepositoryException("Failed to create mobs directory " + path, e);
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
@@ -9,6 +9,7 @@ import io.taanielo.jmud.core.ability.BasicAbilityCostResolver;
 import io.taanielo.jmud.core.ability.RoomAbilityTargetResolver;
 import io.taanielo.jmud.core.ability.repository.AbilityRepositoryException;
 import io.taanielo.jmud.core.ability.repository.json.JsonAbilityRepository;
+import io.taanielo.jmud.core.action.PlayerEventBus;
 import io.taanielo.jmud.core.audit.AuditService;
 import io.taanielo.jmud.core.authentication.AuthenticationLimiter;
 import io.taanielo.jmud.core.authentication.AuthenticationPolicy;
@@ -30,6 +31,9 @@ import io.taanielo.jmud.core.effects.EffectRepositoryException;
 import io.taanielo.jmud.core.effects.repository.json.JsonEffectRepository;
 import io.taanielo.jmud.core.healing.HealingBaseResolver;
 import io.taanielo.jmud.core.healing.HealingEngine;
+import io.taanielo.jmud.core.mob.MobRegistry;
+import io.taanielo.jmud.core.mob.MobRepositoryException;
+import io.taanielo.jmud.core.mob.repository.json.JsonMobTemplateRepository;
 import io.taanielo.jmud.core.player.EncumbranceService;
 import io.taanielo.jmud.core.player.JsonPlayerRepository;
 import io.taanielo.jmud.core.player.PlayerRepository;
@@ -39,7 +43,9 @@ import io.taanielo.jmud.core.tick.TickRegistry;
 import io.taanielo.jmud.core.world.RoomId;
 import io.taanielo.jmud.core.world.RoomService;
 import io.taanielo.jmud.core.world.repository.InMemoryRoomRepository;
+import io.taanielo.jmud.core.world.repository.ItemRepository;
 import io.taanielo.jmud.core.world.repository.RoomRepository;
+import io.taanielo.jmud.core.world.repository.json.JsonItemRepository;
 
 /**
  * Shared dependency container for socket server components.
@@ -64,7 +70,9 @@ public record GameContext(
     HealingBaseResolver healingBaseResolver,
     AbilityCostResolver abilityCostResolver,
     AbilityTargetResolver abilityTargetResolver,
-    SocketCommandRegistry commandRegistry
+    SocketCommandRegistry commandRegistry,
+    PlayerEventBus playerEventBus,
+    MobRegistry mobRegistry
 ) {
 
     /**
@@ -102,6 +110,13 @@ public record GameContext(
 
         SocketCommandRegistry commandRegistry = SocketCommandRegistry.createDefault();
 
+        PlayerEventBus playerEventBus = new PlayerEventBus();
+        MobRegistry mobRegistry = createMobRegistry(playerEventBus, roomService, playerRepository);
+        if (mobRegistry != null) {
+            mobRegistry.init();
+            tickRegistry.register(mobRegistry);
+        }
+
         return new GameContext(
             userRegistry,
             authenticationPolicy,
@@ -122,8 +137,27 @@ public record GameContext(
             healingBaseResolver,
             abilityCostResolver,
             abilityTargetResolver,
-            commandRegistry
+            commandRegistry,
+            playerEventBus,
+            mobRegistry
         );
+    }
+
+    private static MobRegistry createMobRegistry(
+        PlayerEventBus playerEventBus,
+        RoomService roomService,
+        PlayerRepository playerRepository
+    ) {
+        try {
+            JsonMobTemplateRepository templateRepo = new JsonMobTemplateRepository();
+            ItemRepository itemRepo = new JsonItemRepository();
+            JsonAttackRepository attackRepo = new JsonAttackRepository();
+            return new MobRegistry(templateRepo, itemRepo, attackRepo, roomService, playerRepository, playerEventBus);
+        } catch (MobRepositoryException
+            | io.taanielo.jmud.core.world.repository.RepositoryException
+            | AttackRepositoryException e) {
+            throw new IllegalStateException("Failed to initialize mob registry: " + e.getMessage(), e);
+        }
     }
 
     private static AbilityRegistry loadAbilities() {

--- a/src/main/java/io/taanielo/jmud/core/server/socket/KillCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/KillCommand.java
@@ -1,0 +1,28 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles kill commands targeting mobs in the same room.
+ */
+public class KillCommand extends RegistrableCommand {
+    public KillCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "kill";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        String token = parts[0];
+        if (!"KILL".equals(token) && !"K".equals(token)) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> context.killMob(args)));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -47,6 +47,7 @@ import io.taanielo.jmud.core.world.RoomService;
 public class SocketClient implements Client {
 
     private final ClientConnection connection;
+    private final GameContext context;
     private final PlayerSession session;
     private final GameActionService gameActionService;
     private final AuthenticationService authenticationService;
@@ -77,6 +78,7 @@ public class SocketClient implements Client {
         TransportSecurity transportSecurity
     ) {
         Objects.requireNonNull(context, "Game context is required");
+        this.context = context;
         this.connection = Objects.requireNonNull(connection, "Connection is required");
         this.authenticationService = Objects.requireNonNull(authenticationService, "Authentication service is required");
         this.playerRepository = context.playerRepository();
@@ -205,6 +207,9 @@ public class SocketClient implements Client {
                 metadata
             );
         }
+        if (context.playerEventBus() != null && session.getPlayer() != null) {
+            context.playerEventBus().unregister(session.getPlayer().getUsername());
+        }
         session.close();
         connection.close();
         clientPool.remove(this);
@@ -249,6 +254,13 @@ public class SocketClient implements Client {
             roomService.clearPlayerLocation(player.getUsername());
         } else {
             roomService.ensurePlayerLocation(player.getUsername());
+        }
+        if (context.playerEventBus() != null) {
+            context.playerEventBus().register(player.getUsername(),
+                result -> session.enqueueCommand(() -> {
+                    deliverResult(result);
+                    sendPrompt();
+                }));
         }
         session.registerEffects(new EffectMessageSink() {
             @Override
@@ -614,6 +626,15 @@ public class SocketClient implements Client {
             }
             RoomService.LookResult result = roomService.look(session.getPlayer().getUsername());
             connection.writeLines(result.lines());
+            if (context.mobRegistry() != null && result.room() != null) {
+                var mobs = context.mobRegistry().getMobsInRoom(result.room().getId());
+                if (!mobs.isEmpty()) {
+                    String mobLine = "Mobs: " + mobs.stream()
+                        .map(m -> m.template().name() + " (" + m.currentHp() + " HP)")
+                        .collect(java.util.stream.Collectors.joining(", "));
+                    connection.writeLine(mobLine);
+                }
+            }
             sendPrompt();
         }
 
@@ -806,6 +827,28 @@ public class SocketClient implements Client {
                 return;
             }
             GameActionResult result = gameActionService.unequipSlot(session.getPlayer(), args);
+            deliverResult(result);
+            sendPrompt();
+        }
+
+        @Override
+        public void killMob(String args) {
+            if (!session.isAuthenticated() || session.getPlayer() == null) {
+                writeLineWithPrompt("You must be logged in to attack.");
+                return;
+            }
+            if (context.mobRegistry() == null) {
+                writeLineWithPrompt("There are no mobs here.");
+                return;
+            }
+            Player player = session.getPlayer();
+            var roomIdOpt = roomService.findPlayerLocation(player.getUsername());
+            if (roomIdOpt.isEmpty()) {
+                writeLineWithPrompt("You are nowhere.");
+                return;
+            }
+            GameActionResult result = context.mobRegistry()
+                .processPlayerAttack(player, args, roomIdOpt.get());
             deliverResult(result);
             sendPrompt();
         }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -117,4 +117,9 @@ public interface SocketCommandContext extends Client {
      */
     void unequipItem(String args);
 
+    /**
+     * Executes a kill command targeting a mob in the same room.
+     */
+    void killMob(String args);
+
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -25,6 +25,7 @@ public class SocketCommandRegistry {
         new SayCommand(registry);
         new AbilityCommand(registry);
         new AttackCommand(registry);
+        new KillCommand(registry);
         new AnsiCommand(registry);
         new QuitCommand(registry);
         return registry;

--- a/src/main/java/io/taanielo/jmud/core/world/Item.java
+++ b/src/main/java/io/taanielo/jmud/core/world/Item.java
@@ -8,6 +8,7 @@ import lombok.Value;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.taanielo.jmud.core.combat.AttackId;
 import io.taanielo.jmud.core.messaging.MessageSpec;
 
 @Value
@@ -21,6 +22,7 @@ public class Item {
     EquipmentSlot equipSlot;
     int weight;
     int value;
+    AttackId attackRef;
 
     @JsonCreator
     public Item(
@@ -32,7 +34,8 @@ public class Item {
         @JsonProperty("messages") List<MessageSpec> messages,
         @JsonProperty("equipSlot") EquipmentSlot equipSlot,
         @JsonProperty("weight") int weight,
-        @JsonProperty("value") int value
+        @JsonProperty("value") int value,
+        @JsonProperty("attackRef") AttackId attackRef
     ) {
         this.id = Objects.requireNonNull(id, "Item id is required");
         if (name == null || name.isBlank()) {
@@ -52,5 +55,6 @@ public class Item {
             throw new IllegalArgumentException("Item value must be non-negative");
         }
         this.value = value;
+        this.attackRef = attackRef;
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/RoomService.java
+++ b/src/main/java/io/taanielo/jmud/core/world/RoomService.java
@@ -46,6 +46,17 @@ public class RoomService {
     }
 
     /**
+     * Returns all player usernames currently in the given room.
+     */
+    public List<Username> getPlayersInRoom(RoomId roomId) {
+        Objects.requireNonNull(roomId, "Room id is required");
+        return playerLocations.entrySet().stream()
+            .filter(e -> e.getValue().equals(roomId))
+            .map(java.util.Map.Entry::getKey)
+            .toList();
+    }
+
+    /**
      * Ensures a player has a location, defaulting to the starting room if missing.
      */
     public RoomId ensurePlayerLocation(Username username) {
@@ -316,7 +327,8 @@ public class RoomService {
             List.of(),
             null,
             0,
-            0
+            0,
+            null
         );
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/dto/ItemDto.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/ItemDto.java
@@ -14,6 +14,7 @@ public record ItemDto(
     List<MessageSpecDto> messages,
     String equipSlot,
     int weight,
-    int value
+    int value,
+    String attackRef
 ) {
 }

--- a/src/main/java/io/taanielo/jmud/core/world/dto/ItemMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/ItemMapper.java
@@ -3,6 +3,7 @@ package io.taanielo.jmud.core.world.dto;
 import java.util.List;
 import java.util.Objects;
 
+import io.taanielo.jmud.core.combat.AttackId;
 import io.taanielo.jmud.core.effects.EffectId;
 import io.taanielo.jmud.core.messaging.MessageSpec;
 import io.taanielo.jmud.core.messaging.MessageSpecMapper;
@@ -30,7 +31,8 @@ public class ItemMapper {
             MessageSpecMapper.toDtos(item.getMessages()),
             item.getEquipSlot() == null ? null : item.getEquipSlot().id(),
             item.getWeight(),
-            item.getValue()
+            item.getValue(),
+            item.getAttackRef() == null ? null : item.getAttackRef().getValue()
         );
     }
 
@@ -43,6 +45,7 @@ public class ItemMapper {
             .toList();
         List<MessageSpec> messages = MessageSpecMapper.fromDtos(dto.messages());
         EquipmentSlot slot = EquipmentSlot.fromId(dto.equipSlot());
+        AttackId attackRef = dto.attackRef() != null ? AttackId.of(dto.attackRef()) : null;
         return new Item(
             ItemId.of(dto.id()),
             dto.name(),
@@ -52,7 +55,8 @@ public class ItemMapper {
             messages,
             slot,
             dto.weight(),
-            dto.value()
+            dto.value(),
+            attackRef
         );
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/repository/InMemoryRoomRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/world/repository/InMemoryRoomRepository.java
@@ -38,7 +38,8 @@ public class InMemoryRoomRepository implements RoomRepository {
                 List.of(),
                 EquipmentSlot.WEAPON,
                 5,
-                25
+                25,
+                null
             ), new Item(
                 ItemId.of("poisonous-potion"),
                 "Poisonous Potion",
@@ -48,7 +49,8 @@ public class InMemoryRoomRepository implements RoomRepository {
                 List.of(),
                 null,
                 1,
-                5
+                5,
+                null
             )),
             List.of()
         );
@@ -67,7 +69,8 @@ public class InMemoryRoomRepository implements RoomRepository {
                 List.of(),
                 EquipmentSlot.OFFHAND,
                 6,
-                15
+                15,
+                null
             )),
             List.of()
         );

--- a/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
@@ -208,7 +208,8 @@ class GameActionServiceTest {
             List.of(),
             null,
             1,
-            5
+            5,
+            null
         );
         roomService.dropItem(attacker.getUsername(), torch);
 
@@ -246,7 +247,8 @@ class GameActionServiceTest {
             List.of(),
             null,
             1,
-            5
+            5,
+            null
         );
         Player withItem = attacker.addItem(torch);
 
@@ -307,7 +309,8 @@ class GameActionServiceTest {
             ),
             null,
             1,
-            1
+            1,
+            null
         );
         Player withItem = attacker.addItem(potion);
 
@@ -343,7 +346,8 @@ class GameActionServiceTest {
             List.of(),
             null,
             1,
-            1
+            1,
+            null
         );
         Player withItem = attacker.addItem(rock);
 

--- a/src/test/java/io/taanielo/jmud/core/player/PlayerRespawnTickerTest.java
+++ b/src/test/java/io/taanielo/jmud/core/player/PlayerRespawnTickerTest.java
@@ -53,7 +53,8 @@ class PlayerRespawnTickerTest {
                 List.of(),
                 null,
                 1,
-                0
+                0,
+                null
             )),
             List.of()
         );

--- a/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherAuditTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherAuditTest.java
@@ -185,6 +185,10 @@ class SocketCommandDispatcherAuditTest {
         }
 
         @Override
+        public void killMob(String args) {
+        }
+
+        @Override
         public void sendMessage(io.taanielo.jmud.core.messaging.Message message) {
         }
 

--- a/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
@@ -199,6 +199,10 @@ class SocketCommandDispatcherTest {
         }
 
         @Override
+        public void killMob(String args) {
+        }
+
+        @Override
         public void sendMessage(io.taanielo.jmud.core.messaging.Message message) {
         }
 

--- a/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
@@ -79,7 +79,8 @@ class RoomServiceTest {
             List.of(),
             null,
             1,
-            5
+            5,
+            null
         );
         Room roomA = new Room(
             roomAId,
@@ -139,7 +140,8 @@ class RoomServiceTest {
             List.of(),
             null,
             1,
-            5
+            5,
+            null
         );
         Room roomA = new Room(
             roomAId,
@@ -185,7 +187,8 @@ class RoomServiceTest {
             List.of(),
             null,
             1,
-            1
+            1,
+            null
         );
         service.dropItem(bob, apple);
 

--- a/src/test/java/io/taanielo/jmud/core/world/repository/json/JsonItemRepositoryTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/repository/json/JsonItemRepositoryTest.java
@@ -36,7 +36,8 @@ class JsonItemRepositoryTest {
             List.of(),
             null,
             2,
-            3
+            3,
+            null
         );
         repository.save(item);
 

--- a/src/test/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepositoryTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepositoryTest.java
@@ -40,7 +40,8 @@ class JsonRoomRepositoryTest {
             List.of(),
             null,
             3,
-            12
+            12,
+            null
         );
         Item potion = new Item(
             ItemId.of("minor-potion"),
@@ -51,7 +52,8 @@ class JsonRoomRepositoryTest {
             List.of(),
             null,
             1,
-            8
+            8,
+            null
         );
         itemRepository.save(sword);
         itemRepository.save(potion);


### PR DESCRIPTION
## Summary

Closes #83. Implements both phases of the feature: equipping a weapon now changes your attack, and the world is populated with mobs that fight back.

## Changes

**Phase 1 — Weapon-based combat**
- `Item` gains an optional `attackRef` field linking to an `AttackDefinition`
- `GameActionService.attack()` resolves the equipped weapon's attack definition before falling back to unarmed
- `data/attacks/attack.iron-sword.json` (3–8 dmg, better accuracy) created and linked from `iron-sword.json`

**Phase 2 — NPC/Monster system**
- New `core/mob` package: `MobTemplate` (static data from JSON), `MobInstance` (live state with `AtomicInteger` HP), `MobRegistry` (`Tickable`)
- `MobRegistry.tick()` drives mob AI: each tick, live mobs attack a random player in their room; dead mobs count down and respawn
- Loot drops on mob death via `RoomService.addItem()`
- `PlayerEventBus` (new in `core/action`) decouples mob damage delivery from transport — `MobRegistry` publishes `GameActionResult`s; `SocketClient` registers a handler on login that enqueues delivery onto the player's existing command queue. No game logic in `SocketClient`.
- `KILL <mob>` / `K <mob>` command added
- `LOOK` now appends a "Mobs:" line listing live mobs with current HP
- Starter data: `goblin` (2 spawns, attacks, drops health potion at 50%) and `training-dummy` (safe practice target, no attacks)

## Architecture note

Mob AI and player command processing both run on the tick thread (via `TickRegistry`), so mob state mutations are naturally serialized. `MobInstance` HP uses `AtomicInteger` for safe visibility when player-thread attack commands race with tick-thread AI reads.

Closes #83