### PR TITLE
feat(combat): training area, mob retaliation, and auto-combat loop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(26)
     }
 }
 

--- a/data/attacks/attack.kobold.json
+++ b/data/attacks/attack.kobold.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "attack.kobold",
+  "name": "kobold scratch",
+  "min_damage": 2,
+  "max_damage": 5,
+  "hit_bonus": 0,
+  "crit_bonus": 0,
+  "damage_bonus": 0,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The kobold scratches you for {damage}."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The kobold swipes at you but misses."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The kobold rakes its claws across you for {damage}!"
+    }
+  ]
+}

--- a/data/attacks/attack.rat.json
+++ b/data/attacks/attack.rat.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "attack.rat",
+  "name": "rat bite",
+  "min_damage": 1,
+  "max_damage": 3,
+  "hit_bonus": 0,
+  "crit_bonus": 0,
+  "damage_bonus": 0,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The giant rat bites you for {damage}."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The giant rat snaps at you but misses."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The giant rat sinks its teeth deep into you for {damage}!"
+    }
+  ]
+}

--- a/data/attacks/attack.spider.json
+++ b/data/attacks/attack.spider.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "attack.spider",
+  "name": "spider fangs",
+  "min_damage": 2,
+  "max_damage": 6,
+  "hit_bonus": -5,
+  "crit_bonus": 5,
+  "damage_bonus": 0,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The giant spider sinks its fangs into you for {damage}."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The giant spider lunges at you but misses."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The giant spider drives its fangs deep into you for {damage}!"
+    }
+  ]
+}

--- a/data/mobs/giant-spider.json
+++ b/data/mobs/giant-spider.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "giant-spider",
+  "name": "Giant Spider",
+  "max_hp": 14,
+  "attack_id": "attack.spider",
+  "aggressive": false,
+  "spawn_room_id": "dark-burrow",
+  "max_count": 2,
+  "respawn_ticks": 20,
+  "loot": []
+}

--- a/data/mobs/goblin.json
+++ b/data/mobs/goblin.json
@@ -4,7 +4,8 @@
   "name": "Goblin",
   "max_hp": 15,
   "attack_id": "attack.goblin",
-  "spawn_room_id": "training-yard",
+  "aggressive": false,
+  "spawn_room_id": "sparring-pit",
   "max_count": 2,
   "respawn_ticks": 30,
   "loot": [

--- a/data/mobs/kobold.json
+++ b/data/mobs/kobold.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "kobold",
+  "name": "Kobold",
+  "max_hp": 12,
+  "attack_id": "attack.kobold",
+  "aggressive": false,
+  "spawn_room_id": "rocky-alcove",
+  "max_count": 2,
+  "respawn_ticks": 25,
+  "loot": [
+    {
+      "item_id": "health-potion",
+      "drop_chance": 0.3
+    }
+  ]
+}

--- a/data/mobs/rat.json
+++ b/data/mobs/rat.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "rat",
+  "name": "Giant Rat",
+  "max_hp": 8,
+  "attack_id": "attack.rat",
+  "aggressive": false,
+  "spawn_room_id": "muddy-hollow",
+  "max_count": 3,
+  "respawn_ticks": 15,
+  "loot": []
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/MobInstance.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobInstance.java
@@ -1,8 +1,12 @@
 package io.taanielo.jmud.core.mob;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.taanielo.jmud.core.authentication.Username;
 import io.taanielo.jmud.core.world.RoomId;
 
 /**
@@ -18,6 +22,7 @@ public class MobInstance {
     private final MobTemplate template;
     private final AtomicInteger hp;
     private final AtomicInteger respawnTicksRemaining = new AtomicInteger(0);
+    private final Set<Username> engagedPlayers = ConcurrentHashMap.newKeySet();
 
     public MobInstance(MobTemplate template) {
         this.template = template;
@@ -63,9 +68,22 @@ public class MobInstance {
         return respawnTicksRemaining.decrementAndGet() <= 0;
     }
 
+    public void engage(Username player) {
+        engagedPlayers.add(player);
+    }
+
+    public void disengage(Username player) {
+        engagedPlayers.remove(player);
+    }
+
+    public Set<Username> engagedPlayers() {
+        return Collections.unmodifiableSet(engagedPlayers);
+    }
+
     /** Resets the mob to full HP, ready to act again. */
     public void respawn() {
         hp.set(template.maxHp());
         respawnTicksRemaining.set(0);
+        engagedPlayers.clear();
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
@@ -48,6 +49,7 @@ public class MobRegistry implements Tickable {
     private final PlayerEventBus playerEventBus;
 
     private final ConcurrentHashMap<UUID, MobInstance> instances = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Username, UUID> playerCombatTargets = new ConcurrentHashMap<>();
 
     public MobRegistry(
         MobTemplateRepository templateRepository,
@@ -87,6 +89,7 @@ public class MobRegistry implements Tickable {
 
     @Override
     public void tick() {
+        runPlayerCombat();
         for (MobInstance mob : instances.values()) {
             if (!mob.isAlive()) {
                 if (mob.tickRespawn()) {
@@ -96,6 +99,9 @@ public class MobRegistry implements Tickable {
                 continue;
             }
             if (mob.template().attackId() == null) {
+                continue;
+            }
+            if (!mob.template().aggressive() && mob.engagedPlayers().isEmpty()) {
                 continue;
             }
             runMobAi(mob);
@@ -136,6 +142,9 @@ public class MobRegistry implements Tickable {
         int damage = rollDamage(attack);
         int remaining = mob.takeDamage(damage);
 
+        mob.engage(attacker.getUsername());
+        playerCombatTargets.put(attacker.getUsername(), mob.instanceId());
+
         List<GameMessage> messages = new ArrayList<>();
         messages.add(GameMessage.toSource(
             "You strike the " + mob.template().name() + " for " + damage + " damage. ("
@@ -145,6 +154,7 @@ public class MobRegistry implements Tickable {
             messages.add(GameMessage.toSource("You slay the " + mob.template().name() + "!"));
             dropLoot(mob);
             mob.scheduleRespawn();
+            endCombatForMob(mob);
         }
         return new GameActionResult(null, null, messages);
     }
@@ -152,11 +162,18 @@ public class MobRegistry implements Tickable {
     // ── Mob AI ────────────────────────────────────────────────────────
 
     private void runMobAi(MobInstance mob) {
-        List<Username> players = roomService.getPlayersInRoom(mob.roomId());
-        if (players.isEmpty()) {
+        List<Username> candidates;
+        Set<Username> engaged = mob.engagedPlayers();
+        if (!engaged.isEmpty()) {
+            List<Username> inRoom = roomService.getPlayersInRoom(mob.roomId());
+            candidates = engaged.stream().filter(inRoom::contains).toList();
+        } else {
+            candidates = roomService.getPlayersInRoom(mob.roomId());
+        }
+        if (candidates.isEmpty()) {
             return;
         }
-        Username targetUsername = players.get(ThreadLocalRandom.current().nextInt(players.size()));
+        Username targetUsername = candidates.get(ThreadLocalRandom.current().nextInt(candidates.size()));
         Player target = playerRepository.loadPlayer(targetUsername).orElse(null);
         if (target == null || target.isDead()) {
             return;
@@ -169,7 +186,7 @@ public class MobRegistry implements Tickable {
         Player damagedPlayer = target.withVitals(target.getVitals().damage(damage));
 
         if (damagedPlayer.getVitals().hp() <= 0) {
-            handleMobKill(mob, damagedPlayer, players);
+            handleMobKill(mob, damagedPlayer, candidates);
         } else {
             playerRepository.savePlayer(damagedPlayer);
             String hitMsg = "The " + mob.template().name() + " hits you for " + damage + " damage!";
@@ -183,6 +200,8 @@ public class MobRegistry implements Tickable {
         roomService.spawnCorpse(deadPlayer.getUsername(), mob.roomId());
         roomService.clearPlayerLocation(deadPlayer.getUsername());
         playerRepository.savePlayer(deadPlayer);
+        mob.disengage(deadPlayer.getUsername());
+        playerCombatTargets.remove(deadPlayer.getUsername());
 
         String slainMsg = "The " + mob.template().name() + " has slain you!";
         playerEventBus.publish(deadPlayer.getUsername(),
@@ -195,6 +214,61 @@ public class MobRegistry implements Tickable {
                 playerEventBus.publish(occupant,
                     new GameActionResult(null, null, List.of(GameMessage.toSource(roomMsg))));
             }
+        }
+    }
+
+    private void runPlayerCombat() {
+        for (var entry : playerCombatTargets.entrySet()) {
+            Username username = entry.getKey();
+            UUID mobId = entry.getValue();
+
+            MobInstance mob = instances.get(mobId);
+            if (mob == null || !mob.isAlive()) {
+                playerCombatTargets.remove(username);
+                if (mob != null) mob.disengage(username);
+                continue;
+            }
+
+            Player player = playerRepository.loadPlayer(username).orElse(null);
+            if (player == null || player.isDead()) {
+                playerCombatTargets.remove(username);
+                mob.disengage(username);
+                continue;
+            }
+
+            RoomId playerRoom = roomService.findPlayerLocation(username).orElse(null);
+            if (playerRoom == null || !playerRoom.equals(mob.roomId())) {
+                playerCombatTargets.remove(username);
+                mob.disengage(username);
+                continue;
+            }
+
+            AttackId attackId = resolveAttackId(player);
+            AttackDefinition attack = loadAttack(attackId);
+            if (attack == null) {
+                continue;
+            }
+            int damage = rollDamage(attack);
+            int remaining = mob.takeDamage(damage);
+
+            List<GameMessage> messages = new ArrayList<>();
+            messages.add(GameMessage.toSource(
+                "You strike the " + mob.template().name() + " for " + damage + " damage. ("
+                    + remaining + " HP remaining)"));
+
+            if (!mob.isAlive()) {
+                messages.add(GameMessage.toSource("You slay the " + mob.template().name() + "!"));
+                dropLoot(mob);
+                mob.scheduleRespawn();
+                endCombatForMob(mob);
+            }
+            playerEventBus.publish(username, new GameActionResult(null, null, messages));
+        }
+    }
+
+    private void endCombatForMob(MobInstance mob) {
+        for (Username engaged : mob.engagedPlayers()) {
+            playerCombatTargets.remove(engaged);
         }
     }
 

--- a/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
@@ -14,6 +14,7 @@ public record MobTemplate(
     String name,
     int maxHp,
     AttackId attackId,
+    boolean aggressive,
     List<LootEntry> lootTable,
     RoomId spawnRoomId,
     int maxCount,

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
@@ -8,6 +8,7 @@ public record MobTemplateDto(
     String name,
     int maxHp,
     String attackId,
+    Boolean aggressive,
     List<LootEntryDto> loot,
     String spawnRoomId,
     int maxCount,

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
@@ -18,11 +18,13 @@ public class MobTemplateDtoMapper {
         List<LootEntry> loot = dto.loot() == null ? List.of() : dto.loot().stream()
             .map(e -> new LootEntry(ItemId.of(e.itemId()), e.dropChance()))
             .toList();
+        boolean aggressive = dto.aggressive() == null || dto.aggressive();
         return new MobTemplate(
             MobId.of(dto.id()),
             dto.name(),
             dto.maxHp(),
             attackId,
+            aggressive,
             loot,
             RoomId.of(dto.spawnRoomId()),
             dto.maxCount(),

--- a/src/main/java/io/taanielo/jmud/core/world/repository/InMemoryRoomRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/world/repository/InMemoryRoomRepository.java
@@ -23,12 +23,16 @@ public class InMemoryRoomRepository implements RoomRepository {
         RoomId trainingYardId = RoomId.of("training-yard");
         RoomId armoryId = RoomId.of("armory");
         RoomId courtyardId = RoomId.of("courtyard");
+        RoomId sparringPitId = RoomId.of("sparring-pit");
+        RoomId muddyHollowId = RoomId.of("muddy-hollow");
+        RoomId rockyAlcoveId = RoomId.of("rocky-alcove");
+        RoomId darkBurrowId = RoomId.of("dark-burrow");
 
         Room trainingYard = new Room(
             trainingYardId,
             "Training Yard",
             "A dusty yard with practice dummies and scattered weapons.",
-            Map.of(Direction.NORTH, armoryId, Direction.EAST, courtyardId),
+            Map.of(Direction.NORTH, armoryId, Direction.EAST, courtyardId, Direction.SOUTH, sparringPitId),
             List.of(new Item(
                 ItemId.of("iron-sword"),
                 "Iron Sword",
@@ -84,10 +88,50 @@ public class InMemoryRoomRepository implements RoomRepository {
             List.of()
         );
 
+        Room sparringPit = new Room(
+            sparringPitId,
+            "Sparring Pit",
+            "A sunken dirt pit ringed by wooden stakes. A few goblins pace here, eyeing you warily but holding their ground.",
+            Map.of(Direction.NORTH, trainingYardId, Direction.EAST, muddyHollowId, Direction.SOUTH, rockyAlcoveId),
+            List.of(),
+            List.of()
+        );
+
+        Room muddyHollow = new Room(
+            muddyHollowId,
+            "Muddy Hollow",
+            "A waterlogged depression thick with roots and mud. Giant rats skitter through the muck.",
+            Map.of(Direction.WEST, sparringPitId, Direction.SOUTH, darkBurrowId),
+            List.of(),
+            List.of()
+        );
+
+        Room rockyAlcove = new Room(
+            rockyAlcoveId,
+            "Rocky Alcove",
+            "A jagged nook cut into the hillside. Scrawny kobolds crouch among the stones, watching you with beady eyes.",
+            Map.of(Direction.NORTH, sparringPitId, Direction.EAST, darkBurrowId),
+            List.of(),
+            List.of()
+        );
+
+        Room darkBurrow = new Room(
+            darkBurrowId,
+            "Dark Burrow",
+            "A low earthen tunnel that opens into a dim chamber. Thick webs cling to every corner and giant spiders hang motionless overhead.",
+            Map.of(Direction.NORTH, muddyHollowId, Direction.WEST, rockyAlcoveId),
+            List.of(),
+            List.of()
+        );
+
         this.rooms = new ConcurrentHashMap<>();
         this.rooms.put(trainingYardId, trainingYard);
         this.rooms.put(armoryId, armory);
         this.rooms.put(courtyardId, courtyard);
+        this.rooms.put(sparringPitId, sparringPit);
+        this.rooms.put(muddyHollowId, muddyHollow);
+        this.rooms.put(rockyAlcoveId, rockyAlcove);
+        this.rooms.put(darkBurrowId, darkBurrow);
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Adds a 4-room explorable training area reachable south of the Training Yard: **Sparring Pit → Muddy Hollow / Rocky Alcove → Dark Burrow**, forming a loopable 2×2 grid
- Introduces 3 new mob types (Giant Rat, Kobold, Giant Spider) with matching attack definitions; all training-area mobs are non-aggressive by default
- Adds `aggressive` flag to `MobTemplate` (defaults `true` when omitted, backward-compatible) so mobs can hold their ground until provoked
- **Mob retaliation**: any mob that takes damage from a player engages them and fights back each tick regardless of `aggressive` flag
- **Auto-combat loop**: once a player types `kill <mob>`, the player auto-attacks that mob every tick; combat ends automatically when the mob dies, the player dies, or the player leaves the room
- Bumps Java toolchain to 26

## Test plan

- [ ] `gradle test` passes
- [ ] Walk south from Training Yard → Sparring Pit; goblins are present but do not attack unprovoked
- [ ] Type `kill goblin` — first hit lands immediately; subsequent ticks show auto-attack and goblin retaliation messages without further input
- [ ] Goblin dies → slay message appears, no further auto-attack messages
- [ ] Start combat, then walk north — auto-combat stops
- [ ] Explore Muddy Hollow (east), Rocky Alcove (south), Dark Burrow (southeast corner); each room has its own mob type

🤖 Generated with [Claude Code](https://claude.com/claude-code)