### PR TITLE
feat(server): add who command to list online players

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -570,6 +570,18 @@ public class SocketClient implements Client {
             && session.getPlayer().getUsername().equals(username);
     }
 
+    /**
+     * Returns the authenticated player's username for this client, or empty when
+     * the client is still at the login stage. Used to build the online roster.
+     */
+    private Optional<Username> authenticatedUsername() {
+        if (!session.isAuthenticated()) {
+            return Optional.empty();
+        }
+        Player player = session.getPlayer();
+        return player == null ? Optional.empty() : Optional.of(player.getUsername());
+    }
+
     private void applyExternalPlayerUpdate(Player updated) {
         if (!isAuthenticatedUser(updated.getUsername())) {
             return;
@@ -600,6 +612,16 @@ public class SocketClient implements Client {
         @Override
         public List<Client> clients() {
             return clientPool.clients();
+        }
+
+        @Override
+        public List<Username> onlinePlayerNames() {
+            return clientPool.clients().stream()
+                .filter(SocketClient.class::isInstance)
+                .map(SocketClient.class::cast)
+                .map(SocketClient::authenticatedUsername)
+                .flatMap(Optional::stream)
+                .toList();
         }
 
         @Override

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -28,6 +28,15 @@ public interface SocketCommandContext extends Client {
     List<io.taanielo.jmud.core.server.Client> clients();
 
     /**
+     * Returns the usernames of all connected, authenticated players.
+     *
+     * <p>Clients that are connected but not yet authenticated (still at login)
+     * are excluded. The result is a read-only snapshot intended for the
+     * {@code who} command.
+     */
+    List<Username> onlinePlayerNames();
+
+    /**
      * Sends a look response for the current player.
      */
     void sendLook();

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -23,6 +23,7 @@ public class SocketCommandRegistry {
         new EquipCommand(registry);
         new UnequipCommand(registry);
         new SayCommand(registry);
+        new WhoCommand(registry);
         new AbilityCommand(registry);
         new AttackCommand(registry);
         new KillCommand(registry);

--- a/src/main/java/io/taanielo/jmud/core/server/socket/WhoCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/WhoCommand.java
@@ -1,0 +1,46 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.taanielo.jmud.core.authentication.Username;
+
+/**
+ * Handles the {@code who} command, listing all connected and authenticated
+ * players together with a total online count.
+ *
+ * <p>The command is read-only: it inspects live session state via the context
+ * and never reads or writes persisted data. Formatting is delegated to
+ * {@link WhoListing} so the listing logic stays testable without networking.
+ */
+public class WhoCommand extends RegistrableCommand {
+    public WhoCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "who";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String token = SocketCommandParsing.firstToken(input);
+        if (!"WHO".equals(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(new SocketCommandMatch(this, WhoCommand::handleWho));
+    }
+
+    private static void handleWho(SocketCommandContext context) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to see who is online.");
+            return;
+        }
+        List<Username> onlineNames = context.onlinePlayerNames();
+        for (String line : WhoListing.format(onlineNames)) {
+            context.writeLineSafe(line);
+        }
+        context.sendPrompt();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/WhoListing.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/WhoListing.java
@@ -1,0 +1,55 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.taanielo.jmud.core.authentication.Username;
+
+/**
+ * Pure, network-free helper that formats the roster of online players for the
+ * {@code who} command.
+ *
+ * <p>Kept free of any I/O so the listing, count, and ordering logic can be unit
+ * tested in isolation. The same rendered output is reused by every transport
+ * (telnet and SSH) since both are driven by {@code SocketClient}.
+ */
+public final class WhoListing {
+
+    private static final String HEADER = "Players online:";
+
+    private WhoListing() {
+    }
+
+    /**
+     * Formats the given online player names into display lines.
+     *
+     * <p>The output always starts with a header, lists each player name indented
+     * on its own line, and ends with a footer carrying the total count. The input
+     * order is preserved.
+     *
+     * @param onlineNames the authenticated, connected player names to list
+     * @return the lines to render, never empty
+     */
+    public static List<String> format(List<Username> onlineNames) {
+        Objects.requireNonNull(onlineNames, "Online names are required");
+        List<String> lines = new ArrayList<>(onlineNames.size() + 2);
+        lines.add(HEADER);
+        for (Username name : onlineNames) {
+            lines.add("  " + Objects.requireNonNull(name, "Online name is required").getValue());
+        }
+        lines.add(footer(onlineNames.size()));
+        return List.copyOf(lines);
+    }
+
+    /**
+     * Builds the count footer line, pluralising "player" as appropriate.
+     *
+     * @param count the number of online players
+     * @return the footer line, e.g. {@code "3 players online."}
+     */
+    static String footer(int count) {
+        String noun = count == 1 ? "player" : "players";
+        return count + " " + noun + " online.";
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherAuditTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherAuditTest.java
@@ -112,6 +112,11 @@ class SocketCommandDispatcherAuditTest {
         }
 
         @Override
+        public List<Username> onlinePlayerNames() {
+            return List.of();
+        }
+
+        @Override
         public void sendLook() {
         }
 

--- a/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
@@ -125,6 +125,11 @@ class SocketCommandDispatcherTest {
         }
 
         @Override
+        public List<Username> onlinePlayerNames() {
+            return List.of();
+        }
+
+        @Override
         public void sendLook() {
         }
 

--- a/src/test/java/io/taanielo/jmud/core/server/socket/WhoListingTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/WhoListingTest.java
@@ -1,0 +1,68 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Username;
+
+class WhoListingTest {
+
+    @Test
+    void listsMultiplePlayersWithHeaderAndCount() {
+        List<String> lines = WhoListing.format(List.of(
+            Username.of("Aragorn"),
+            Username.of("Gandalf"),
+            Username.of("Legolas")
+        ));
+
+        assertEquals(List.of(
+            "Players online:",
+            "  Aragorn",
+            "  Gandalf",
+            "  Legolas",
+            "3 players online."
+        ), lines);
+    }
+
+    @Test
+    void preservesInputOrder() {
+        List<String> lines = WhoListing.format(List.of(
+            Username.of("Zoe"),
+            Username.of("Alice")
+        ));
+
+        assertEquals("  Zoe", lines.get(1));
+        assertEquals("  Alice", lines.get(2));
+    }
+
+    @Test
+    void singlePlayerUsesSingularNoun() {
+        List<String> lines = WhoListing.format(List.of(Username.of("Solo")));
+
+        assertEquals(List.of(
+            "Players online:",
+            "  Solo",
+            "1 player online."
+        ), lines);
+    }
+
+    @Test
+    void noPlayersStillRendersHeaderAndZeroCount() {
+        List<String> lines = WhoListing.format(List.of());
+
+        assertEquals(List.of(
+            "Players online:",
+            "0 players online."
+        ), lines);
+    }
+
+    @Test
+    void footerPluralisesByCount() {
+        assertEquals("0 players online.", WhoListing.footer(0));
+        assertEquals("1 player online.", WhoListing.footer(1));
+        assertEquals("5 players online.", WhoListing.footer(5));
+    }
+}


### PR DESCRIPTION
Closes #87

Adds a `who` command that lists all connected, authenticated players with a total count.

- New `WhoCommand` (Interface/Adapters layer) registered in `SocketCommandRegistry.createDefault()`.
- Pure, network-free `WhoListing` formatter — unit-tested in isolation (5 tests).
- `SocketCommandContext.onlinePlayerNames()` resolves authenticated-only players inside `SocketClient`, keeping session internals out of the command (respects layering).
- Shared by telnet + SSH (both driven by `SocketClient`).
- Read-only: no JSON schema or save-data changes (save-game safe).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>