### PR TITLE
feat(io): wire JSON file I/O for rooms and user registry

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -8,5 +8,6 @@ Layout:
 - attacks/ (attack definitions)
 - races/ (race definitions)
 - classes/ (class definitions)
+- users/ (authentication credentials, one JSON file per user — separate from players/ character state)
 
 See docs/data-schema.md for schema details and examples.

--- a/data/rooms/training-yard.json
+++ b/data/rooms/training-yard.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "id": "training-yard",
   "name": "Training Yard",
   "description": "A dusty yard with practice dummies and scattered weapons.",
@@ -7,5 +7,10 @@
     "iron-sword",
     "health-potion",
     "poisonous-potion"
-  ]
+  ],
+  "exits": {
+    "north": "armory",
+    "east": "courtyard",
+    "south": "sparring-pit"
+  }
 }

--- a/src/main/java/io/taanielo/jmud/core/authentication/JsonUserRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/authentication/JsonUserRegistry.java
@@ -1,0 +1,147 @@
+package io.taanielo.jmud.core.authentication;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import io.taanielo.jmud.core.world.repository.json.JsonDataMapper;
+
+/**
+ * JSON-backed {@link UserRegistry} that persists each user as an individual
+ * file under {@code data/users/}.
+ *
+ * <p>Writes are atomic: the new content is first written to a sibling
+ * {@code .tmp} file and then renamed over the target file, ensuring that a
+ * concurrent reader never observes a partially-written state.
+ *
+ * <p>An in-memory {@link ConcurrentHashMap} cache is kept so that
+ * {@link #findByUsername} does not require a disk read after the first load.
+ */
+@Slf4j
+public class JsonUserRegistry implements UserRegistry {
+
+    private static final String USERS_DIR = "users";
+
+    private final ObjectMapper objectMapper;
+    private final Path usersDirPath;
+    private final Map<Username, User> cache;
+
+    /**
+     * Creates a registry that stores user files under {@code data/users/}
+     * relative to the current working directory.
+     *
+     * @throws UserRegistryException if the users directory cannot be created
+     */
+    public JsonUserRegistry() throws UserRegistryException {
+        this(Path.of("data"));
+    }
+
+    /**
+     * Creates a registry that stores user files under {@code <dataRoot>/users/}.
+     *
+     * @param dataRoot root of the data directory tree
+     * @throws UserRegistryException if the users directory cannot be created
+     */
+    public JsonUserRegistry(Path dataRoot) throws UserRegistryException {
+        this.objectMapper = JsonDataMapper.create();
+        this.cache = new ConcurrentHashMap<>();
+        this.usersDirPath = Objects.requireNonNull(dataRoot, "Data root is required").resolve(USERS_DIR);
+        ensureDirectory(usersDirPath);
+    }
+
+    /**
+     * Returns the user with the given username, loading from disk on first
+     * access and caching the result.
+     *
+     * @param username the username to look up
+     * @return an {@link Optional} containing the user, or empty if not found
+     */
+    @Override
+    public Optional<User> findByUsername(Username username) {
+        Objects.requireNonNull(username, "Username is required");
+        User cached = cache.get(username);
+        if (cached != null) {
+            return Optional.of(cached);
+        }
+        Path filePath = userFilePath(username);
+        if (!Files.exists(filePath)) {
+            return Optional.empty();
+        }
+        try {
+            User user = objectMapper.readValue(filePath.toFile(), User.class);
+            cache.put(user.getUsername(), user);
+            return Optional.of(user);
+        } catch (IOException e) {
+            log.error("Failed to load user {} from {}", username.getValue(), filePath, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Persists a new user to disk.  If a file for this username already exists
+     * it is left untouched (first-registered-wins semantics, matching the
+     * in-memory implementation).
+     *
+     * @param user the user to register
+     */
+    @Override
+    public void register(User user) {
+        Objects.requireNonNull(user, "User is required");
+        Path filePath = userFilePath(user.getUsername());
+        if (Files.exists(filePath)) {
+            // File already exists on disk — first registration wins; do not overwrite.
+            // Ensure cache reflects the on-disk user (loaded lazily on next findByUsername).
+            return;
+        }
+        if (cache.putIfAbsent(user.getUsername(), user) != null) {
+            // Already present in cache — do not overwrite.
+            return;
+        }
+        try {
+            writeUser(filePath, user);
+            log.info("User {} registered and saved to {}", user.getUsername().getValue(), filePath);
+        } catch (UserRegistryException e) {
+            log.error("Failed to persist user {}", user.getUsername().getValue(), e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private Path userFilePath(Username username) {
+        return usersDirPath.resolve(username.getValue().toLowerCase() + ".json");
+    }
+
+    private void writeUser(Path filePath, User user) throws UserRegistryException {
+        Path tempFile = filePath.getParent().resolve(filePath.getFileName() + ".tmp");
+        try {
+            objectMapper.writeValue(tempFile.toFile(), user);
+            Files.move(tempFile, filePath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            try {
+                Files.deleteIfExists(tempFile);
+            } catch (IOException ignored) {
+            }
+            throw new UserRegistryException(
+                "Failed to write user " + user.getUsername().getValue() + " to " + filePath + ": " + e.getMessage(), e
+            );
+        }
+    }
+
+    private void ensureDirectory(Path path) throws UserRegistryException {
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new UserRegistryException("Failed to create users directory " + path + ": " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/authentication/UserRegistryException.java
+++ b/src/main/java/io/taanielo/jmud/core/authentication/UserRegistryException.java
@@ -1,0 +1,16 @@
+package io.taanielo.jmud.core.authentication;
+
+/**
+ * Thrown when a {@link UserRegistry} operation fails due to an I/O or
+ * persistence error.
+ */
+public class UserRegistryException extends Exception {
+
+    public UserRegistryException(String message) {
+        super(message);
+    }
+
+    public UserRegistryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
@@ -13,8 +13,9 @@ import io.taanielo.jmud.core.action.PlayerEventBus;
 import io.taanielo.jmud.core.audit.AuditService;
 import io.taanielo.jmud.core.authentication.AuthenticationLimiter;
 import io.taanielo.jmud.core.authentication.AuthenticationPolicy;
+import io.taanielo.jmud.core.authentication.JsonUserRegistry;
 import io.taanielo.jmud.core.authentication.UserRegistry;
-import io.taanielo.jmud.core.authentication.UserRegistryImpl;
+import io.taanielo.jmud.core.authentication.UserRegistryException;
 import io.taanielo.jmud.core.config.GameConfig;
 import io.taanielo.jmud.core.character.repository.ClassRepositoryException;
 import io.taanielo.jmud.core.character.repository.RaceRepositoryException;
@@ -42,10 +43,11 @@ import io.taanielo.jmud.core.tick.TickClock;
 import io.taanielo.jmud.core.tick.TickRegistry;
 import io.taanielo.jmud.core.world.RoomId;
 import io.taanielo.jmud.core.world.RoomService;
-import io.taanielo.jmud.core.world.repository.InMemoryRoomRepository;
 import io.taanielo.jmud.core.world.repository.ItemRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
 import io.taanielo.jmud.core.world.repository.RoomRepository;
 import io.taanielo.jmud.core.world.repository.json.JsonItemRepository;
+import io.taanielo.jmud.core.world.repository.json.JsonRoomRepository;
 
 /**
  * Shared dependency container for socket server components.
@@ -80,11 +82,11 @@ public record GameContext(
      */
     public static GameContext create() {
         GameConfig config = GameConfig.load();
-        UserRegistry userRegistry = new UserRegistryImpl();
+        UserRegistry userRegistry = createUserRegistry();
         AuthenticationPolicy authenticationPolicy = AuthenticationPolicy.fromConfig(config);
         AuthenticationLimiter authenticationLimiter = new AuthenticationLimiter(authenticationPolicy, Clock.systemUTC());
         PlayerRepository playerRepository = new JsonPlayerRepository();
-        RoomRepository roomRepository = new InMemoryRoomRepository();
+        RoomRepository roomRepository = createRoomRepository();
         RoomService roomService = new RoomService(roomRepository, RoomId.of("training-yard"));
 
         TickRegistry tickRegistry = new TickRegistry();
@@ -141,6 +143,23 @@ public record GameContext(
             playerEventBus,
             mobRegistry
         );
+    }
+
+    private static UserRegistry createUserRegistry() {
+        try {
+            return new JsonUserRegistry();
+        } catch (UserRegistryException e) {
+            throw new IllegalStateException("Failed to initialize user registry: " + e.getMessage(), e);
+        }
+    }
+
+    private static RoomRepository createRoomRepository() {
+        try {
+            ItemRepository itemRepository = new JsonItemRepository();
+            return new JsonRoomRepository(itemRepository);
+        } catch (RepositoryException e) {
+            throw new IllegalStateException("Failed to initialize room repository: " + e.getMessage(), e);
+        }
     }
 
     private static MobRegistry createMobRegistry(

--- a/src/main/java/io/taanielo/jmud/core/world/dto/RoomDto.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/RoomDto.java
@@ -1,6 +1,11 @@
 package io.taanielo.jmud.core.world.dto;
 
 import java.util.List;
+import java.util.Map;
 
-public record RoomDto(int schemaVersion, String id, String name, String description, List<String> itemIds) {
+/**
+ * Data transfer object for room persistence. Schema version 2 adds the {@code exits} field;
+ * version 1 files are still accepted and will produce rooms with no exits.
+ */
+public record RoomDto(int schemaVersion, String id, String name, String description, List<String> itemIds, Map<String, String> exits) {
 }

--- a/src/main/java/io/taanielo/jmud/core/world/dto/RoomMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/RoomMapper.java
@@ -1,31 +1,52 @@
 package io.taanielo.jmud.core.world.dto;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import io.taanielo.jmud.core.world.Direction;
 import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.Room;
 import io.taanielo.jmud.core.world.RoomId;
 
+/**
+ * Maps between {@link Room} domain objects and {@link RoomDto} transfer objects.
+ */
 public class RoomMapper {
 
+    /**
+     * Converts a domain room to its DTO representation.
+     */
     public RoomDto toDto(Room room) {
         Objects.requireNonNull(room, "Room is required");
         List<String> itemIds = room.getItems().stream()
             .map(item -> item.getId().getValue())
             .toList();
-        return new RoomDto(SchemaVersions.V1, room.getId().getValue(), room.getName(), room.getDescription(), itemIds);
+        Map<String, String> exits = new HashMap<>();
+        room.getExits().forEach((dir, roomId) -> exits.put(dir.name().toLowerCase(), roomId.getValue()));
+        return new RoomDto(SchemaVersions.V2, room.getId().getValue(), room.getName(), room.getDescription(), itemIds, exits);
     }
 
+    /**
+     * Converts a DTO and resolved item list back to a domain room.
+     */
     public Room toDomain(RoomDto dto, List<Item> items) {
         Objects.requireNonNull(dto, "Room DTO is required");
         Objects.requireNonNull(items, "Room items are required");
+        Map<Direction, RoomId> exits = new HashMap<>();
+        if (dto.exits() != null) {
+            for (Map.Entry<String, String> entry : dto.exits().entrySet()) {
+                Direction.fromInput(entry.getKey()).ifPresent(
+                    dir -> exits.put(dir, RoomId.of(entry.getValue()))
+                );
+            }
+        }
         return new Room(
             RoomId.of(dto.id()),
             dto.name(),
             dto.description(),
-            Map.of(),
+            exits,
             items,
             List.of()
         );

--- a/src/main/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepository.java
@@ -119,7 +119,7 @@ public class JsonRoomRepository implements RoomRepository {
     }
 
     private void validateSchema(RoomDto dto, Path path) throws RepositoryException {
-        if (dto.schemaVersion() != SchemaVersions.V1) {
+        if (dto.schemaVersion() != SchemaVersions.V1 && dto.schemaVersion() != SchemaVersions.V2) {
             throw new RepositoryException("Unsupported room schema version " + dto.schemaVersion() + " in " + path);
         }
     }

--- a/src/test/java/io/taanielo/jmud/core/authentication/JsonUserRegistryTest.java
+++ b/src/test/java/io/taanielo/jmud/core/authentication/JsonUserRegistryTest.java
@@ -1,0 +1,84 @@
+package io.taanielo.jmud.core.authentication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JsonUserRegistryTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void savesAndLoadsUser() throws Exception {
+        JsonUserRegistry registry = new JsonUserRegistry(tempDir);
+        User user = User.of(Username.of("gandalf"), Password.hash("mellon", 1000));
+
+        registry.register(user);
+
+        Optional<User> loaded = registry.findByUsername(Username.of("gandalf"));
+        assertTrue(loaded.isPresent());
+        assertEquals("gandalf", loaded.get().getUsername().getValue());
+        assertTrue(loaded.get().getPassword().matches("mellon"));
+    }
+
+    @Test
+    void returnsEmptyForUnknownUser() throws Exception {
+        JsonUserRegistry registry = new JsonUserRegistry(tempDir);
+
+        Optional<User> result = registry.findByUsername(Username.of("nobody"));
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void doesNotOverwriteExistingUser() throws Exception {
+        JsonUserRegistry registry = new JsonUserRegistry(tempDir);
+        User first = User.of(Username.of("bilbo"), Password.hash("shire", 1000));
+        User second = User.of(Username.of("bilbo"), Password.hash("ring", 1000));
+
+        registry.register(first);
+        registry.register(second);
+
+        Optional<User> loaded = registry.findByUsername(Username.of("bilbo"));
+        assertTrue(loaded.isPresent());
+        // First registration wins; password should still match "shire", not "ring"
+        assertTrue(loaded.get().getPassword().matches("shire"));
+        assertFalse(loaded.get().getPassword().matches("ring"));
+    }
+
+    @Test
+    void loadsUserFromDiskAfterCacheIsCleared() throws Exception {
+        Path dataRoot = tempDir.resolve("data");
+
+        // First registry instance: register a user (writes to disk)
+        JsonUserRegistry registryA = new JsonUserRegistry(dataRoot);
+        User user = User.of(Username.of("frodo"), Password.hash("baggins", 1000));
+        registryA.register(user);
+
+        // Second registry instance: no warm cache, must read from disk
+        JsonUserRegistry registryB = new JsonUserRegistry(dataRoot);
+        Optional<User> loaded = registryB.findByUsername(Username.of("frodo"));
+
+        assertTrue(loaded.isPresent());
+        assertEquals("frodo", loaded.get().getUsername().getValue());
+        assertTrue(loaded.get().getPassword().matches("baggins"));
+    }
+
+    @Test
+    void lookupIsCaseInsensitive() throws Exception {
+        JsonUserRegistry registry = new JsonUserRegistry(tempDir);
+        User user = User.of(Username.of("Legolas"), Password.hash("elven", 1000));
+
+        registry.register(user);
+
+        Optional<User> loaded = registry.findByUsername(Username.of("legolas"));
+        assertTrue(loaded.isPresent());
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces `InMemoryRoomRepository` with `JsonRoomRepository` in `GameContext`, loading rooms from `data/rooms/`
- Replaces `UserRegistryImpl` with new `JsonUserRegistry` backed by `data/users/`, one JSON file per user
- Adds `UserRegistryException` checked exception for registry initialisation failures
- Extends `RoomDto` and `RoomMapper` to support schema version 2 with an `exits` map; version 1 files remain valid and produce rooms with no exits
- Updates `data/rooms/training-yard.json` to schema v2 with example exits
- Adds `data/users/.gitkeep` to track the empty directory and documents it in `data/README.md`
- Adds `JsonUserRegistryTest` covering registration, login, duplicate-user, and persistence round-trips

## Test plan

- [ ] Run `./gradlew test` — all existing tests and new `JsonUserRegistryTest` pass
- [ ] Start the server and verify login/registration persists a file under `data/users/`
- [ ] Restart the server and confirm the persisted user can log in again
- [ ] Verify the training-yard room loads with exits (north → armory, east → courtyard, south → sparring-pit)

Closes #89

Generated with [Claude Code](https://claude.com/claude-code)