### PR TITLE
feat(combat): award XP on mob kill and trigger level-up with stat gains

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -21,6 +21,8 @@ import io.taanielo.jmud.core.combat.AttackId;
 import io.taanielo.jmud.core.combat.repository.AttackRepository;
 import io.taanielo.jmud.core.combat.repository.AttackRepositoryException;
 import io.taanielo.jmud.core.combat.CombatSettings;
+import io.taanielo.jmud.core.player.LevelUpService;
+import io.taanielo.jmud.core.player.LevelUpService.LevelUpResult;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.tick.Tickable;
@@ -47,6 +49,7 @@ public class MobRegistry implements Tickable {
     private final RoomService roomService;
     private final PlayerRepository playerRepository;
     private final PlayerEventBus playerEventBus;
+    private final LevelUpService levelUpService = new LevelUpService();
 
     private final ConcurrentHashMap<UUID, MobInstance> instances = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Username, UUID> playerCombatTargets = new ConcurrentHashMap<>();
@@ -155,6 +158,15 @@ public class MobRegistry implements Tickable {
             dropLoot(mob);
             mob.scheduleRespawn();
             endCombatForMob(mob);
+            Player reloaded = playerRepository.loadPlayer(attacker.getUsername()).orElse(attacker);
+            LevelUpResult levelUpResult = levelUpService.awardXp(reloaded, mob.template().xpReward());
+            playerRepository.savePlayer(levelUpResult.player());
+            messages.add(GameMessage.toSource(
+                "You gain " + mob.template().xpReward() + " experience points."));
+            if (levelUpResult.leveledUp()) {
+                messages.add(GameMessage.toSource(
+                    "You have advanced to level " + levelUpResult.player().getLevel() + "!"));
+            }
         }
         return new GameActionResult(null, null, messages);
     }
@@ -261,6 +273,15 @@ public class MobRegistry implements Tickable {
                 dropLoot(mob);
                 mob.scheduleRespawn();
                 endCombatForMob(mob);
+                Player reloaded = playerRepository.loadPlayer(username).orElse(player);
+                LevelUpResult levelUpResult = levelUpService.awardXp(reloaded, mob.template().xpReward());
+                playerRepository.savePlayer(levelUpResult.player());
+                messages.add(GameMessage.toSource(
+                    "You gain " + mob.template().xpReward() + " experience points."));
+                if (levelUpResult.leveledUp()) {
+                    messages.add(GameMessage.toSource(
+                        "You have advanced to level " + levelUpResult.player().getLevel() + "!"));
+                }
             }
             playerEventBus.publish(username, new GameActionResult(null, null, messages));
         }

--- a/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
@@ -18,7 +18,8 @@ public record MobTemplate(
     List<LootEntry> lootTable,
     RoomId spawnRoomId,
     int maxCount,
-    int respawnTicks
+    int respawnTicks,
+    int xpReward
 ) {
     public MobTemplate {
         if (maxHp <= 0) {
@@ -29,6 +30,9 @@ public record MobTemplate(
         }
         if (respawnTicks < 0) {
             throw new IllegalArgumentException("Mob respawnTicks must be non-negative");
+        }
+        if (xpReward < 0) {
+            throw new IllegalArgumentException("Mob xpReward must be non-negative");
         }
         lootTable = List.copyOf(lootTable);
     }

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
@@ -12,6 +12,7 @@ public record MobTemplateDto(
     List<LootEntryDto> loot,
     String spawnRoomId,
     int maxCount,
-    int respawnTicks
+    int respawnTicks,
+    Integer xpReward
 ) {
 }

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
@@ -19,6 +19,7 @@ public class MobTemplateDtoMapper {
             .map(e -> new LootEntry(ItemId.of(e.itemId()), e.dropChance()))
             .toList();
         boolean aggressive = dto.aggressive() == null || dto.aggressive();
+        int xpReward = dto.xpReward() != null ? dto.xpReward() : dto.maxHp();
         return new MobTemplate(
             MobId.of(dto.id()),
             dto.name(),
@@ -28,7 +29,8 @@ public class MobTemplateDtoMapper {
             loot,
             RoomId.of(dto.spawnRoomId()),
             dto.maxCount(),
-            dto.respawnTicks()
+            dto.respawnTicks(),
+            xpReward
         );
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/player/LevelUpService.java
+++ b/src/main/java/io/taanielo/jmud/core/player/LevelUpService.java
@@ -1,0 +1,78 @@
+package io.taanielo.jmud.core.player;
+
+/**
+ * Domain service that awards XP to a player and triggers level-ups when the
+ * XP threshold is reached.
+ *
+ * <p>Formula:
+ * <ul>
+ *   <li>XP required to advance from level {@code N} to {@code N+1}: {@code N * 100}</li>
+ *   <li>Each level-up grants {@code +10} permanent max HP and {@code +5} permanent max mana.</li>
+ * </ul>
+ *
+ * <p>The service is stateless and thread-safe; callers are responsible for
+ * persisting the returned {@link LevelUpResult}.
+ */
+public class LevelUpService {
+
+    /** XP needed to advance from level {@code level} to the next level. */
+    public static long xpForNextLevel(int level) {
+        return (long) level * 100;
+    }
+
+    /** Max-HP gain applied per level-up. */
+    public static final int HP_GAIN_PER_LEVEL = 10;
+
+    /** Max-mana gain applied per level-up. */
+    public static final int MANA_GAIN_PER_LEVEL = 5;
+
+    /**
+     * Awards the given amount of XP to the player and resolves any resulting
+     * level-ups.
+     *
+     * @param player    the player receiving XP; must not be null
+     * @param xpAmount  the amount of XP to award; must be non-negative
+     * @return a {@link LevelUpResult} containing the updated player and a flag
+     *         indicating whether at least one level-up occurred
+     */
+    public LevelUpResult awardXp(Player player, long xpAmount) {
+        if (xpAmount < 0) {
+            throw new IllegalArgumentException("xpAmount must be non-negative");
+        }
+        long newXp = player.getExperience() + xpAmount;
+        int newLevel = player.getLevel();
+        PlayerVitals newVitals = player.getVitals();
+        boolean leveledUp = false;
+
+        // Resolve multiple level-ups in case the XP gain is large
+        while (newXp >= xpForNextLevel(newLevel)) {
+            newXp -= xpForNextLevel(newLevel);
+            newLevel++;
+            int newMaxHp = newVitals.maxHp() + HP_GAIN_PER_LEVEL;
+            int newMaxMana = newVitals.maxMana() + MANA_GAIN_PER_LEVEL;
+            // Restore player to full on level-up (classic MUD behaviour)
+            newVitals = new PlayerVitals(
+                newMaxHp, newMaxHp, newMaxHp,
+                newMaxMana, newMaxMana,
+                newVitals.maxMove(), newVitals.maxMove()
+            );
+            leveledUp = true;
+        }
+
+        Player updated = player
+            .withIdentity(player.identity()
+                .withLevel(newLevel)
+                .withExperience(newXp))
+            .withVitals(newVitals);
+
+        return new LevelUpResult(updated, leveledUp);
+    }
+
+    /**
+     * Result of an XP award operation.
+     *
+     * @param player    the updated player (with new XP, level, and vitals if applicable)
+     * @param leveledUp {@code true} if at least one level-up occurred
+     */
+    public record LevelUpResult(Player player, boolean leveledUp) {}
+}

--- a/src/main/java/io/taanielo/jmud/core/player/Player.java
+++ b/src/main/java/io/taanielo/jmud/core/player/Player.java
@@ -264,4 +264,11 @@ public class Player implements EffectTarget, Combatant {
     public Player withEquipment(PlayerEquipment nextEquipment) {
         return new Player(identity, combatState, preferences, abilities, inventory, nextEquipment);
     }
+
+    /**
+     * Returns a copy of this player with the given identity (level and experience).
+     */
+    public Player withIdentity(PlayerIdentity nextIdentity) {
+        return new Player(nextIdentity, combatState, preferences, abilities, inventory, equipment);
+    }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/ScoreCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/ScoreCommand.java
@@ -1,0 +1,53 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+import io.taanielo.jmud.core.player.LevelUpService;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerVitals;
+
+/**
+ * Handles the {@code score} / {@code sc} command, displaying the player's level,
+ * experience, XP needed for the next level, and current vitals.
+ */
+public class ScoreCommand extends RegistrableCommand {
+
+    public ScoreCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "score";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String token = SocketCommandParsing.firstToken(input);
+        if (!"SCORE".equals(token) && !"SC".equals(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(new SocketCommandMatch(this, ScoreCommand::handleScore));
+    }
+
+    private static void handleScore(SocketCommandContext context) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to view your score.");
+            return;
+        }
+        Player player = context.getPlayer();
+        PlayerVitals vitals = player.getVitals();
+        int level = player.getLevel();
+        long xp = player.getExperience();
+        long xpNeeded = LevelUpService.xpForNextLevel(level);
+        long xpRemaining = Math.max(0L, xpNeeded - xp);
+
+        context.writeLineSafe("--- Score ---");
+        context.writeLineSafe(String.format("Level : %d", level));
+        context.writeLineSafe(String.format("XP    : %d / %d  (%d to next level)", xp, xpNeeded, xpRemaining));
+        context.writeLineSafe(String.format("HP    : %d / %d", vitals.hp(), vitals.maxHp()));
+        context.writeLineSafe(String.format("Mana  : %d / %d", vitals.mana(), vitals.maxMana()));
+        context.writeLineSafe(String.format("Move  : %d / %d", vitals.move(), vitals.maxMove()));
+        context.sendPrompt();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -24,6 +24,7 @@ public class SocketCommandRegistry {
         new UnequipCommand(registry);
         new SayCommand(registry);
         new WhoCommand(registry);
+        new ScoreCommand(registry);
         new AbilityCommand(registry);
         new AttackCommand(registry);
         new KillCommand(registry);

--- a/src/test/java/io/taanielo/jmud/core/player/LevelUpServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/player/LevelUpServiceTest.java
@@ -1,0 +1,129 @@
+package io.taanielo.jmud.core.player;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+
+class LevelUpServiceTest {
+
+    private static Player basePlayer(int level, long xp) {
+        User user = User.of(Username.of("hero"), Password.hash("pw", 1000));
+        PlayerVitals vitals = PlayerVitals.defaults();
+        return new Player(user, level, xp, vitals, List.of(), "prompt", false, List.of(), null, null);
+    }
+
+    private final LevelUpService service = new LevelUpService();
+
+    // ── xpForNextLevel ────────────────────────────────────────────────────────
+
+    @Test
+    void xpForNextLevelScalesWithLevel() {
+        assertEquals(100L, LevelUpService.xpForNextLevel(1));
+        assertEquals(200L, LevelUpService.xpForNextLevel(2));
+        assertEquals(500L, LevelUpService.xpForNextLevel(5));
+    }
+
+    // ── awardXp: no level-up ─────────────────────────────────────────────────
+
+    @Test
+    void awardXpBelowThresholdDoesNotLevelUp() {
+        Player player = basePlayer(1, 0);
+        LevelUpService.LevelUpResult result = service.awardXp(player, 50);
+
+        assertFalse(result.leveledUp());
+        assertEquals(1, result.player().getLevel());
+        assertEquals(50, result.player().getExperience());
+    }
+
+    @Test
+    void awardingZeroXpIsNoop() {
+        Player player = basePlayer(1, 42);
+        LevelUpService.LevelUpResult result = service.awardXp(player, 0);
+
+        assertFalse(result.leveledUp());
+        assertEquals(1, result.player().getLevel());
+        assertEquals(42, result.player().getExperience());
+    }
+
+    // ── awardXp: single level-up ─────────────────────────────────────────────
+
+    @Test
+    void awardXpExactlyAtThresholdTriggersLevelUp() {
+        Player player = basePlayer(1, 0);
+        // Level 1 -> 2 requires 100 XP
+        LevelUpService.LevelUpResult result = service.awardXp(player, 100);
+
+        assertTrue(result.leveledUp());
+        assertEquals(2, result.player().getLevel());
+        assertEquals(0, result.player().getExperience());
+    }
+
+    @Test
+    void excessXpCarriesOverAfterLevelUp() {
+        Player player = basePlayer(1, 0);
+        // Level 1->2 needs 100; award 150 → 50 XP left at level 2
+        LevelUpService.LevelUpResult result = service.awardXp(player, 150);
+
+        assertTrue(result.leveledUp());
+        assertEquals(2, result.player().getLevel());
+        assertEquals(50, result.player().getExperience());
+    }
+
+    @Test
+    void levelUpGrantsHpAndManaGain() {
+        Player player = basePlayer(1, 0);
+        int initialMaxHp = player.getVitals().maxHp();
+        int initialMaxMana = player.getVitals().maxMana();
+
+        LevelUpService.LevelUpResult result = service.awardXp(player, 100);
+
+        int expectedMaxHp = initialMaxHp + LevelUpService.HP_GAIN_PER_LEVEL;
+        int expectedMaxMana = initialMaxMana + LevelUpService.MANA_GAIN_PER_LEVEL;
+        assertEquals(expectedMaxHp, result.player().getVitals().maxHp());
+        assertEquals(expectedMaxMana, result.player().getVitals().maxMana());
+    }
+
+    @Test
+    void levelUpRestoresVitalsToFull() {
+        // Player is partially damaged before the level-up
+        User user = User.of(Username.of("hero"), Password.hash("pw", 1000));
+        PlayerVitals damaged = new PlayerVitals(5, 20, 8, 20, 10, 20);
+        Player player = new Player(user, 1, 0, damaged, List.of(), "prompt", false, List.of(), null, null);
+
+        LevelUpService.LevelUpResult result = service.awardXp(player, 100);
+
+        PlayerVitals after = result.player().getVitals();
+        assertEquals(after.maxHp(), after.hp(), "HP should be restored to max on level-up");
+        assertEquals(after.maxMana(), after.mana(), "Mana should be restored to max on level-up");
+    }
+
+    // ── awardXp: multiple level-ups ──────────────────────────────────────────
+
+    @Test
+    void awardXpCanTriggerMultipleLevelUps() {
+        Player player = basePlayer(1, 0);
+        // Level 1->2: 100, Level 2->3: 200 => 300 total to reach level 3
+        LevelUpService.LevelUpResult result = service.awardXp(player, 300);
+
+        assertTrue(result.leveledUp());
+        assertEquals(3, result.player().getLevel());
+        assertEquals(0, result.player().getExperience());
+    }
+
+    // ── awardXp: validation ───────────────────────────────────────────────────
+
+    @Test
+    void negativeXpThrows() {
+        Player player = basePlayer(1, 0);
+        assertThrows(IllegalArgumentException.class, () -> service.awardXp(player, -1));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `xpReward` field to `MobTemplate` (defaults to `maxHp` for backward compatibility with existing data files)
- Wires XP grants in both kill paths in `MobRegistry`
- Introduces `LevelUpService` with XP threshold formula (`level * 100` XP per level) and stat gains (+10 `maxHp` / +5 `maxMana` per level-up)
- Adds `ScoreCommand` (aliases: `SCORE`, `SC`) displaying level, XP progress bar, and current vitals
- Registers `ScoreCommand` in `SocketCommandRegistry`
- Unit tests for `LevelUpService` covering threshold logic, multi-level-up scenarios, and stat gain accumulation

Closes #91

## Test plan

- [ ] Run `./gradlew test` — `LevelUpServiceTest` suite must pass
- [ ] Start the server and kill a mob; verify XP is awarded and logged
- [ ] Kill enough mobs to cross a level threshold; confirm level-up message and increased `maxHp`/`maxMana`
- [ ] Run `SCORE` (and alias `SC`) in-game; verify level, XP progress, and vitals display correctly
- [ ] Confirm existing mob data files without `xpReward` field still load correctly (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)