### PR TITLE
feat(inventory): add INVENTORY and EQUIPMENT commands

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/EquipmentCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/EquipmentCommand.java
@@ -1,0 +1,36 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the {@code equipment} / {@code eq} command, displaying the items a
+ * player currently has worn in each equipment slot.
+ */
+public class EquipmentCommand extends RegistrableCommand {
+
+    public EquipmentCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "equipment";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String token = SocketCommandParsing.firstToken(input);
+        if (!"EQUIPMENT".equals(token) && !"EQ".equals(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(new SocketCommandMatch(this, EquipmentCommand::handleEquipment));
+    }
+
+    private static void handleEquipment(SocketCommandContext context) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to check your equipment.");
+            return;
+        }
+        context.sendEquipment();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/EquipmentListing.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/EquipmentListing.java
@@ -1,0 +1,64 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import io.taanielo.jmud.core.world.EquipmentSlot;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemId;
+
+/**
+ * Pure, network-free helper that formats a player's worn equipment for the
+ * {@code equipment} command.
+ *
+ * <p>Kept free of any I/O so the listing logic can be unit-tested in isolation.
+ */
+public final class EquipmentListing {
+
+    private static final String HEADER = "You are wearing:";
+    private static final String EMPTY_SLOT = "(empty)";
+
+    private EquipmentListing() {
+    }
+
+    /**
+     * Formats the equipment slots into display lines.
+     *
+     * <p>Every {@link EquipmentSlot} is shown in declaration order. Equipped
+     * slots display the item name; empty slots display {@code (empty)}.
+     *
+     * @param slots    the map of currently equipped item ids keyed by slot
+     * @param itemById a lookup function mapping an {@link ItemId} to an {@link Item},
+     *                 used to resolve the display name; returns {@code null} when unknown
+     * @return the lines to render, never empty
+     */
+    public static List<String> format(Map<EquipmentSlot, ItemId> slots, Function<ItemId, Item> itemById) {
+        Objects.requireNonNull(slots, "Slots are required");
+        Objects.requireNonNull(itemById, "Item lookup is required");
+        List<String> lines = new ArrayList<>(EquipmentSlot.values().length + 1);
+        lines.add(HEADER);
+        for (EquipmentSlot slot : EquipmentSlot.values()) {
+            ItemId equipped = slots.get(slot);
+            String label = capitalize(slot.id());
+            if (equipped == null) {
+                lines.add(String.format("  %-8s : %s", label, EMPTY_SLOT));
+            } else {
+                Item item = itemById.apply(equipped);
+                String itemName = item != null ? item.getName() : equipped.getValue();
+                lines.add(String.format("  %-8s : %s", label, itemName));
+            }
+        }
+        return List.copyOf(lines);
+    }
+
+    private static String capitalize(String s) {
+        if (s == null || s.isEmpty()) {
+            return s;
+        }
+        return Character.toUpperCase(s.charAt(0)) + s.substring(1).toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/InventoryCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/InventoryCommand.java
@@ -1,0 +1,37 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the {@code inventory} / {@code inv} / {@code i} command, displaying
+ * the items a player is currently carrying together with individual weights and
+ * total encumbrance.
+ */
+public class InventoryCommand extends RegistrableCommand {
+
+    public InventoryCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "inventory";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String token = SocketCommandParsing.firstToken(input);
+        if (!"INVENTORY".equals(token) && !"INV".equals(token) && !"I".equals(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(new SocketCommandMatch(this, InventoryCommand::handleInventory));
+    }
+
+    private static void handleInventory(SocketCommandContext context) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to check your inventory.");
+            return;
+        }
+        context.sendInventory();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/InventoryListing.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/InventoryListing.java
@@ -1,0 +1,48 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.taanielo.jmud.core.world.Item;
+
+/**
+ * Pure, network-free helper that formats a player's carried inventory for the
+ * {@code inventory} command.
+ *
+ * <p>Kept free of any I/O so the listing logic can be unit-tested in isolation.
+ */
+public final class InventoryListing {
+
+    private static final String HEADER = "You are carrying:";
+
+    private InventoryListing() {
+    }
+
+    /**
+     * Formats the given item list and encumbrance values into display lines.
+     *
+     * <p>The output starts with a header, lists each item with its weight, and
+     * ends with a footer showing total carried weight and the carry limit.
+     *
+     * @param items         the items currently in the player's inventory
+     * @param carriedWeight the sum of all item weights
+     * @param maxCarry      the player's carry weight limit
+     * @return the lines to render, never empty
+     */
+    public static List<String> format(List<Item> items, int carriedWeight, int maxCarry) {
+        Objects.requireNonNull(items, "Items are required");
+        List<String> lines = new ArrayList<>(items.size() + 2);
+        lines.add(HEADER);
+        if (items.isEmpty()) {
+            lines.add("  (nothing)");
+        } else {
+            for (Item item : items) {
+                Objects.requireNonNull(item, "Item must not be null");
+                lines.add(String.format("  %-30s %d lb", item.getName(), item.getWeight()));
+            }
+        }
+        lines.add(String.format("Carrying %d / %d lbs.", carriedWeight, maxCarry));
+        return List.copyOf(lines);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,6 +41,8 @@ import io.taanielo.jmud.core.server.Client;
 import io.taanielo.jmud.core.server.ClientPool;
 import io.taanielo.jmud.core.server.connection.ClientConnection;
 import io.taanielo.jmud.core.server.connection.TransportSecurity;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.Room;
 import io.taanielo.jmud.core.world.RoomService;
 
@@ -872,6 +875,36 @@ public class SocketClient implements Client {
             GameActionResult result = context.mobRegistry()
                 .processPlayerAttack(player, args, roomIdOpt.get());
             deliverResult(result);
+            sendPrompt();
+        }
+
+        @Override
+        public void sendInventory() {
+            Player player = session.getPlayer();
+            if (!session.isAuthenticated() || player == null) {
+                writeLineWithPrompt("You must be logged in to check your inventory.");
+                return;
+            }
+            int carried = encumbranceService.carriedWeight(player);
+            int maxCarry = encumbranceService.maxCarry(player);
+            for (String line : InventoryListing.format(player.getInventory(), carried, maxCarry)) {
+                connection.writeLine(line);
+            }
+            sendPrompt();
+        }
+
+        @Override
+        public void sendEquipment() {
+            Player player = session.getPlayer();
+            if (!session.isAuthenticated() || player == null) {
+                writeLineWithPrompt("You must be logged in to check your equipment.");
+                return;
+            }
+            Map<ItemId, Item> inventoryIndex = player.getInventory().stream()
+                .collect(Collectors.toMap(Item::getId, i -> i, (a, b) -> a));
+            for (String line : EquipmentListing.format(player.getEquipment().slots(), inventoryIndex::get)) {
+                connection.writeLine(line);
+            }
             sendPrompt();
         }
     }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -131,4 +131,14 @@ public interface SocketCommandContext extends Client {
      */
     void killMob(String args);
 
+    /**
+     * Sends the current player's inventory listing (carried items and encumbrance).
+     */
+    void sendInventory();
+
+    /**
+     * Sends the current player's equipment listing (worn items per slot).
+     */
+    void sendEquipment();
+
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -22,6 +22,8 @@ public class SocketCommandRegistry {
         new QuaffCommand(registry);
         new EquipCommand(registry);
         new UnequipCommand(registry);
+        new InventoryCommand(registry);
+        new EquipmentCommand(registry);
         new SayCommand(registry);
         new WhoCommand(registry);
         new ScoreCommand(registry);

--- a/src/test/java/io/taanielo/jmud/core/server/socket/EquipmentCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/EquipmentCommandTest.java
@@ -1,0 +1,127 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerVitals;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+class EquipmentCommandTest {
+
+    @Test
+    void matchesEquipmentToken() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        EquipmentCommand command = new EquipmentCommand(registry);
+
+        assertTrue(command.match("equipment").isPresent());
+        assertTrue(command.match("EQUIPMENT").isPresent());
+    }
+
+    @Test
+    void matchesEqAlias() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        EquipmentCommand command = new EquipmentCommand(registry);
+
+        assertTrue(command.match("eq").isPresent());
+        assertTrue(command.match("EQ").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        EquipmentCommand command = new EquipmentCommand(registry);
+
+        assertFalse(command.match("equip").isPresent());
+        assertFalse(command.match("inventory").isPresent());
+        assertFalse(command.match("").isPresent());
+    }
+
+    @Test
+    void executionDelegatesToSendEquipment() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        EquipmentCommand command = new EquipmentCommand(registry);
+        Player player = makeAlivePlayer("hero");
+        CapturingContext context = new CapturingContext(player, true);
+
+        Optional<SocketCommandMatch> match = command.match("eq");
+        assertTrue(match.isPresent());
+        match.get().execute(context);
+
+        assertTrue(context.equipmentCalled, "sendEquipment should have been called");
+    }
+
+    @Test
+    void unauthenticatedPlayerGetsErrorMessage() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        EquipmentCommand command = new EquipmentCommand(registry);
+        CapturingContext context = new CapturingContext(null, false);
+
+        Optional<SocketCommandMatch> match = command.match("equipment");
+        assertTrue(match.isPresent());
+        match.get().execute(context);
+
+        assertFalse(context.equipmentCalled);
+        assertNotNull(context.lastPromptMessage);
+    }
+
+    private static Player makeAlivePlayer(String name) {
+        return new Player(
+            User.of(Username.of(name), Password.hash("pw", 1000)),
+            1, 0,
+            new PlayerVitals(20, 20, 10, 10, 10, 10),
+            List.of(), "prompt", false, List.of(), null, null
+        );
+    }
+
+    private static class CapturingContext implements SocketCommandContext {
+        private final Player player;
+        private final boolean authenticated;
+        boolean equipmentCalled;
+        String lastPromptMessage;
+
+        CapturingContext(Player player, boolean authenticated) {
+            this.player = player;
+            this.authenticated = authenticated;
+        }
+
+        @Override public boolean isAuthenticated() { return authenticated; }
+        @Override public Player getPlayer() { return player; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) { lastPromptMessage = m; }
+        @Override public void writeLineSafe(String m) {}
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) {}
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() { equipmentCalled = true; }
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/EquipmentListingTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/EquipmentListingTest.java
@@ -1,0 +1,98 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.world.EquipmentSlot;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemAttributes;
+import io.taanielo.jmud.core.world.ItemId;
+
+class EquipmentListingTest {
+
+    private static Item item(String id, String name, EquipmentSlot slot) {
+        return new Item(
+            ItemId.of(id),
+            name,
+            "A " + name + ".",
+            ItemAttributes.empty(),
+            List.of(),
+            List.of(),
+            slot,
+            1,
+            0,
+            null
+        );
+    }
+
+    @Test
+    void allSlotsShownWhenNothingEquipped() {
+        List<String> lines = EquipmentListing.format(Map.of(), id -> null);
+
+        assertEquals("You are wearing:", lines.get(0));
+        assertEquals(EquipmentSlot.values().length + 1, lines.size(), "Header plus one line per slot");
+        for (String line : lines.subList(1, lines.size())) {
+            assertTrue(line.contains("(empty)"), "All slots should be empty: " + line);
+        }
+    }
+
+    @Test
+    void equippedSlotShowsItemName() {
+        ItemId swordId = ItemId.of("sword");
+        Item sword = item("sword", "Iron Sword", EquipmentSlot.WEAPON);
+        List<String> lines = EquipmentListing.format(
+            Map.of(EquipmentSlot.WEAPON, swordId),
+            id -> id.equals(swordId) ? sword : null
+        );
+
+        String weaponLine = lines.stream()
+            .filter(l -> l.contains("Weapon"))
+            .findFirst()
+            .orElseThrow();
+        assertTrue(weaponLine.contains("Iron Sword"), "Weapon slot should show item name: " + weaponLine);
+    }
+
+    @Test
+    void unknownItemIdFallsBackToId() {
+        ItemId unknownId = ItemId.of("unknown-item");
+        List<String> lines = EquipmentListing.format(
+            Map.of(EquipmentSlot.HEAD, unknownId),
+            id -> null
+        );
+
+        String headLine = lines.stream()
+            .filter(l -> l.contains("Head"))
+            .findFirst()
+            .orElseThrow();
+        assertTrue(headLine.contains("unknown-item"), "Should fall back to item id: " + headLine);
+    }
+
+    @Test
+    void multipleEquippedSlotsAllRendered() {
+        ItemId swordId = ItemId.of("sword");
+        ItemId helmetId = ItemId.of("helmet");
+        Item sword = item("sword", "Iron Sword", EquipmentSlot.WEAPON);
+        Item helmet = item("helmet", "Iron Helmet", EquipmentSlot.HEAD);
+
+        Map<EquipmentSlot, ItemId> slots = Map.of(
+            EquipmentSlot.WEAPON, swordId,
+            EquipmentSlot.HEAD, helmetId
+        );
+        List<String> lines = EquipmentListing.format(slots, id -> {
+            if (id.equals(swordId)) return sword;
+            if (id.equals(helmetId)) return helmet;
+            return null;
+        });
+
+        assertTrue(lines.stream().anyMatch(l -> l.contains("Iron Sword")));
+        assertTrue(lines.stream().anyMatch(l -> l.contains("Iron Helmet")));
+        // remaining slots empty
+        long emptyCount = lines.stream().filter(l -> l.contains("(empty)")).count();
+        assertEquals(EquipmentSlot.values().length - 2, emptyCount);
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/InventoryCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/InventoryCommandTest.java
@@ -1,0 +1,138 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerVitals;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+class InventoryCommandTest {
+
+    @Test
+    void matchesInventoryToken() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        InventoryCommand command = new InventoryCommand(registry);
+
+        assertTrue(command.match("inventory").isPresent());
+        assertTrue(command.match("INVENTORY").isPresent());
+    }
+
+    @Test
+    void matchesInvAlias() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        InventoryCommand command = new InventoryCommand(registry);
+
+        assertTrue(command.match("inv").isPresent());
+        assertTrue(command.match("INV").isPresent());
+    }
+
+    @Test
+    void matchesSingleLetterI() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        InventoryCommand command = new InventoryCommand(registry);
+
+        assertTrue(command.match("i").isPresent());
+        assertTrue(command.match("I").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        InventoryCommand command = new InventoryCommand(registry);
+
+        assertFalse(command.match("look").isPresent());
+        assertFalse(command.match("score").isPresent());
+        assertFalse(command.match("").isPresent());
+    }
+
+    @Test
+    void executionDelegatesToSendInventory() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        InventoryCommand command = new InventoryCommand(registry);
+        Player player = makeAlivePlayer("hero");
+        CapturingContext context = new CapturingContext(player, true);
+
+        Optional<SocketCommandMatch> match = command.match("inventory");
+        assertTrue(match.isPresent());
+        match.get().execute(context);
+
+        assertTrue(context.inventoryCalled, "sendInventory should have been called");
+    }
+
+    @Test
+    void unauthenticatedPlayerGetsErrorMessage() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        InventoryCommand command = new InventoryCommand(registry);
+        CapturingContext context = new CapturingContext(null, false);
+
+        Optional<SocketCommandMatch> match = command.match("i");
+        assertTrue(match.isPresent());
+        match.get().execute(context);
+
+        assertFalse(context.inventoryCalled);
+        assertNotNull(context.lastPromptMessage);
+    }
+
+    private static Player makeAlivePlayer(String name) {
+        return new Player(
+            User.of(Username.of(name), Password.hash("pw", 1000)),
+            1, 0,
+            new PlayerVitals(20, 20, 10, 10, 10, 10),
+            List.of(), "prompt", false, List.of(), null, null
+        );
+    }
+
+    private static class CapturingContext implements SocketCommandContext {
+        private final Player player;
+        private final boolean authenticated;
+        boolean inventoryCalled;
+        String lastPromptMessage;
+
+        CapturingContext(Player player, boolean authenticated) {
+            this.player = player;
+            this.authenticated = authenticated;
+        }
+
+        @Override public boolean isAuthenticated() { return authenticated; }
+        @Override public Player getPlayer() { return player; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) { lastPromptMessage = m; }
+        @Override public void writeLineSafe(String m) {}
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) {}
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void sendInventory() { inventoryCalled = true; }
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/InventoryListingTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/InventoryListingTest.java
@@ -1,0 +1,70 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemAttributes;
+import io.taanielo.jmud.core.world.ItemId;
+
+class InventoryListingTest {
+
+    private static Item item(String id, String name, int weight) {
+        return new Item(
+            ItemId.of(id),
+            name,
+            "A " + name + ".",
+            ItemAttributes.empty(),
+            List.of(),
+            List.of(),
+            null,
+            weight,
+            0,
+            null
+        );
+    }
+
+    @Test
+    void emptyInventoryShowsNothingAndWeight() {
+        List<String> lines = InventoryListing.format(List.of(), 0, 100);
+
+        assertEquals("You are carrying:", lines.get(0));
+        assertEquals("  (nothing)", lines.get(1));
+        assertTrue(lines.get(2).contains("0 / 100"), "Footer should show 0 / 100 but was: " + lines.get(2));
+    }
+
+    @Test
+    void singleItemListedWithWeight() {
+        Item sword = item("sword", "Iron Sword", 5);
+        List<String> lines = InventoryListing.format(List.of(sword), 5, 50);
+
+        assertEquals("You are carrying:", lines.get(0));
+        assertTrue(lines.get(1).contains("Iron Sword"), "Should contain item name");
+        assertTrue(lines.get(1).contains("5 lb"), "Should show item weight");
+        assertTrue(lines.get(2).contains("5 / 50"), "Footer should show carried / max");
+    }
+
+    @Test
+    void multipleItemsAllListed() {
+        Item sword = item("sword", "Iron Sword", 5);
+        Item shield = item("shield", "Wooden Shield", 3);
+        List<String> lines = InventoryListing.format(List.of(sword, shield), 8, 50);
+
+        assertEquals(4, lines.size(), "Header + 2 items + footer");
+        assertTrue(lines.get(1).contains("Iron Sword"));
+        assertTrue(lines.get(2).contains("Wooden Shield"));
+        assertTrue(lines.get(3).contains("8 / 50"));
+    }
+
+    @Test
+    void footerReflectsCarriedAndMaxWeight() {
+        Item heavy = item("anvil", "Iron Anvil", 40);
+        List<String> lines = InventoryListing.format(List.of(heavy), 40, 50);
+
+        assertTrue(lines.getLast().contains("40 / 50 lbs"), "Footer: " + lines.getLast());
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherAuditTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherAuditTest.java
@@ -194,6 +194,14 @@ class SocketCommandDispatcherAuditTest {
         }
 
         @Override
+        public void sendInventory() {
+        }
+
+        @Override
+        public void sendEquipment() {
+        }
+
+        @Override
         public void sendMessage(io.taanielo.jmud.core.messaging.Message message) {
         }
 

--- a/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
@@ -208,6 +208,14 @@ class SocketCommandDispatcherTest {
         }
 
         @Override
+        public void sendInventory() {
+        }
+
+        @Override
+        public void sendEquipment() {
+        }
+
+        @Override
         public void sendMessage(io.taanielo.jmud.core.messaging.Message message) {
         }
 


### PR DESCRIPTION
Closes #94

## Summary

- Added `InventoryCommand` (tokens: INVENTORY, INV, I) and `EquipmentCommand` (tokens: EQUIPMENT, EQ) to let players inspect their carried items and worn gear.
- Added `InventoryListing` and `EquipmentListing` formatting helpers that produce human-readable output strings from a player's item/gear state.
- Extended `SocketCommandContext` and `SocketCommandContextImpl` with `sendInventory()` and `sendEquipment()` methods so commands can write formatted output to the client.
- Registered both new commands in `SocketCommandRegistry`.
- Added unit tests: `InventoryListingTest`, `EquipmentListingTest`, `InventoryCommandTest`, `EquipmentCommandTest`.
- Updated `SocketCommandDispatcherTest` and `SocketCommandDispatcherAuditTest` with stub implementations to cover the new context methods.

## Test plan

- [ ] `./gradlew test` passes with no failures.
- [ ] Connecting to the server and typing `I`, `INV`, or `INVENTORY` returns the player's carried items.
- [ ] Typing `EQ` or `EQUIPMENT` returns the player's worn gear.
- [ ] Empty inventory/equipment slots display a sensible "nothing" message rather than a blank or error.

Generated with [Claude Code](https://claude.com/claude-code)