### PR TITLE
feat(look): show mobs in LOOK output so players can see room threats

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -402,6 +402,10 @@ public class SocketClient implements Client {
             Map.of()
         );
         connection.writeLines(result.lines());
+        if (context.mobRegistry() != null && result.room() != null) {
+            var mobs = context.mobRegistry().getMobsInRoom(result.room().getId());
+            connection.writeLine(formatMonstersLine(mobs));
+        }
         sendPrompt();
     }
 
@@ -567,6 +571,33 @@ public class SocketClient implements Client {
 
     // ── Utility ────────────────────────────────────────────────────────
 
+    /**
+     * Formats a {@code Monsters:} summary line for the given live mob instances.
+     *
+     * <p>Mobs of the same template name are grouped and counted; e.g.
+     * {@code "Monsters: 2x Goblin, 1x Troll"}. Returns {@code "Monsters: none"}
+     * when the list is empty.
+     *
+     * @param mobs live mob instances currently in the room
+     * @return formatted Monsters line
+     */
+    static String formatMonstersLine(java.util.List<io.taanielo.jmud.core.mob.MobInstance> mobs) {
+        if (mobs == null || mobs.isEmpty()) {
+            return "Monsters: none";
+        }
+        // Group by template name, preserving encounter order for determinism.
+        java.util.LinkedHashMap<String, Long> counts = mobs.stream()
+            .collect(java.util.stream.Collectors.groupingBy(
+                m -> m.template().name(),
+                java.util.LinkedHashMap::new,
+                java.util.stream.Collectors.counting()
+            ));
+        String body = counts.entrySet().stream()
+            .map(e -> e.getValue() + "x " + e.getKey())
+            .collect(java.util.stream.Collectors.joining(", "));
+        return "Monsters: " + body;
+    }
+
     private boolean isAuthenticatedUser(Username username) {
         return session.isAuthenticated()
             && session.getPlayer() != null
@@ -653,12 +684,7 @@ public class SocketClient implements Client {
             connection.writeLines(result.lines());
             if (context.mobRegistry() != null && result.room() != null) {
                 var mobs = context.mobRegistry().getMobsInRoom(result.room().getId());
-                if (!mobs.isEmpty()) {
-                    String mobLine = "Mobs: " + mobs.stream()
-                        .map(m -> m.template().name() + " (" + m.currentHp() + " HP)")
-                        .collect(java.util.stream.Collectors.joining(", "));
-                    connection.writeLine(mobLine);
-                }
+                connection.writeLine(formatMonstersLine(mobs));
             }
             sendPrompt();
         }
@@ -728,6 +754,10 @@ public class SocketClient implements Client {
                 deliverRoomMessage(player.getUsername(), null, arriveMessage);
             }
             connection.writeLines(result.lines());
+            if (result.moved() && context.mobRegistry() != null && result.room() != null) {
+                var mobs = context.mobRegistry().getMobsInRoom(result.room().getId());
+                connection.writeLine(formatMonstersLine(mobs));
+            }
             sendPrompt();
         }
 

--- a/src/test/java/io/taanielo/jmud/core/server/socket/MonstersLineFormatterTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/MonstersLineFormatterTest.java
@@ -1,0 +1,76 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.mob.MobInstance;
+import io.taanielo.jmud.core.mob.MobTemplate;
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * Unit tests for {@link SocketClient#formatMonstersLine(List)}.
+ */
+class MonstersLineFormatterTest {
+
+    private static MobInstance mob(String name) {
+        MobTemplate template = new MobTemplate(
+            io.taanielo.jmud.core.mob.MobId.of(name.toLowerCase().replace(' ', '-')),
+            name,
+            10,
+            null,
+            false,
+            List.of(),
+            RoomId.of("test-room"),
+            1,
+            0,
+            0
+        );
+        return new MobInstance(template);
+    }
+
+    @Test
+    void emptyListReturnsNone() {
+        assertEquals("Monsters: none", SocketClient.formatMonstersLine(List.of()));
+    }
+
+    @Test
+    void nullListReturnsNone() {
+        assertEquals("Monsters: none", SocketClient.formatMonstersLine(null));
+    }
+
+    @Test
+    void singleMobShowsOneEntry() {
+        assertEquals("Monsters: 1x Goblin", SocketClient.formatMonstersLine(List.of(mob("Goblin"))));
+    }
+
+    @Test
+    void multipleDifferentMobsListedSeparately() {
+        String result = SocketClient.formatMonstersLine(List.of(mob("Goblin"), mob("Troll")));
+        assertEquals("Monsters: 1x Goblin, 1x Troll", result);
+    }
+
+    @Test
+    void sameTypeMobsAreGroupedAndCounted() {
+        String result = SocketClient.formatMonstersLine(
+            List.of(mob("Goblin"), mob("Goblin"), mob("Goblin")));
+        assertEquals("Monsters: 3x Goblin", result);
+    }
+
+    @Test
+    void mixedMobsGroupedByName() {
+        String result = SocketClient.formatMonstersLine(
+            List.of(mob("Goblin"), mob("Troll"), mob("Goblin")));
+        assertEquals("Monsters: 2x Goblin, 1x Troll", result);
+    }
+
+    @Test
+    void encounterOrderPreservedForFirstOccurrence() {
+        // Troll appears first, then Goblin — output must match insertion order.
+        String result = SocketClient.formatMonstersLine(
+            List.of(mob("Troll"), mob("Goblin"), mob("Troll")));
+        assertEquals("Monsters: 2x Troll, 1x Goblin", result);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `Monsters:` line to LOOK, move, and respawn room descriptions
- Mobs are grouped by name with counts (e.g. `2x Goblin, 1x Giant Rat`)
- Shows `Monsters: none` when the room is empty so players always have clear feedback
- Avoids circular dependency by keeping mob formatting in the socket adapter layer

Closes #97

## Test plan
- [ ] Build passes (`./gradlew build`)
- [ ] LOOK in a room with mobs shows `Monsters: 2x Goblin` (or similar)
- [ ] LOOK in an empty room shows `Monsters: none`
- [ ] Moving into a room with mobs shows the monsters line
- [ ] Respawning shows the monsters line for the starting room

🤖 Generated with [Claude Code](https://claude.ai/claude-code)