### PR TITLE
feat(server): add HELP command for in-game command discovery

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/GetCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GetCommand.java
@@ -16,6 +16,18 @@ public class GetCommand extends RegistrableCommand {
     }
 
     @Override
+    public String shortDescription() {
+        return "Pick up an item from the room floor.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: GET <item>\n"
+             + "  Picks up the named item from the floor of your current room\n"
+             + "  and adds it to your inventory.";
+    }
+
+    @Override
     public Optional<SocketCommandMatch> match(String input) {
         String[] parts = SocketCommandParsing.splitInput(input);
         if (!"GET".equals(parts[0])) {

--- a/src/main/java/io/taanielo/jmud/core/server/socket/HelpCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/HelpCommand.java
@@ -1,0 +1,115 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Handles the {@code HELP} / {@code H} command, giving players a way to
+ * discover all available commands and their descriptions.
+ *
+ * <p>Two forms are supported:
+ * <ul>
+ *   <li>{@code HELP}       — prints a sorted list of all registered command names
+ *       together with their {@link SocketCommandHandler#shortDescription()}.</li>
+ *   <li>{@code HELP <name>} — prints the {@link SocketCommandHandler#longDescription()}
+ *       for the named command, or an error if no matching command is found.</li>
+ * </ul>
+ *
+ * <p>The command list is derived from the registry snapshot at the time the
+ * command is executed, so newly registered commands are visible immediately.
+ */
+public class HelpCommand extends RegistrableCommand {
+
+    private final SocketCommandRegistry registry;
+
+    /**
+     * Creates a {@code HelpCommand} and registers it with the given registry.
+     *
+     * @param registry the registry that this command is part of
+     */
+    public HelpCommand(SocketCommandRegistry registry) {
+        super(registry);
+        this.registry = registry;
+    }
+
+    @Override
+    public String name() {
+        return "help";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "List available commands or describe a specific command. Aliases: H";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: HELP  |  HELP <command>\n"
+             + "  HELP          — show a sorted list of all commands with short descriptions.\n"
+             + "  HELP <name>   — show the full description for the named command.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        String token = parts[0];
+        if (!"HELP".equals(token) && !"H".equals(token)) {
+            return Optional.empty();
+        }
+        String arg = parts[1].trim();
+        if (arg.isBlank()) {
+            return Optional.of(new SocketCommandMatch(this, this::handleListAll));
+        }
+        String target = arg;
+        return Optional.of(new SocketCommandMatch(this, context -> handleDetail(context, target)));
+    }
+
+    /**
+     * Sends a sorted list of all commands with their short descriptions.
+     */
+    private void handleListAll(SocketCommandContext context) {
+        List<SocketCommandHandler> sorted = registry.commands().stream()
+                .sorted(Comparator.comparing(SocketCommandHandler::name))
+                .toList();
+
+        context.writeLineSafe("Available commands:");
+        for (SocketCommandHandler handler : sorted) {
+            String short_ = handler.shortDescription();
+            if (short_.isBlank()) {
+                context.writeLineSafe("  " + handler.name());
+            } else {
+                context.writeLineSafe(String.format("  %-12s %s", handler.name(), short_));
+            }
+        }
+        context.sendPrompt();
+    }
+
+    /**
+     * Sends the long description for the named command, or an error message.
+     *
+     * @param context the command execution context
+     * @param name    the command name to look up (case-insensitive)
+     */
+    private void handleDetail(SocketCommandContext context, String name) {
+        String lower = name.toLowerCase();
+        Optional<SocketCommandHandler> found = registry.commands().stream()
+                .filter(h -> h.name().equalsIgnoreCase(lower))
+                .findFirst();
+
+        if (found.isEmpty()) {
+            context.writeLineWithPrompt("No help available for '" + name + "'.");
+            return;
+        }
+        SocketCommandHandler handler = found.get();
+        String desc = handler.longDescription();
+        if (desc.isBlank()) {
+            context.writeLineWithPrompt("No detailed help available for '" + handler.name() + "'.");
+            return;
+        }
+        for (String line : desc.split("\n", -1)) {
+            context.writeLineSafe(line);
+        }
+        context.sendPrompt();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/KillCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/KillCommand.java
@@ -16,6 +16,17 @@ public class KillCommand extends RegistrableCommand {
     }
 
     @Override
+    public String shortDescription() {
+        return "Attack a mob in the same room. Aliases: K";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: KILL <target>  |  K <target>\n"
+             + "  Initiates combat against the named mob in your current room.";
+    }
+
+    @Override
     public Optional<SocketCommandMatch> match(String input) {
         String[] parts = SocketCommandParsing.splitInput(input);
         String token = parts[0];

--- a/src/main/java/io/taanielo/jmud/core/server/socket/LookCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/LookCommand.java
@@ -16,6 +16,18 @@ public class LookCommand extends RegistrableCommand {
     }
 
     @Override
+    public String shortDescription() {
+        return "Examine your surroundings or a target. Aliases: L";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: LOOK  |  LOOK <target>\n"
+             + "  LOOK        — describe the current room, its exits, and visible occupants.\n"
+             + "  LOOK <name> — examine a specific player or object in the room.";
+    }
+
+    @Override
     public Optional<SocketCommandMatch> match(String input) {
         String[] parts = SocketCommandParsing.splitInput(input);
         String token = parts[0];

--- a/src/main/java/io/taanielo/jmud/core/server/socket/ScoreCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/ScoreCommand.java
@@ -22,6 +22,18 @@ public class ScoreCommand extends RegistrableCommand {
     }
 
     @Override
+    public String shortDescription() {
+        return "Display your level, XP, and current vitals. Aliases: SC";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: SCORE\n"
+             + "  Shows your current level, experience points, HP, Mana, and Move.\n"
+             + "  Alias: SC";
+    }
+
+    @Override
     public Optional<SocketCommandMatch> match(String input) {
         String token = SocketCommandParsing.firstToken(input);
         if (!"SCORE".equals(token) && !"SC".equals(token)) {

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandHandler.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandHandler.java
@@ -13,6 +13,27 @@ public interface SocketCommandHandler {
     String name();
 
     /**
+     * Returns a one-line description shown in the {@code HELP} command listing.
+     *
+     * <p>Implementors should override this to provide a meaningful summary.
+     * The default returns an empty string so existing commands need no changes.
+     */
+    default String shortDescription() {
+        return "";
+    }
+
+    /**
+     * Returns a multi-line description shown when the player asks for
+     * {@code HELP <name>}.
+     *
+     * <p>Implementors should override this to explain usage and aliases.
+     * The default falls back to the {@link #shortDescription()}.
+     */
+    default String longDescription() {
+        return shortDescription();
+    }
+
+    /**
      * Attempts to match the raw input and produce an executable match.
      */
     Optional<SocketCommandMatch> match(String input);

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -32,6 +32,7 @@ public class SocketCommandRegistry {
         new KillCommand(registry);
         new AnsiCommand(registry);
         new QuitCommand(registry);
+        new HelpCommand(registry);
         return registry;
     }
 

--- a/src/main/java/io/taanielo/jmud/core/server/socket/WhoCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/WhoCommand.java
@@ -24,6 +24,17 @@ public class WhoCommand extends RegistrableCommand {
     }
 
     @Override
+    public String shortDescription() {
+        return "List all players currently online.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: WHO\n"
+             + "  Displays a list of every authenticated player connected to the server.";
+    }
+
+    @Override
     public Optional<SocketCommandMatch> match(String input) {
         String token = SocketCommandParsing.firstToken(input);
         if (!"WHO".equals(token)) {

--- a/src/test/java/io/taanielo/jmud/core/server/socket/HelpCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/HelpCommandTest.java
@@ -1,0 +1,171 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Unit tests for {@link HelpCommand}.
+ */
+class HelpCommandTest {
+
+    @Test
+    void matchesHelpToken() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        HelpCommand command = new HelpCommand(registry);
+
+        assertTrue(command.match("HELP").isPresent());
+        assertTrue(command.match("help").isPresent());
+    }
+
+    @Test
+    void matchesHAlias() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        HelpCommand command = new HelpCommand(registry);
+
+        assertTrue(command.match("H").isPresent());
+        assertTrue(command.match("h").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        HelpCommand command = new HelpCommand(registry);
+
+        assertFalse(command.match("look").isPresent());
+        assertFalse(command.match("who").isPresent());
+        assertFalse(command.match("").isPresent());
+    }
+
+    @Test
+    void listingIsSortedAlphabetically() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        // Register stub commands in non-alphabetical order.
+        registry.register(stubCommand("zebra", "Does zebra things"));
+        registry.register(stubCommand("alpha", "Does alpha things"));
+        registry.register(stubCommand("mango", "Does mango things"));
+        HelpCommand help = new HelpCommand(registry);
+
+        CapturingContext context = new CapturingContext();
+        help.match("HELP").get().execute(context);
+
+        // Extract names from the output lines (skip header line).
+        List<String> outputLines = context.lines;
+        assertTrue(outputLines.get(0).startsWith("Available commands:"),
+                "First line should be the header");
+
+        // Command lines start with two spaces followed by the name.
+        List<String> commandLines = outputLines.stream()
+                .filter(l -> l.startsWith("  "))
+                .toList();
+
+        // "alpha", "help", "mango", "zebra" (help itself is registered too)
+        assertEquals("alpha", commandLines.get(0).trim().split("\\s+")[0]);
+        assertEquals("help",  commandLines.get(1).trim().split("\\s+")[0]);
+        assertEquals("mango", commandLines.get(2).trim().split("\\s+")[0]);
+        assertEquals("zebra", commandLines.get(3).trim().split("\\s+")[0]);
+    }
+
+    @Test
+    void listingReflectsRegistryContents() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        registry.register(stubCommand("foo", "Does foo"));
+        registry.register(stubCommand("bar", "Does bar"));
+        HelpCommand help = new HelpCommand(registry);
+
+        CapturingContext context = new CapturingContext();
+        help.match("HELP").get().execute(context);
+
+        String combined = String.join("\n", context.lines);
+        assertTrue(combined.contains("foo"), "Output should mention 'foo'");
+        assertTrue(combined.contains("bar"), "Output should mention 'bar'");
+        assertTrue(combined.contains("help"), "Output should mention 'help' itself");
+    }
+
+    @Test
+    void detailShowsLongDescriptionForKnownCommand() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        registry.register(stubCommand("foo", "Short foo", "Long foo description\nSecond line"));
+        HelpCommand help = new HelpCommand(registry);
+
+        CapturingContext context = new CapturingContext();
+        help.match("HELP foo").get().execute(context);
+
+        String combined = String.join("\n", context.lines);
+        assertTrue(combined.contains("Long foo description"), "Should show long description");
+        assertTrue(combined.contains("Second line"), "Should show all lines of long description");
+    }
+
+    @Test
+    void detailReturnsErrorForUnknownCommand() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        HelpCommand help = new HelpCommand(registry);
+
+        CapturingContext context = new CapturingContext();
+        help.match("HELP unknowncmd").get().execute(context);
+
+        assertFalse(context.promptMessage.isBlank(),
+                "Should write an error message via writeLineWithPrompt");
+        assertTrue(context.promptMessage.contains("unknowncmd"));
+    }
+
+    // --- helpers ---
+
+    private static SocketCommandHandler stubCommand(String name, String shortDesc) {
+        return stubCommand(name, shortDesc, shortDesc);
+    }
+
+    private static SocketCommandHandler stubCommand(String name, String shortDesc, String longDesc) {
+        return new SocketCommandHandler() {
+            @Override public String name() { return name; }
+            @Override public String shortDescription() { return shortDesc; }
+            @Override public String longDescription() { return longDesc; }
+            @Override public Optional<SocketCommandMatch> match(String input) { return Optional.empty(); }
+        };
+    }
+
+    private static class CapturingContext implements SocketCommandContext {
+        final List<String> lines = new ArrayList<>();
+        String promptMessage = "";
+
+        @Override public boolean isAuthenticated() { return true; }
+        @Override public Player getPlayer() { return null; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) { promptMessage = m; }
+        @Override public void writeLineSafe(String m) { lines.add(m); }
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) {}
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}


### PR DESCRIPTION
## Summary
- New `HelpCommand` handles `HELP`/`H` — lists all registered commands sorted alphabetically with short descriptions
- `HELP <name>` shows long description for a specific command
- Added `shortDescription()` and `longDescription()` default methods to `SocketCommandHandler` (no breaking changes)
- Wired descriptions into LOOK, SCORE, KILL, GET, WHO as examples

Closes #101

## Test plan
- [ ] Build passes (`./gradlew build`)
- [ ] `HELP` lists all commands alphabetically
- [ ] `HELP look` shows LOOK's long description
- [ ] `HELP unknown` shows an error message
- [ ] `H` alias works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)