### PR TITLE
feat(server): add TELL command for private cross-room player messaging

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -25,6 +25,7 @@ public class SocketCommandRegistry {
         new InventoryCommand(registry);
         new EquipmentCommand(registry);
         new SayCommand(registry);
+        new TellCommand(registry);
         new WhoCommand(registry);
         new ScoreCommand(registry);
         new AbilityCommand(registry);

--- a/src/main/java/io/taanielo/jmud/core/server/socket/TellCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/TellCommand.java
@@ -1,0 +1,95 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+
+/**
+ * Handles the {@code TELL} / {@code T} command, which sends a private message
+ * to another online player regardless of their current room.
+ *
+ * <p>Usage: {@code TELL <playername> <message>}
+ *
+ * <p>The sender sees: {@code You tell <Name>: <message>}
+ * <br>The recipient sees: {@code <Name> tells you: <message>}
+ *
+ * <p>Errors are reported to the sender when the target player is not online,
+ * or when the command is invoked without sufficient arguments.
+ */
+public class TellCommand extends RegistrableCommand {
+
+    /**
+     * Creates a {@code TellCommand} and registers it with the given registry.
+     *
+     * @param registry the registry to register this command with
+     */
+    public TellCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "tell";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Send a private message to an online player. Aliases: T";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: TELL <playername> <message>\n"
+             + "  Sends a private message to the named player, wherever they are.\n"
+             + "  The recipient sees: <YourName> tells you: <message>\n"
+             + "  Aliases: T";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        String token = parts[0];
+        if (!"TELL".equals(token) && !"T".equals(token)) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> handleTell(context, args)));
+    }
+
+    private void handleTell(SocketCommandContext context, String args) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to send tells.");
+            return;
+        }
+        if (args.isBlank()) {
+            context.writeLineWithPrompt("Usage: TELL <playername> <message>");
+            return;
+        }
+        String[] argParts = args.split("\\s+", 2);
+        String targetName = argParts[0];
+        if (argParts.length < 2 || argParts[1].isBlank()) {
+            context.writeLineWithPrompt("Usage: TELL <playername> <message>");
+            return;
+        }
+        String message = argParts[1].trim();
+
+        Player sender = context.getPlayer();
+        String senderName = sender.getUsername().getValue();
+
+        // Find the target among online players (case-insensitive).
+        Username targetUsername = context.onlinePlayerNames().stream()
+                .filter(u -> u.equals(Username.of(targetName)))
+                .findFirst()
+                .orElse(null);
+
+        if (targetUsername == null) {
+            context.writeLineWithPrompt(targetName + " is not online.");
+            return;
+        }
+
+        context.sendToUsername(targetUsername, senderName + " tells you: " + message);
+        context.writeLineSafe("You tell " + targetUsername.getValue() + ": " + message);
+        context.sendPrompt();
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/TellCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/TellCommandTest.java
@@ -1,0 +1,176 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Unit tests for {@link TellCommand}.
+ */
+class TellCommandTest {
+
+    // --- token matching ---
+
+    @Test
+    void matchesTellToken() {
+        TellCommand cmd = new TellCommand(new SocketCommandRegistry());
+        assertTrue(cmd.match("TELL taaniel hello").isPresent());
+        assertTrue(cmd.match("tell taaniel hello").isPresent());
+    }
+
+    @Test
+    void matchesTAlias() {
+        TellCommand cmd = new TellCommand(new SocketCommandRegistry());
+        assertTrue(cmd.match("T taaniel hello").isPresent());
+        assertTrue(cmd.match("t taaniel hello").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        TellCommand cmd = new TellCommand(new SocketCommandRegistry());
+        assertFalse(cmd.match("SAY hello").isPresent());
+        assertFalse(cmd.match("WHO").isPresent());
+        assertFalse(cmd.match("").isPresent());
+    }
+
+    // --- delivery ---
+
+    @Test
+    void deliversTellToRecipient() {
+        CapturingContext context = new CapturingContext("Sender");
+        context.addOnlinePlayer("Recipient");
+
+        TellCommand cmd = new TellCommand(new SocketCommandRegistry());
+        cmd.match("TELL Recipient hello there").get().execute(context);
+
+        assertEquals("Sender tells you: hello there",
+                context.sentToUsername.get("recipient"),
+                "Recipient should receive the formatted tell message");
+    }
+
+    @Test
+    void senderSeesConfirmation() {
+        CapturingContext context = new CapturingContext("Sender");
+        context.addOnlinePlayer("Recipient");
+
+        TellCommand cmd = new TellCommand(new SocketCommandRegistry());
+        cmd.match("TELL Recipient hello there").get().execute(context);
+
+        assertTrue(context.lines.stream().anyMatch(l -> l.equals("You tell Recipient: hello there")),
+                "Sender should see confirmation line");
+    }
+
+    @Test
+    void playerNotOnlineReturnsError() {
+        CapturingContext context = new CapturingContext("Sender");
+        // No players added — target is offline.
+
+        TellCommand cmd = new TellCommand(new SocketCommandRegistry());
+        cmd.match("TELL Ghost hello").get().execute(context);
+
+        assertTrue(context.promptMessage.contains("Ghost") && context.promptMessage.contains("not online"),
+                "Error message should name the missing player");
+    }
+
+    @Test
+    void missingMessageReturnsUsageError() {
+        CapturingContext context = new CapturingContext("Sender");
+        context.addOnlinePlayer("Recipient");
+
+        TellCommand cmd = new TellCommand(new SocketCommandRegistry());
+        cmd.match("TELL Recipient").get().execute(context);
+
+        assertFalse(context.promptMessage.isBlank(), "Usage error should be written via writeLineWithPrompt");
+        assertTrue(context.promptMessage.contains("Usage"), "Error should mention usage");
+    }
+
+    @Test
+    void missingAllArgsReturnsUsageError() {
+        CapturingContext context = new CapturingContext("Sender");
+
+        TellCommand cmd = new TellCommand(new SocketCommandRegistry());
+        cmd.match("TELL").get().execute(context);
+
+        assertFalse(context.promptMessage.isBlank(), "Usage error should be written via writeLineWithPrompt");
+        assertTrue(context.promptMessage.contains("Usage"), "Error should mention usage");
+    }
+
+    @Test
+    void targetLookupIsCaseInsensitive() {
+        CapturingContext context = new CapturingContext("Sender");
+        context.addOnlinePlayer("TAANIEL");
+
+        TellCommand cmd = new TellCommand(new SocketCommandRegistry());
+        cmd.match("TELL taaniel hi").get().execute(context);
+
+        assertFalse(context.sentToUsername.isEmpty(),
+                "Tell should be delivered even when case differs");
+    }
+
+    // --- helpers ---
+
+    private static Player stubPlayer(String name) {
+        User user = User.of(Username.of(name), Password.hash("secret"));
+        return Player.of(user, "%h/%H hp>");
+    }
+
+    private static class CapturingContext implements SocketCommandContext {
+        final List<String> lines = new ArrayList<>();
+        String promptMessage = "";
+        final Map<String, String> sentToUsername = new HashMap<>();
+        private final List<Username> onlinePlayers = new ArrayList<>();
+        private final Player player;
+
+        CapturingContext(String senderName) {
+            this.player = stubPlayer(senderName);
+        }
+
+        void addOnlinePlayer(String name) {
+            onlinePlayers.add(Username.of(name));
+        }
+
+        @Override public boolean isAuthenticated() { return true; }
+        @Override public Player getPlayer() { return player; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.copyOf(onlinePlayers); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) { promptMessage = m; }
+        @Override public void writeLineSafe(String m) { lines.add(m); }
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) { sentToUsername.put(u.getValue().toLowerCase(), m); }
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}


### PR DESCRIPTION
## Summary
- New `TellCommand` handles `TELL`/`T` — sends a private message to any online player regardless of room
- Sender sees: `You tell Taaniel: hello`
- Recipient sees: `Taaniel tells you: hello`
- Errors for offline target or missing message

Closes #103

## Test plan
- [ ] Build passes (`./gradlew build`)
- [ ] `TELL <player> <message>` delivers privately to the target
- [ ] Sender receives confirmation
- [ ] `TELL <offline>` returns error
- [ ] `T` alias works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)