### PR TITLE
feat(items): wire QUAFF hp stat so potions heal or damage the player

### DIFF
--- a/data/items/health-potion.json
+++ b/data/items/health-potion.json
@@ -4,7 +4,9 @@
   "name": "Health Potion",
   "description": "A small red vial that restores a bit of vitality.",
   "attributes": {
-    "stats": {}
+    "stats": {
+      "hp": 20
+    }
   },
   "effects": [],
   "messages": [

--- a/data/items/poisonous-potion.json
+++ b/data/items/poisonous-potion.json
@@ -4,7 +4,9 @@
   "name": "Poisonous Potion",
   "description": "A cloudy green vial that smells faintly of rot.",
   "attributes": {
-    "stats": {}
+    "stats": {
+      "hp": -10
+    }
   },
   "effects": [
     {

--- a/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
+++ b/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
@@ -30,6 +30,7 @@ import io.taanielo.jmud.core.messaging.MessagePhase;
 import io.taanielo.jmud.core.player.EncumbranceService;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerEquipment;
+import io.taanielo.jmud.core.player.PlayerVitals;
 import io.taanielo.jmud.core.world.EquipmentSlot;
 import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.ItemEffect;
@@ -263,7 +264,12 @@ public class GameActionService {
     }
 
     /**
-     * Consumes an item from inventory, applying its effects to the player.
+     * Consumes an item from inventory, applying its hp stat and any item effects to the player.
+     *
+     * <p>A positive {@code hp} stat in {@link io.taanielo.jmud.core.world.ItemAttributes} heals
+     * the player (capped at max HP); a negative value deals damage. Item effects such as
+     * poison are applied after the stat change. An item that has neither an {@code hp} stat
+     * nor any effects results in a "Nothing happens." message.
      *
      * @param source the player quaffing the item
      * @param itemInput the item name or id to quaff
@@ -278,28 +284,38 @@ public class GameActionService {
         if (item == null) {
             return GameActionResult.error("You aren't carrying that.");
         }
-        if (item.getEffects().isEmpty()) {
+        int hpDelta = item.getAttributes().getStats().getOrDefault("hp", 0);
+        boolean hasHpStat = hpDelta != 0;
+        if (!hasHpStat && item.getEffects().isEmpty()) {
             return GameActionResult.error("Nothing happens.");
         }
+        // Apply hp stat: positive heals, negative damages
+        PlayerVitals vitals = source.getVitals();
+        if (hpDelta > 0) {
+            vitals = vitals.heal(hpDelta);
+        } else if (hpDelta < 0) {
+            vitals = vitals.damage(-hpDelta);
+        }
+        Player working = source.withVitals(vitals);
         CollectingEffectMessageSink effectSink = new CollectingEffectMessageSink(
             source.getUsername(),
             source.getUsername()
         );
         try {
             for (ItemEffect effect : item.getEffects()) {
-                abilityEffectEngine.apply(source, effect.id(), effectSink);
+                abilityEffectEngine.apply(working, effect.id(), effectSink);
             }
         } catch (EffectRepositoryException e) {
             return GameActionResult.error("You cannot use that item right now.");
         }
-        PlayerEquipment equipment = source.getEquipment();
+        PlayerEquipment equipment = working.getEquipment();
         if (equipment.isEquipped(item.getId())) {
             EquipmentSlot slot = equipment.equippedSlot(item.getId());
             if (slot != null) {
                 equipment = equipment.unequip(slot);
             }
         }
-        Player updated = source.removeItem(item).withEquipment(equipment);
+        Player updated = working.removeItem(item).withEquipment(equipment);
         List<GameMessage> messages = new ArrayList<>();
         MessageContext context = new MessageContext(
             source.getUsername(),

--- a/src/main/java/io/taanielo/jmud/core/server/socket/QuaffCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/QuaffCommand.java
@@ -3,7 +3,9 @@ package io.taanielo.jmud.core.server.socket;
 import java.util.Optional;
 
 /**
- * Handles quaff commands.
+ * Handles quaff commands, allowing players to consume potions and other drinkable items.
+ *
+ * <p>Accepted tokens: {@code QUAFF} and the abbreviation {@code QU}.
  */
 public class QuaffCommand extends RegistrableCommand {
     public QuaffCommand(SocketCommandRegistry registry) {
@@ -16,9 +18,22 @@ public class QuaffCommand extends RegistrableCommand {
     }
 
     @Override
+    public String shortDescription() {
+        return "Drink a potion from your inventory.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: QUAFF <item>  (alias: QU)\n"
+             + "  Consumes the named item from your inventory, applying its effects\n"
+             + "  immediately. Healing potions restore HP; poisonous potions deal damage.";
+    }
+
+    @Override
     public Optional<SocketCommandMatch> match(String input) {
         String[] parts = SocketCommandParsing.splitInput(input);
-        if (!"QUAFF".equals(parts[0])) {
+        String token = parts[0];
+        if (!"QUAFF".equals(token) && !"QU".equals(token)) {
             return Optional.empty();
         }
         String args = parts[1];

--- a/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
@@ -356,6 +356,90 @@ class GameActionServiceTest {
     }
 
     @Test
+    void quaffItemHealsPlayerWhenHpStatIsPositive() {
+        PlayerVitals lowVitals = new PlayerVitals(5, 20, 20, 20, 20, 20);
+        Player injured = new Player(
+            User.of(Username.of("attacker"), Password.hash("pw", 1000)),
+            1, 0, lowVitals, List.of(), "prompt", false,
+            List.of(), null, null
+        );
+        Item healthPotion = new Item(
+            ItemId.of("health-potion"),
+            "Health Potion",
+            "A small red vial.",
+            new ItemAttributes(Map.of("hp", 20)),
+            List.of(),
+            List.of(
+                new io.taanielo.jmud.core.messaging.MessageSpec(
+                    io.taanielo.jmud.core.messaging.MessagePhase.QUAFF,
+                    io.taanielo.jmud.core.messaging.MessageChannel.SELF,
+                    "You quaff {item}."
+                )
+            ),
+            null,
+            1,
+            15,
+            null
+        );
+        Player withPotion = injured.addItem(healthPotion);
+
+        GameActionResult result = service.quaffItem(withPotion, "health-potion");
+
+        assertEquals(20, result.updatedSource().getVitals().hp());
+        assertTrue(result.updatedSource().getInventory().isEmpty());
+    }
+
+    @Test
+    void quaffItemHpHealingIsCappedAtMaxHp() {
+        // Player is already at full HP (20/20); heal(20) should stay at 20
+        Item healthPotion = new Item(
+            ItemId.of("health-potion"),
+            "Health Potion",
+            "A small red vial.",
+            new ItemAttributes(Map.of("hp", 20)),
+            List.of(),
+            List.of(),
+            null,
+            1,
+            15,
+            null
+        );
+        Player withPotion = attacker.addItem(healthPotion);
+
+        GameActionResult result = service.quaffItem(withPotion, "health-potion");
+
+        assertEquals(20, result.updatedSource().getVitals().hp());
+    }
+
+    @Test
+    void quaffItemDamagesPlayerWhenHpStatIsNegative() {
+        Item poisonPotion = new Item(
+            ItemId.of("poisonous-potion"),
+            "Poisonous Potion",
+            "A cloudy green vial.",
+            new ItemAttributes(Map.of("hp", -10)),
+            List.of(),
+            List.of(
+                new io.taanielo.jmud.core.messaging.MessageSpec(
+                    io.taanielo.jmud.core.messaging.MessagePhase.QUAFF,
+                    io.taanielo.jmud.core.messaging.MessageChannel.SELF,
+                    "You quaff {item}."
+                )
+            ),
+            null,
+            1,
+            5,
+            null
+        );
+        Player withPotion = attacker.addItem(poisonPotion);
+
+        GameActionResult result = service.quaffItem(withPotion, "poisonous-potion");
+
+        assertEquals(10, result.updatedSource().getVitals().hp());
+        assertTrue(result.updatedSource().getInventory().isEmpty());
+    }
+
+    @Test
     void resolveDeathIfNeededDoesNothingWhenAlive() {
         GameActionResult result = service.resolveDeathIfNeeded(target, attacker);
 

--- a/src/test/java/io/taanielo/jmud/core/server/socket/QuaffCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/QuaffCommandTest.java
@@ -1,0 +1,131 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Unit tests for {@link QuaffCommand}.
+ */
+class QuaffCommandTest {
+
+    private QuaffCommand command;
+
+    @BeforeEach
+    void setUp() {
+        command = new QuaffCommand(new SocketCommandRegistry());
+    }
+
+    @Test
+    void matchesQuaffToken() {
+        assertTrue(command.match("QUAFF potion").isPresent());
+        assertTrue(command.match("quaff potion").isPresent());
+    }
+
+    @Test
+    void matchesQuAlias() {
+        assertTrue(command.match("QU potion").isPresent());
+        assertTrue(command.match("qu potion").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        assertFalse(command.match("get potion").isPresent());
+        assertFalse(command.match("drop potion").isPresent());
+        assertFalse(command.match("").isPresent());
+    }
+
+    @Test
+    void passesArgsToContext() {
+        AtomicReference<String> captured = new AtomicReference<>();
+        CapturingContext context = new CapturingContext(captured);
+
+        Optional<SocketCommandMatch> match = command.match("QUAFF health-potion");
+        assertTrue(match.isPresent());
+        match.get().execute(context);
+
+        assertEquals("health-potion", captured.get());
+    }
+
+    @Test
+    void passesArgsToContextViaAlias() {
+        AtomicReference<String> captured = new AtomicReference<>();
+        CapturingContext context = new CapturingContext(captured);
+
+        Optional<SocketCommandMatch> match = command.match("QU health-potion");
+        assertTrue(match.isPresent());
+        match.get().execute(context);
+
+        assertEquals("health-potion", captured.get());
+    }
+
+    @Test
+    void hasShortDescription() {
+        assertNotNull(command.shortDescription());
+        assertFalse(command.shortDescription().isBlank());
+    }
+
+    @Test
+    void hasLongDescription() {
+        assertNotNull(command.longDescription());
+        assertTrue(command.longDescription().contains("QUAFF"));
+        assertTrue(command.longDescription().contains("QU"));
+    }
+
+    @Test
+    void nameIsQuaff() {
+        assertEquals("quaff", command.name());
+    }
+
+    // --- helpers ---
+
+    private static class CapturingContext implements SocketCommandContext {
+        private final AtomicReference<String> captured;
+
+        CapturingContext(AtomicReference<String> captured) {
+            this.captured = captured;
+        }
+
+        @Override public void quaffItem(String args) { captured.set(args); }
+        @Override public boolean isAuthenticated() { return true; }
+        @Override public Player getPlayer() { return null; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) {}
+        @Override public void writeLineSafe(String m) {}
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) {}
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}


### PR DESCRIPTION
## Summary
- `health-potion.json` gets `hp: 20`, `poisonous-potion.json` gets `hp: -10` in `attributes.stats`
- `GameActionService.quaffItem` now reads the `hp` stat and applies heal (capped at maxHp) or damage
- `QuaffCommand` gets `QU` alias plus `shortDescription`/`longDescription`
- Tests cover heal, damage, and HP cap behaviour

Closes #105

## Test plan
- [ ] Build passes (`./gradlew build`)
- [ ] `QUAFF health-potion` restores HP (capped at max)
- [ ] `QUAFF poisonous-potion` reduces HP
- [ ] `QU` alias works
- [ ] Empty inventory returns an error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)