### PR TITLE
feat(items): add EXAMINE command to read item descriptions

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/ExamineCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/ExamineCommand.java
@@ -1,0 +1,47 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the EXAMINE command, letting players read an item's full description,
+ * equipment slot, and stat bonuses.
+ *
+ * <p>Aliases: {@code EX}, {@code EXAM}.
+ * <p>The command searches the player's inventory first, then the items on the
+ * floor of the current room.
+ */
+public class ExamineCommand extends RegistrableCommand {
+
+    public ExamineCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "examine";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Read the description of an item in your inventory or room. Aliases: EX, EXAM";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: EXAMINE <item>  |  EX <item>  |  EXAM <item>\n"
+             + "  Displays the full description, equipment slot (if any), and stat bonuses\n"
+             + "  for an item found in your inventory or on the floor of the current room.\n"
+             + "  Partial name matching is supported (e.g. EXAMINE ir matches Iron Sword).";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        String token = parts[0];
+        if ("EXAMINE".equals(token) || "EX".equals(token) || "EXAM".equals(token)) {
+            String args = parts[1];
+            return Optional.of(new SocketCommandMatch(this, context -> context.examineItem(args)));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -937,6 +937,65 @@ public class SocketClient implements Client {
             }
             sendPrompt();
         }
+
+        @Override
+        public void examineItem(String args) {
+            Player player = session.getPlayer();
+            if (!session.isAuthenticated() || player == null) {
+                writeLineWithPrompt("You must be logged in to examine items.");
+                return;
+            }
+            if (args == null || args.isBlank()) {
+                writeLineWithPrompt("Examine what?");
+                return;
+            }
+            // Search inventory first, then room items.
+            Item found = matchItemByName(player.getInventory(), args);
+            if (found == null) {
+                RoomService.LookResult look = roomService.look(player.getUsername());
+                if (look.room() != null) {
+                    found = matchItemByName(look.room().getItems(), args);
+                }
+            }
+            if (found == null) {
+                writeLineWithPrompt("You don't see '" + args.trim() + "' here.");
+                return;
+            }
+            connection.writeLine(found.getName());
+            connection.writeLine(found.getDescription());
+            if (found.getEquipSlot() != null) {
+                connection.writeLine("Slot: " + found.getEquipSlot().id());
+            }
+            if (found.getAttributes() != null && !found.getAttributes().getStats().isEmpty()) {
+                StringBuilder sb = new StringBuilder("Stats:");
+                found.getAttributes().getStats().entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(e -> sb.append(" ").append(e.getKey()).append(" +").append(e.getValue()));
+                connection.writeLine(sb.toString());
+            }
+            sendPrompt();
+        }
+    }
+
+    // ── Item helpers ───────────────────────────────────────────────────
+
+    /**
+     * Returns the first item in the list whose name or id starts with (or equals)
+     * the normalised input, or {@code null} when no match is found.
+     */
+    private static Item matchItemByName(List<Item> items, String input) {
+        String normalized = input.trim().toLowerCase(java.util.Locale.ROOT);
+        for (Item item : items) {
+            String name = item.getName().toLowerCase(java.util.Locale.ROOT);
+            if (name.equals(normalized) || name.startsWith(normalized)) {
+                return item;
+            }
+            String id = item.getId().getValue().toLowerCase(java.util.Locale.ROOT);
+            if (id.equals(normalized) || id.startsWith(normalized)) {
+                return item;
+            }
+        }
+        return null;
     }
 
     // ── Audit helpers ──────────────────────────────────────────────────

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -141,4 +141,9 @@ public interface SocketCommandContext extends Client {
      */
     void sendEquipment();
 
+    /**
+     * Examines an item by name, searching the player's inventory then the current room.
+     */
+    default void examineItem(String args) {}
+
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -16,6 +16,7 @@ public class SocketCommandRegistry {
     public static SocketCommandRegistry createDefault() {
         SocketCommandRegistry registry = new SocketCommandRegistry();
         new LookCommand(registry);
+        new ExamineCommand(registry);
         new MoveCommand(registry);
         new GetCommand(registry);
         new DropCommand(registry);

--- a/src/test/java/io/taanielo/jmud/core/server/socket/ExamineCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/ExamineCommandTest.java
@@ -1,0 +1,164 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Unit tests for {@link ExamineCommand}.
+ */
+class ExamineCommandTest {
+
+    private ExamineCommand command;
+
+    @BeforeEach
+    void setUp() {
+        command = new ExamineCommand(new SocketCommandRegistry());
+    }
+
+    @Test
+    void matchesExamineToken() {
+        assertTrue(command.match("EXAMINE sword").isPresent());
+        assertTrue(command.match("examine sword").isPresent());
+    }
+
+    @Test
+    void matchesExAlias() {
+        assertTrue(command.match("EX sword").isPresent());
+        assertTrue(command.match("ex sword").isPresent());
+    }
+
+    @Test
+    void matchesExamAlias() {
+        assertTrue(command.match("EXAM sword").isPresent());
+        assertTrue(command.match("exam sword").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        assertFalse(command.match("look sword").isPresent());
+        assertFalse(command.match("get sword").isPresent());
+        assertFalse(command.match("").isPresent());
+    }
+
+    @Test
+    void passesArgsToContext() {
+        AtomicReference<String> captured = new AtomicReference<>();
+        CapturingContext context = new CapturingContext(captured);
+
+        Optional<SocketCommandMatch> match = command.match("EXAMINE iron-sword");
+        assertTrue(match.isPresent());
+        match.get().execute(context);
+
+        assertEquals("iron-sword", captured.get());
+    }
+
+    @Test
+    void passesArgsViaExAlias() {
+        AtomicReference<String> captured = new AtomicReference<>();
+        CapturingContext context = new CapturingContext(captured);
+
+        Optional<SocketCommandMatch> match = command.match("EX iron-sword");
+        assertTrue(match.isPresent());
+        match.get().execute(context);
+
+        assertEquals("iron-sword", captured.get());
+    }
+
+    @Test
+    void passesArgsViaExamAlias() {
+        AtomicReference<String> captured = new AtomicReference<>();
+        CapturingContext context = new CapturingContext(captured);
+
+        Optional<SocketCommandMatch> match = command.match("EXAM health-potion");
+        assertTrue(match.isPresent());
+        match.get().execute(context);
+
+        assertEquals("health-potion", captured.get());
+    }
+
+    @Test
+    void passesBlankArgsWhenNoTarget() {
+        AtomicReference<String> captured = new AtomicReference<>();
+        CapturingContext context = new CapturingContext(captured);
+
+        Optional<SocketCommandMatch> match = command.match("EXAMINE");
+        assertTrue(match.isPresent());
+        match.get().execute(context);
+
+        assertEquals("", captured.get());
+    }
+
+    @Test
+    void hasShortDescription() {
+        assertNotNull(command.shortDescription());
+        assertFalse(command.shortDescription().isBlank());
+    }
+
+    @Test
+    void longDescriptionMentionsAllAliases() {
+        String desc = command.longDescription();
+        assertNotNull(desc);
+        assertTrue(desc.contains("EXAMINE"));
+        assertTrue(desc.contains("EX"));
+        assertTrue(desc.contains("EXAM"));
+    }
+
+    @Test
+    void nameIsExamine() {
+        assertEquals("examine", command.name());
+    }
+
+    // --- helpers ---
+
+    private static class CapturingContext implements SocketCommandContext {
+        private final AtomicReference<String> captured;
+
+        CapturingContext(AtomicReference<String> captured) {
+            this.captured = captured;
+        }
+
+        @Override public void examineItem(String args) { captured.set(args); }
+        @Override public boolean isAuthenticated() { return true; }
+        @Override public Player getPlayer() { return null; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) {}
+        @Override public void writeLineSafe(String m) {}
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) {}
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}


### PR DESCRIPTION
## Summary
- New `ExamineCommand` handles `EXAMINE`/`EX`/`EXAM` — searches inventory then room items by name
- Shows item name, description, equipment slot (if any), and sorted stat bonuses
- `examineItem` made a `default` method on `SocketCommandContext` so existing test stubs compile without changes
- Build fix included (7 test files were broken by the abstract method addition)

Closes #107

## Test plan
- [ ] Build passes (`./gradlew build`)
- [ ] `EXAMINE iron-sword` shows description and slot while item is in inventory
- [ ] `EXAMINE health-potion` shows description while item is in room
- [ ] `EX` and `EXAM` aliases work
- [ ] Unknown item name returns an error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)