### PR TITLE
feat(combat): add FLEE command so players can escape from active combat

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -365,6 +365,38 @@ public class MobRegistry implements Tickable {
         return Math.max(1, base + attack.damageBonus());
     }
 
+    /**
+     * Disengages a player from combat, clearing their combat target and removing
+     * them from any mob's engaged set. Called when a player successfully flees.
+     *
+     * @param username the player fleeing from combat
+     */
+    public void fleeCombat(Username username) {
+        Objects.requireNonNull(username, "Username is required");
+        UUID mobId = playerCombatTargets.remove(username);
+        if (mobId != null) {
+            MobInstance mob = instances.get(mobId);
+            if (mob != null) {
+                mob.disengage(username);
+            }
+        }
+        // Also disengage from any other mobs that may have engaged this player.
+        for (MobInstance mob : instances.values()) {
+            mob.disengage(username);
+        }
+    }
+
+    /**
+     * Returns whether the given player is currently engaged in combat.
+     *
+     * @param username the player to check
+     * @return {@code true} if the player has an active combat target
+     */
+    public boolean isInCombat(Username username) {
+        Objects.requireNonNull(username, "Username is required");
+        return playerCombatTargets.containsKey(username);
+    }
+
     Collection<MobInstance> allInstances() {
         return instances.values();
     }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/FleeCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/FleeCommand.java
@@ -1,0 +1,40 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the {@code FLEE} command, allowing a player to escape from active combat
+ * by moving to a randomly chosen available exit.
+ */
+public class FleeCommand extends RegistrableCommand {
+
+    public FleeCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "flee";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Escape from combat by fleeing to a random exit. Aliases: FL";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: FLEE  |  FL\n"
+             + "  Attempts to escape from active combat by moving to a randomly chosen exit.\n"
+             + "  You must be in combat to flee. The direction taken is chosen at random.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String token = SocketCommandParsing.splitInput(input)[0];
+        if (!"FLEE".equals(token) && !"FL".equals(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(new SocketCommandMatch(this, SocketCommandContext::fleeCombat));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -2,12 +2,14 @@ package io.taanielo.jmud.core.server.socket;
 
 import java.io.IOException;
 import java.net.SocketException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -41,6 +43,7 @@ import io.taanielo.jmud.core.server.Client;
 import io.taanielo.jmud.core.server.ClientPool;
 import io.taanielo.jmud.core.server.connection.ClientConnection;
 import io.taanielo.jmud.core.server.connection.TransportSecurity;
+import io.taanielo.jmud.core.world.Direction;
 import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.Room;
@@ -906,6 +909,34 @@ public class SocketClient implements Client {
                 .processPlayerAttack(player, args, roomIdOpt.get());
             deliverResult(result);
             sendPrompt();
+        }
+
+        @Override
+        public void fleeCombat() {
+            if (!session.isAuthenticated() || session.getPlayer() == null) {
+                writeLineWithPrompt("You must be logged in to flee.");
+                return;
+            }
+            if (context.mobRegistry() == null) {
+                writeLineWithPrompt("You are not in combat.");
+                return;
+            }
+            Player player = session.getPlayer();
+            if (!context.mobRegistry().isInCombat(player.getUsername())) {
+                writeLineWithPrompt("You are not in combat.");
+                return;
+            }
+            RoomService.LookResult lookResult = roomService.look(player.getUsername());
+            Room currentRoom = lookResult.room();
+            if (currentRoom == null || currentRoom.getExits().isEmpty()) {
+                writeLineWithPrompt("There is nowhere to flee!");
+                return;
+            }
+            List<Direction> exits = new ArrayList<>(currentRoom.getExits().keySet());
+            Direction chosen = exits.get(ThreadLocalRandom.current().nextInt(exits.size()));
+            connection.writeLine("You flee to the " + chosen.label() + "!");
+            context.mobRegistry().fleeCombat(player.getUsername());
+            sendMove(chosen);
         }
 
         @Override

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -146,4 +146,9 @@ public interface SocketCommandContext extends Client {
      */
     default void examineItem(String args) {}
 
+    /**
+     * Attempts to flee from active combat by moving to a random available exit.
+     */
+    void fleeCombat();
+
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -32,6 +32,7 @@ public class SocketCommandRegistry {
         new AbilityCommand(registry);
         new AttackCommand(registry);
         new KillCommand(registry);
+        new FleeCommand(registry);
         new AnsiCommand(registry);
         new QuitCommand(registry);
         new HelpCommand(registry);

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryFleeCombatTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryFleeCombatTest.java
@@ -1,0 +1,204 @@
+package io.taanielo.jmud.core.mob;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.action.GameActionResult;
+import io.taanielo.jmud.core.action.PlayerEventBus;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.combat.AttackDefinition;
+import io.taanielo.jmud.core.combat.AttackId;
+import io.taanielo.jmud.core.combat.CombatSettings;
+import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.combat.repository.AttackRepositoryException;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemAttributes;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.ItemRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Unit tests for {@link MobRegistry#fleeCombat(Username)} and
+ * {@link MobRegistry#isInCombat(Username)}.
+ */
+class MobRegistryFleeCombatTest {
+
+    private static final RoomId ROOM_ID = RoomId.of("room.test");
+    private static final AttackId DEFAULT_ATTACK =
+        AttackId.of(CombatSettings.DEFAULT_ATTACK_ID);
+    private static final AttackDefinition ONE_DMG_ATTACK =
+        new AttackDefinition(DEFAULT_ATTACK, "punch", 1, 1, 0, 0, 0, List.of());
+
+    private Player player(String name) {
+        User user = User.of(Username.of(name), Password.hash("pw", 1));
+        return Player.of(user, "%hp> ");
+    }
+
+    private MobRegistry buildRegistryWithMob(Player attacker, int mobHp) {
+        MobTemplate template = new MobTemplate(
+            MobId.of("mob.goblin"),
+            "Goblin",
+            mobHp,
+            null,
+            false,
+            List.of(),
+            ROOM_ID,
+            1,
+            10,
+            5
+        );
+        MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
+        AttackRepository attackRepo = new StubAttackRepository(Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));
+        ItemRepository itemRepo = new StubItemRepository(Map.of());
+
+        RoomService roomService = new RoomService(new StubRoomRepository(ROOM_ID), ROOM_ID);
+        roomService.ensurePlayerLocation(attacker.getUsername());
+
+        PlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        PlayerEventBus bus = new PlayerEventBus();
+
+        MobRegistry registry = new MobRegistry(
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo, bus);
+        registry.init();
+        return registry;
+    }
+
+    @Test
+    void isInCombat_returnsFalse_whenPlayerHasNotAttacked() {
+        Player attacker = player("hero");
+        MobRegistry registry = buildRegistryWithMob(attacker, 100);
+
+        assertFalse(registry.isInCombat(attacker.getUsername()),
+            "Player should not be in combat before attacking");
+    }
+
+    @Test
+    void isInCombat_returnsTrue_afterPlayerAttacks() {
+        Player attacker = player("hero");
+        MobRegistry registry = buildRegistryWithMob(attacker, 100);
+
+        registry.processPlayerAttack(attacker, "Goblin", ROOM_ID);
+
+        assertTrue(registry.isInCombat(attacker.getUsername()),
+            "Player should be in combat after attacking a mob");
+    }
+
+    @Test
+    void fleeCombat_clearsPlayerCombatTarget() {
+        Player attacker = player("hero");
+        MobRegistry registry = buildRegistryWithMob(attacker, 100);
+
+        registry.processPlayerAttack(attacker, "Goblin", ROOM_ID);
+        assertTrue(registry.isInCombat(attacker.getUsername()),
+            "Precondition: player must be in combat");
+
+        registry.fleeCombat(attacker.getUsername());
+
+        assertFalse(registry.isInCombat(attacker.getUsername()),
+            "Player should not be in combat after fleeing");
+    }
+
+    @Test
+    void fleeCombat_isIdempotent_whenPlayerNotInCombat() {
+        Player attacker = player("hero");
+        MobRegistry registry = buildRegistryWithMob(attacker, 100);
+
+        // Should not throw even when player was never in combat.
+        registry.fleeCombat(attacker.getUsername());
+
+        assertFalse(registry.isInCombat(attacker.getUsername()),
+            "Player should still not be in combat after calling flee when not in combat");
+    }
+
+    @Test
+    void fleeCombat_disengagesMobFromPlayer() {
+        Player attacker = player("hero");
+        MobRegistry registry = buildRegistryWithMob(attacker, 100);
+
+        registry.processPlayerAttack(attacker, "Goblin", ROOM_ID);
+        registry.fleeCombat(attacker.getUsername());
+
+        // After fleeing, the mob should no longer have the player in its engaged set.
+        // We verify indirectly: isInCombat is false, meaning the registry is consistent.
+        assertFalse(registry.isInCombat(attacker.getUsername()),
+            "Player combat state must be cleared after fleeing");
+    }
+
+    // ── stubs ─────────────────────────────────────────────────────────
+
+    private record StubMobTemplateRepository(List<MobTemplate> templates)
+        implements MobTemplateRepository {
+        @Override
+        public List<MobTemplate> findAll() { return templates; }
+    }
+
+    private record StubAttackRepository(Map<AttackId, AttackDefinition> attacks)
+        implements AttackRepository {
+        @Override
+        public Optional<AttackDefinition> findById(AttackId id) throws AttackRepositoryException {
+            return Optional.ofNullable(attacks.get(id));
+        }
+    }
+
+    private static class StubItemRepository implements ItemRepository {
+        private final Map<ItemId, Item> items;
+
+        StubItemRepository(Map<ItemId, Item> items) { this.items = Map.copyOf(items); }
+
+        @Override
+        public void save(Item item) throws RepositoryException {}
+
+        @Override
+        public Optional<Item> findById(ItemId id) throws RepositoryException {
+            return Optional.ofNullable(items.get(id));
+        }
+    }
+
+    private static class StubPlayerRepository implements PlayerRepository {
+        private final ConcurrentHashMap<Username, Player> store = new ConcurrentHashMap<>();
+
+        StubPlayerRepository(Player initial) {
+            store.put(initial.getUsername(), initial);
+        }
+
+        @Override
+        public void savePlayer(Player player) { store.put(player.getUsername(), player); }
+
+        @Override
+        public Optional<Player> loadPlayer(Username username) {
+            return Optional.ofNullable(store.get(username));
+        }
+    }
+
+    private static class StubRoomRepository implements RoomRepository {
+        private final Room room;
+
+        StubRoomRepository(RoomId roomId) {
+            this.room = new Room(
+                roomId, "Test Room", "A featureless void.", Map.of(), List.of(), List.of());
+        }
+
+        @Override
+        public void save(Room room) throws RepositoryException {}
+
+        @Override
+        public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return room.getId().equals(id) ? Optional.of(room) : Optional.empty();
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/EquipmentCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/EquipmentCommandTest.java
@@ -118,6 +118,7 @@ class EquipmentCommandTest {
         @Override public void equipItem(String a) {}
         @Override public void unequipItem(String a) {}
         @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
         @Override public void sendInventory() {}
         @Override public void sendEquipment() { equipmentCalled = true; }
         @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/ExamineCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/ExamineCommandTest.java
@@ -155,6 +155,7 @@ class ExamineCommandTest {
         @Override public void equipItem(String a) {}
         @Override public void unequipItem(String a) {}
         @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
         @Override public void sendInventory() {}
         @Override public void sendEquipment() {}
         @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/FleeCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/FleeCommandTest.java
@@ -1,0 +1,141 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Unit tests for {@link FleeCommand}.
+ *
+ * <p>Guard logic (not-in-combat, no-exits) lives in
+ * {@code SocketClient.SocketCommandContextImpl.fleeCombat()} and is exercised via
+ * integration paths. These tests verify token matching, command metadata, and
+ * that a successful match delegates to {@link SocketCommandContext#fleeCombat()}.
+ */
+class FleeCommandTest {
+
+    @Test
+    void matchesFleeToken() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        FleeCommand command = new FleeCommand(registry);
+
+        assertTrue(command.match("FLEE").isPresent());
+        assertTrue(command.match("flee").isPresent());
+        assertTrue(command.match("Flee").isPresent());
+    }
+
+    @Test
+    void matchesFlAlias() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        FleeCommand command = new FleeCommand(registry);
+
+        assertTrue(command.match("FL").isPresent());
+        assertTrue(command.match("fl").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        FleeCommand command = new FleeCommand(registry);
+
+        assertFalse(command.match("look").isPresent());
+        assertFalse(command.match("kill").isPresent());
+        assertFalse(command.match("").isPresent());
+        assertFalse(command.match("fly").isPresent());
+        assertFalse(command.match("f").isPresent());
+    }
+
+    @Test
+    void successfulMatchDelegatesToFleeCombat() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        FleeCommand command = new FleeCommand(registry);
+
+        TrackingContext context = new TrackingContext();
+        command.match("FLEE").get().execute(context);
+
+        assertTrue(context.fleeCalled, "A matched FLEE command must delegate to context.fleeCombat()");
+    }
+
+    @Test
+    void flAliasAlsoDelegatesToFleeCombat() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        FleeCommand command = new FleeCommand(registry);
+
+        TrackingContext context = new TrackingContext();
+        command.match("FL").get().execute(context);
+
+        assertTrue(context.fleeCalled, "A matched FL alias must delegate to context.fleeCombat()");
+    }
+
+    @Test
+    void hasShortAndLongDescriptions() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        FleeCommand command = new FleeCommand(registry);
+
+        assertFalse(command.shortDescription().isBlank(), "shortDescription must not be blank");
+        assertFalse(command.longDescription().isBlank(), "longDescription must not be blank");
+    }
+
+    @Test
+    void nameIsCorrect() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        FleeCommand command = new FleeCommand(registry);
+
+        assertTrue(command.name().equalsIgnoreCase("flee"),
+                "Command name should be 'flee'");
+    }
+
+    @Test
+    void registersItselfWithRegistry() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        new FleeCommand(registry);
+
+        assertTrue(registry.commands().stream().anyMatch(c -> c instanceof FleeCommand),
+                "FleeCommand should register itself with the registry");
+    }
+
+    // --- helpers ---
+
+    private static class TrackingContext implements SocketCommandContext {
+        boolean fleeCalled = false;
+
+        @Override public boolean isAuthenticated() { return true; }
+        @Override public Player getPlayer() { return null; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) {}
+        @Override public void writeLineSafe(String m) {}
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) {}
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void fleeCombat() { fleeCalled = true; }
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/HelpCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/HelpCommandTest.java
@@ -162,6 +162,7 @@ class HelpCommandTest {
         @Override public void equipItem(String a) {}
         @Override public void unequipItem(String a) {}
         @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
         @Override public void sendInventory() {}
         @Override public void sendEquipment() {}
         @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/InventoryCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/InventoryCommandTest.java
@@ -129,6 +129,7 @@ class InventoryCommandTest {
         @Override public void equipItem(String a) {}
         @Override public void unequipItem(String a) {}
         @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
         @Override public void sendInventory() { inventoryCalled = true; }
         @Override public void sendEquipment() {}
         @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/QuaffCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/QuaffCommandTest.java
@@ -122,6 +122,7 @@ class QuaffCommandTest {
         @Override public void equipItem(String a) {}
         @Override public void unequipItem(String a) {}
         @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
         @Override public void sendInventory() {}
         @Override public void sendEquipment() {}
         @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherAuditTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherAuditTest.java
@@ -194,6 +194,10 @@ class SocketCommandDispatcherAuditTest {
         }
 
         @Override
+        public void fleeCombat() {
+        }
+
+        @Override
         public void sendInventory() {
         }
 

--- a/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherTest.java
@@ -208,6 +208,10 @@ class SocketCommandDispatcherTest {
         }
 
         @Override
+        public void fleeCombat() {
+        }
+
+        @Override
         public void sendInventory() {
         }
 

--- a/src/test/java/io/taanielo/jmud/core/server/socket/TellCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/TellCommandTest.java
@@ -167,6 +167,7 @@ class TellCommandTest {
         @Override public void equipItem(String a) {}
         @Override public void unequipItem(String a) {}
         @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
         @Override public void sendInventory() {}
         @Override public void sendEquipment() {}
         @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}


### PR DESCRIPTION
## Summary
- New `FleeCommand` handles `FLEE`/`FL` — picks a random exit, moves the player, disengages all mobs
- Added `fleeCombat(Username)` and `isInCombat(Username)` to `MobRegistry`
- Guards: not in combat → error; no exits → error
- All existing test stubs updated for the new `fleeCombat()` context method

Closes #109

## Test plan
- [ ] Build passes (`./gradlew build`)
- [ ] `FLEE` while in combat moves player to a random adjacent room and disengages mob
- [ ] `FLEE` while not in combat shows "You are not in combat."
- [ ] `FL` alias works
- [ ] Mob stops attacking after flee

🤖 Generated with [Claude Code](https://claude.ai/claude-code)