### PR TITLE
feat(server): add GOSSIP command for global cross-room chat

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/GossipCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GossipCommand.java
@@ -1,0 +1,73 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+import io.taanielo.jmud.core.player.Player;
+
+/**
+ * Handles the {@code GOSSIP} / {@code GOS} / {@code G} command, which broadcasts
+ * a message to all online players regardless of their current room.
+ *
+ * <p>Usage: {@code GOSSIP <message>}
+ *
+ * <p>The sender sees: {@code You gossip: <message>}
+ * <br>All other online players see: {@code <Name> gossips: <message>}
+ *
+ * <p>An error is reported to the sender when the command is invoked without a message.
+ */
+public class GossipCommand extends RegistrableCommand {
+
+    /**
+     * Creates a {@code GossipCommand} and registers it with the given registry.
+     *
+     * @param registry the registry to register this command with
+     */
+    public GossipCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "gossip";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Broadcast a message to all online players. Aliases: GOS, G";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: GOSSIP <message>\n"
+             + "  Sends a message to every online player, regardless of location.\n"
+             + "  Others see: <YourName> gossips: <message>\n"
+             + "  Aliases: GOS, G";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        String token = parts[0];
+        if (!"GOSSIP".equals(token) && !"GOS".equals(token) && !"G".equals(token)) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> handleGossip(context, args)));
+    }
+
+    private void handleGossip(SocketCommandContext context, String message) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to gossip.");
+            return;
+        }
+        if (message == null || message.isBlank()) {
+            context.writeLineWithPrompt("Gossip what?");
+            return;
+        }
+        Player sender = context.getPlayer();
+        String senderName = sender.getUsername().getValue();
+        context.gossip(senderName, message.trim());
+        context.writeLineSafe("You gossip: " + message.trim());
+        context.sendPrompt();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -970,6 +970,25 @@ public class SocketClient implements Client {
         }
 
         @Override
+        public void gossip(String senderName, String message) {
+            for (Client client : clientPool.clients()) {
+                if (client instanceof SocketClient socketClient) {
+                    Optional<Username> usernameOpt = socketClient.authenticatedUsername();
+                    if (usernameOpt.isEmpty()) {
+                        continue;
+                    }
+                    Username recipient = usernameOpt.get();
+                    // Skip the sender — they already see "You gossip: ..." from GossipCommand.
+                    if (recipient.equals(Username.of(senderName))) {
+                        continue;
+                    }
+                    socketClient.connection.writeLine(senderName + " gossips: " + message);
+                    socketClient.sendPrompt();
+                }
+            }
+        }
+
+        @Override
         public void examineItem(String args) {
             Player player = session.getPlayer();
             if (!session.isAuthenticated() || player == null) {

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -151,4 +151,18 @@ public interface SocketCommandContext extends Client {
      */
     void fleeCombat();
 
+    /**
+     * Broadcasts a gossip message from the named sender to all online players.
+     *
+     * <p>Each recipient other than the sender receives:
+     * {@code <senderName> gossips: <message>}
+     *
+     * <p>The default implementation is a no-op so that existing test stubs
+     * do not need to be updated.
+     *
+     * @param senderName the display name of the gossiping player
+     * @param message    the message text to broadcast
+     */
+    default void gossip(String senderName, String message) {}
+
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -27,6 +27,7 @@ public class SocketCommandRegistry {
         new EquipmentCommand(registry);
         new SayCommand(registry);
         new TellCommand(registry);
+        new GossipCommand(registry);
         new WhoCommand(registry);
         new ScoreCommand(registry);
         new AbilityCommand(registry);

--- a/src/test/java/io/taanielo/jmud/core/server/socket/GossipCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/GossipCommandTest.java
@@ -1,0 +1,173 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Unit tests for {@link GossipCommand}.
+ */
+class GossipCommandTest {
+
+    // --- token matching ---
+
+    @Test
+    void matchesGossipToken() {
+        GossipCommand cmd = new GossipCommand(new SocketCommandRegistry());
+        assertTrue(cmd.match("GOSSIP hello world").isPresent());
+        assertTrue(cmd.match("gossip hello world").isPresent());
+    }
+
+    @Test
+    void matchesGosAlias() {
+        GossipCommand cmd = new GossipCommand(new SocketCommandRegistry());
+        assertTrue(cmd.match("GOS hello").isPresent());
+        assertTrue(cmd.match("gos hello").isPresent());
+    }
+
+    @Test
+    void matchesGAlias() {
+        GossipCommand cmd = new GossipCommand(new SocketCommandRegistry());
+        assertTrue(cmd.match("G hello").isPresent());
+        assertTrue(cmd.match("g hello").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        GossipCommand cmd = new GossipCommand(new SocketCommandRegistry());
+        assertFalse(cmd.match("SAY hello").isPresent());
+        assertFalse(cmd.match("TELL someone hello").isPresent());
+        assertFalse(cmd.match("WHO").isPresent());
+        assertFalse(cmd.match("").isPresent());
+    }
+
+    // --- delivery ---
+
+    @Test
+    void senderSeesYouGossipLine() {
+        CapturingContext context = new CapturingContext("Alice");
+
+        GossipCommand cmd = new GossipCommand(new SocketCommandRegistry());
+        cmd.match("GOSSIP hello world").get().execute(context);
+
+        assertTrue(context.lines.stream().anyMatch(l -> l.equals("You gossip: hello world")),
+                "Sender should see 'You gossip: <message>'");
+    }
+
+    @Test
+    void gossipMethodCalledWithSenderNameAndMessage() {
+        CapturingContext context = new CapturingContext("Alice");
+
+        GossipCommand cmd = new GossipCommand(new SocketCommandRegistry());
+        cmd.match("GOSSIP hello world").get().execute(context);
+
+        assertEquals("Alice", context.gossipSender, "gossip() should receive the sender's name");
+        assertEquals("hello world", context.gossipMessage, "gossip() should receive the trimmed message");
+    }
+
+    @Test
+    void emptyMessageReturnsError() {
+        CapturingContext context = new CapturingContext("Alice");
+
+        GossipCommand cmd = new GossipCommand(new SocketCommandRegistry());
+        cmd.match("GOSSIP").get().execute(context);
+
+        assertFalse(context.promptMessage.isBlank(), "Error should be written via writeLineWithPrompt");
+    }
+
+    @Test
+    void blankMessageReturnsError() {
+        CapturingContext context = new CapturingContext("Alice");
+
+        GossipCommand cmd = new GossipCommand(new SocketCommandRegistry());
+        cmd.match("GOSSIP   ").get().execute(context);
+
+        assertFalse(context.promptMessage.isBlank(), "Error should be written via writeLineWithPrompt");
+    }
+
+    @Test
+    void shortDescriptionMentionsAliases() {
+        GossipCommand cmd = new GossipCommand(new SocketCommandRegistry());
+        String desc = cmd.shortDescription();
+        assertTrue(desc.contains("GOS"), "shortDescription should mention GOS alias");
+        assertTrue(desc.contains("G"), "shortDescription should mention G alias");
+    }
+
+    @Test
+    void longDescriptionContainsUsage() {
+        GossipCommand cmd = new GossipCommand(new SocketCommandRegistry());
+        String desc = cmd.longDescription();
+        assertTrue(desc.contains("GOSSIP"), "longDescription should mention GOSSIP");
+        assertTrue(desc.contains("Usage"), "longDescription should contain usage instructions");
+    }
+
+    // --- helpers ---
+
+    private static Player stubPlayer(String name) {
+        User user = User.of(Username.of(name), Password.hash("secret"));
+        return Player.of(user, "%h/%H hp>");
+    }
+
+    private static class CapturingContext implements SocketCommandContext {
+        final List<String> lines = new ArrayList<>();
+        String promptMessage = "";
+        String gossipSender = null;
+        String gossipMessage = null;
+        final Map<String, String> sentToUsername = new HashMap<>();
+        private final Player player;
+
+        CapturingContext(String playerName) {
+            this.player = stubPlayer(playerName);
+        }
+
+        @Override public void gossip(String senderName, String message) {
+            this.gossipSender = senderName;
+            this.gossipMessage = message;
+        }
+
+        @Override public boolean isAuthenticated() { return true; }
+        @Override public Player getPlayer() { return player; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) { promptMessage = m; }
+        @Override public void writeLineSafe(String m) { lines.add(m); }
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) { sentToUsername.put(u.getValue().toLowerCase(), m); }
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}


### PR DESCRIPTION
## Summary
- New `GossipCommand` handles `GOSSIP`/`GOS`/`G` — broadcasts to all online players regardless of room
- Sender sees: `You gossip: <message>`
- All others see: `<Name> gossips: <message>`
- `gossip()` added as a `default` method on `SocketCommandContext` — no existing test stubs need updating

Closes #111

## Test plan
- [ ] Build passes (`./gradlew build`)
- [ ] `GOSSIP hello` is visible to all online players
- [ ] Sender receives confirmation line
- [ ] `GOS` and `G` aliases work
- [ ] Empty message returns an error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)