### PR TITLE
feat(player): add character creation flow for race and class selection

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/character/repository/ClassRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/character/repository/ClassRepository.java
@@ -1,10 +1,16 @@
 package io.taanielo.jmud.core.character.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.taanielo.jmud.core.character.ClassDefinition;
 import io.taanielo.jmud.core.character.ClassId;
 
+/** Repository for {@link ClassDefinition} data. */
 public interface ClassRepository {
+    /** Finds a class by its id, returning empty if not found. */
     Optional<ClassDefinition> findById(ClassId id) throws ClassRepositoryException;
+
+    /** Returns all available class definitions in an unspecified order. */
+    List<ClassDefinition> findAll() throws ClassRepositoryException;
 }

--- a/src/main/java/io/taanielo/jmud/core/character/repository/RaceRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/character/repository/RaceRepository.java
@@ -1,10 +1,16 @@
 package io.taanielo.jmud.core.character.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.taanielo.jmud.core.character.Race;
 import io.taanielo.jmud.core.character.RaceId;
 
+/** Repository for {@link Race} data. */
 public interface RaceRepository {
+    /** Finds a race by its id, returning empty if not found. */
     Optional<Race> findById(RaceId id) throws RaceRepositoryException;
+
+    /** Returns all available races in an unspecified order. */
+    List<Race> findAll() throws RaceRepositoryException;
 }

--- a/src/main/java/io/taanielo/jmud/core/character/repository/json/JsonClassRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/character/repository/json/JsonClassRepository.java
@@ -3,6 +3,8 @@ package io.taanielo.jmud.core.character.repository.json;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,6 +57,30 @@ public class JsonClassRepository implements ClassRepository {
         }
         cache.put(id, definition);
         return Optional.of(definition);
+    }
+
+    @Override
+    public List<ClassDefinition> findAll() throws ClassRepositoryException {
+        List<ClassDefinition> classes = new ArrayList<>();
+        if (!Files.exists(classesDirPath)) {
+            return List.of();
+        }
+        try (var stream = Files.list(classesDirPath)) {
+            for (Path path : stream.filter(p -> p.toString().endsWith(".json")).toList()) {
+                ClassDto dto = readDto(path);
+                ClassDefinition definition;
+                try {
+                    definition = mapper.toDomain(dto);
+                } catch (IllegalArgumentException e) {
+                    throw new ClassRepositoryException("Invalid class data in " + path + ": " + e.getMessage(), e);
+                }
+                cache.put(definition.id(), definition);
+                classes.add(definition);
+            }
+        } catch (IOException e) {
+            throw new ClassRepositoryException("Failed to list classes in " + classesDirPath + ": " + e.getMessage(), e);
+        }
+        return List.copyOf(classes);
     }
 
     private void ensureDirectory(Path path) throws ClassRepositoryException {

--- a/src/main/java/io/taanielo/jmud/core/character/repository/json/JsonRaceRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/character/repository/json/JsonRaceRepository.java
@@ -3,6 +3,8 @@ package io.taanielo.jmud.core.character.repository.json;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,6 +57,30 @@ public class JsonRaceRepository implements RaceRepository {
         }
         cache.put(id, race);
         return Optional.of(race);
+    }
+
+    @Override
+    public List<Race> findAll() throws RaceRepositoryException {
+        List<Race> races = new ArrayList<>();
+        if (!Files.exists(racesDirPath)) {
+            return List.of();
+        }
+        try (var stream = Files.list(racesDirPath)) {
+            for (Path path : stream.filter(p -> p.toString().endsWith(".json")).toList()) {
+                RaceDto dto = readDto(path);
+                Race race;
+                try {
+                    race = mapper.toDomain(dto);
+                } catch (IllegalArgumentException e) {
+                    throw new RaceRepositoryException("Invalid race data in " + path + ": " + e.getMessage(), e);
+                }
+                cache.put(race.id(), race);
+                races.add(race);
+            }
+        } catch (IOException e) {
+            throw new RaceRepositoryException("Failed to list races in " + racesDirPath + ": " + e.getMessage(), e);
+        }
+        return List.copyOf(races);
     }
 
     private void ensureDirectory(Path path) throws RaceRepositoryException {

--- a/src/main/java/io/taanielo/jmud/core/creation/CharacterCreationException.java
+++ b/src/main/java/io/taanielo/jmud/core/creation/CharacterCreationException.java
@@ -1,0 +1,15 @@
+package io.taanielo.jmud.core.creation;
+
+/**
+ * Thrown when character-creation data cannot be loaded or is invalid.
+ */
+public class CharacterCreationException extends Exception {
+
+    public CharacterCreationException(String message) {
+        super(message);
+    }
+
+    public CharacterCreationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/creation/CharacterCreationService.java
+++ b/src/main/java/io/taanielo/jmud/core/creation/CharacterCreationService.java
@@ -1,0 +1,183 @@
+package io.taanielo.jmud.core.creation;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.taanielo.jmud.core.character.ClassDefinition;
+import io.taanielo.jmud.core.character.ClassId;
+import io.taanielo.jmud.core.character.Race;
+import io.taanielo.jmud.core.character.RaceId;
+import io.taanielo.jmud.core.character.repository.ClassRepository;
+import io.taanielo.jmud.core.character.repository.ClassRepositoryException;
+import io.taanielo.jmud.core.character.repository.RaceRepository;
+import io.taanielo.jmud.core.character.repository.RaceRepositoryException;
+
+/**
+ * Application service that drives the character-creation flow for new players.
+ *
+ * <p>The flow has two sequential steps:
+ * <ol>
+ *   <li>The player chooses a race from the list returned by {@link #buildRacePrompt()}.
+ *   <li>The player chooses a class from the list returned by {@link #buildClassPrompt()}.
+ * </ol>
+ *
+ * <p>Input is validated by {@link #resolveRace(String)} and {@link #resolveClass(String)};
+ * both return an empty {@link Optional} for unrecognised input so the caller can
+ * re-prompt.
+ *
+ * <p>This class is stateless and thread-safe; one instance may be shared
+ * across all connected clients.
+ */
+public class CharacterCreationService {
+
+    private final RaceRepository raceRepository;
+    private final ClassRepository classRepository;
+
+    /**
+     * Constructs the service with the given repositories.
+     *
+     * @param raceRepository  repository used to look up available races
+     * @param classRepository repository used to look up available classes
+     */
+    public CharacterCreationService(RaceRepository raceRepository, ClassRepository classRepository) {
+        this.raceRepository = Objects.requireNonNull(raceRepository, "Race repository is required");
+        this.classRepository = Objects.requireNonNull(classRepository, "Class repository is required");
+    }
+
+    /**
+     * Builds the race-selection prompt text that is sent to the player.
+     *
+     * @return a multi-line prompt string listing all available races
+     * @throws CharacterCreationException if race data cannot be loaded
+     */
+    public String buildRacePrompt() throws CharacterCreationException {
+        List<Race> races = loadRaces();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Choose your race:\n");
+        for (Race race : races) {
+            sb.append("  ").append(race.id().getValue())
+              .append(" - ").append(race.name());
+            appendRaceHint(sb, race);
+            sb.append('\n');
+        }
+        sb.append("Enter race name: ");
+        return sb.toString();
+    }
+
+    /**
+     * Builds the class-selection prompt text that is sent to the player.
+     *
+     * @return a multi-line prompt string listing all available classes
+     * @throws CharacterCreationException if class data cannot be loaded
+     */
+    public String buildClassPrompt() throws CharacterCreationException {
+        List<ClassDefinition> classes = loadClasses();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Choose your class:\n");
+        for (ClassDefinition cd : classes) {
+            sb.append("  ").append(cd.id().getValue())
+              .append(" - ").append(cd.name());
+            appendClassHint(sb, cd);
+            sb.append('\n');
+        }
+        sb.append("Enter class name: ");
+        return sb.toString();
+    }
+
+    /**
+     * Resolves a player's race input to a {@link RaceId}.
+     *
+     * <p>Matching is case-insensitive on the race's id value.
+     *
+     * @param input the raw text typed by the player
+     * @return the matching {@link RaceId}, or empty if input is unrecognised
+     * @throws CharacterCreationException if race data cannot be loaded
+     */
+    public Optional<RaceId> resolveRace(String input) throws CharacterCreationException {
+        if (input == null || input.isBlank()) {
+            return Optional.empty();
+        }
+        String normalised = input.trim().toLowerCase(Locale.ROOT);
+        return loadRaces().stream()
+            .filter(r -> r.id().getValue().equalsIgnoreCase(normalised)
+                      || r.name().equalsIgnoreCase(normalised))
+            .map(Race::id)
+            .findFirst();
+    }
+
+    /**
+     * Resolves a player's class input to a {@link ClassId}.
+     *
+     * <p>Matching is case-insensitive on the class's id value or name.
+     *
+     * @param input the raw text typed by the player
+     * @return the matching {@link ClassId}, or empty if input is unrecognised
+     * @throws CharacterCreationException if class data cannot be loaded
+     */
+    public Optional<ClassId> resolveClass(String input) throws CharacterCreationException {
+        if (input == null || input.isBlank()) {
+            return Optional.empty();
+        }
+        String normalised = input.trim().toLowerCase(Locale.ROOT);
+        return loadClasses().stream()
+            .filter(c -> c.id().getValue().equalsIgnoreCase(normalised)
+                      || c.name().equalsIgnoreCase(normalised))
+            .map(ClassDefinition::id)
+            .findFirst();
+    }
+
+    // ── private helpers ────────────────────────────────────────────────
+
+    private List<Race> loadRaces() throws CharacterCreationException {
+        try {
+            List<Race> races = raceRepository.findAll();
+            if (races.isEmpty()) {
+                throw new CharacterCreationException("No races are defined in the data directory.");
+            }
+            return races.stream()
+                .sorted((a, b) -> a.id().getValue().compareToIgnoreCase(b.id().getValue()))
+                .toList();
+        } catch (RaceRepositoryException e) {
+            throw new CharacterCreationException("Failed to load races: " + e.getMessage(), e);
+        }
+    }
+
+    private List<ClassDefinition> loadClasses() throws CharacterCreationException {
+        try {
+            List<ClassDefinition> classes = classRepository.findAll();
+            if (classes.isEmpty()) {
+                throw new CharacterCreationException("No classes are defined in the data directory.");
+            }
+            return classes.stream()
+                .sorted((a, b) -> a.id().getValue().compareToIgnoreCase(b.id().getValue()))
+                .toList();
+        } catch (ClassRepositoryException e) {
+            throw new CharacterCreationException("Failed to load classes: " + e.getMessage(), e);
+        }
+    }
+
+    private void appendRaceHint(StringBuilder sb, Race race) {
+        // Show carry capacity and healing modifier as brief description.
+        sb.append(" (carry ").append(race.carryBase());
+        int hmod = race.healingBaseModifier();
+        if (hmod > 0) {
+            sb.append(", healing +").append(hmod);
+        } else if (hmod < 0) {
+            sb.append(", healing ").append(hmod);
+        }
+        sb.append(')');
+    }
+
+    private void appendClassHint(StringBuilder sb, ClassDefinition cd) {
+        sb.append(" (carry bonus +").append(cd.carryBonus());
+        int hmod = cd.healingBaseModifier();
+        if (hmod > 0) {
+            sb.append(", healing +").append(hmod);
+        } else if (hmod < 0) {
+            sb.append(", healing ").append(hmod);
+        }
+        sb.append(')');
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/creation/CharacterCreationState.java
+++ b/src/main/java/io/taanielo/jmud/core/creation/CharacterCreationState.java
@@ -1,0 +1,24 @@
+package io.taanielo.jmud.core.creation;
+
+import io.taanielo.jmud.core.character.RaceId;
+
+/**
+ * Represents the in-progress state of a character-creation flow.
+ *
+ * <p>A newly created player starts in {@link ChoosingRace}; after a valid race
+ * is chosen they move to {@link ChoosingClass}; once a class is confirmed the
+ * flow is complete and the client enters normal gameplay.
+ */
+public sealed interface CharacterCreationState
+    permits CharacterCreationState.ChoosingRace, CharacterCreationState.ChoosingClass {
+
+    /** The player has not yet chosen a race. */
+    record ChoosingRace() implements CharacterCreationState {}
+
+    /**
+     * The player has chosen a race and is now choosing a class.
+     *
+     * @param chosenRace the race the player selected
+     */
+    record ChoosingClass(RaceId chosenRace) implements CharacterCreationState {}
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
@@ -21,6 +21,7 @@ import io.taanielo.jmud.core.character.repository.ClassRepositoryException;
 import io.taanielo.jmud.core.character.repository.RaceRepositoryException;
 import io.taanielo.jmud.core.character.repository.json.JsonClassRepository;
 import io.taanielo.jmud.core.character.repository.json.JsonRaceRepository;
+import io.taanielo.jmud.core.creation.CharacterCreationService;
 import io.taanielo.jmud.core.combat.CombatEngine;
 import io.taanielo.jmud.core.combat.CombatModifierResolver;
 import io.taanielo.jmud.core.combat.ThreadLocalCombatRandom;
@@ -74,7 +75,8 @@ public record GameContext(
     AbilityTargetResolver abilityTargetResolver,
     SocketCommandRegistry commandRegistry,
     PlayerEventBus playerEventBus,
-    MobRegistry mobRegistry
+    MobRegistry mobRegistry,
+    CharacterCreationService characterCreationService
 ) {
 
     /**
@@ -119,6 +121,8 @@ public record GameContext(
             tickRegistry.register(mobRegistry);
         }
 
+        CharacterCreationService characterCreationService = createCharacterCreationService();
+
         return new GameContext(
             userRegistry,
             authenticationPolicy,
@@ -141,7 +145,8 @@ public record GameContext(
             abilityTargetResolver,
             commandRegistry,
             playerEventBus,
-            mobRegistry
+            mobRegistry,
+            characterCreationService
         );
     }
 
@@ -217,6 +222,14 @@ public record GameContext(
             return new EncumbranceService(new JsonRaceRepository(), new JsonClassRepository());
         } catch (RaceRepositoryException | ClassRepositoryException e) {
             throw new IllegalStateException("Failed to initialize encumbrance service: " + e.getMessage(), e);
+        }
+    }
+
+    private static CharacterCreationService createCharacterCreationService() {
+        try {
+            return new CharacterCreationService(new JsonRaceRepository(), new JsonClassRepository());
+        } catch (RaceRepositoryException | ClassRepositoryException e) {
+            throw new IllegalStateException("Failed to initialize character creation service: " + e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -18,6 +18,13 @@ import lombok.extern.slf4j.Slf4j;
 import io.taanielo.jmud.core.ability.AbilityMatch;
 import io.taanielo.jmud.core.ability.AbilityRegistry;
 import io.taanielo.jmud.core.ability.AbilityTargetResolver;
+import io.taanielo.jmud.core.character.ClassId;
+import io.taanielo.jmud.core.character.RaceId;
+import io.taanielo.jmud.core.creation.CharacterCreationException;
+import io.taanielo.jmud.core.creation.CharacterCreationService;
+import io.taanielo.jmud.core.creation.CharacterCreationState;
+import io.taanielo.jmud.core.creation.CharacterCreationState.ChoosingClass;
+import io.taanielo.jmud.core.creation.CharacterCreationState.ChoosingRace;
 import io.taanielo.jmud.core.action.GameActionResult;
 import io.taanielo.jmud.core.action.GameActionService;
 import io.taanielo.jmud.core.action.GameMessage;
@@ -72,6 +79,8 @@ public class SocketClient implements Client {
     private final boolean preAuthenticatedNewUser;
     private final Runnable onClose;
     private final AtomicBoolean closed = new AtomicBoolean();
+    /** Non-null while a new player is choosing race/class; null during normal gameplay. */
+    private volatile CharacterCreationState creationState;
 
     public SocketClient(
         ClientConnection connection,
@@ -155,6 +164,8 @@ public class SocketClient implements Client {
 
                 if (!session.isAuthenticated()) {
                     handleAuthentication(clientInput);
+                } else if (creationState != null) {
+                    handleCharacterCreation(clientInput);
                 } else {
                     handleCommand(clientInput);
                 }
@@ -293,6 +304,94 @@ public class SocketClient implements Client {
             resolveRoomId(player),
             "success",
             Map.of("newPlayer", created.get())
+        );
+
+        if (created.get() && context.characterCreationService() != null) {
+            beginCharacterCreation();
+        } else {
+            String correlationId = auditService.newCorrelationId();
+            session.enqueueCommand(() -> {
+                currentCorrelationId.set(correlationId);
+                try {
+                    commandDispatcher.dispatch(new SocketCommandContextImpl(), "look", correlationId);
+                } finally {
+                    currentCorrelationId.remove();
+                }
+            });
+        }
+    }
+
+    // ── Character creation ─────────────────────────────────────────────
+
+    private void beginCharacterCreation() {
+        creationState = new ChoosingRace();
+        CharacterCreationService svc = context.characterCreationService();
+        try {
+            String prompt = svc.buildRacePrompt();
+            connection.writeLine(prompt);
+        } catch (CharacterCreationException e) {
+            log.error("Failed to build race prompt", e);
+            connection.writeLine("Character creation unavailable. You have been assigned a default race and class.");
+            finishCharacterCreation(null, null);
+        }
+    }
+
+    private void handleCharacterCreation(String input) {
+        CharacterCreationService svc = context.characterCreationService();
+        if (svc == null) {
+            creationState = null;
+            return;
+        }
+        switch (creationState) {
+            case ChoosingRace ignored -> {
+                try {
+                    var raceIdOpt = svc.resolveRace(input);
+                    if (raceIdOpt.isEmpty()) {
+                        connection.writeLine("Unknown race '" + input.trim() + "'. Please try again.");
+                        connection.writeLine(svc.buildRacePrompt());
+                    } else {
+                        creationState = new ChoosingClass(raceIdOpt.get());
+                        connection.writeLine(svc.buildClassPrompt());
+                    }
+                } catch (CharacterCreationException e) {
+                    log.error("Error during race selection", e);
+                    connection.writeLine("An error occurred. Please try again.");
+                }
+            }
+            case ChoosingClass choosing -> {
+                try {
+                    var classIdOpt = svc.resolveClass(input);
+                    if (classIdOpt.isEmpty()) {
+                        connection.writeLine("Unknown class '" + input.trim() + "'. Please try again.");
+                        connection.writeLine(svc.buildClassPrompt());
+                    } else {
+                        finishCharacterCreation(choosing.chosenRace(), classIdOpt.get());
+                    }
+                } catch (CharacterCreationException e) {
+                    log.error("Error during class selection", e);
+                    connection.writeLine("An error occurred. Please try again.");
+                }
+            }
+        }
+    }
+
+    private void finishCharacterCreation(RaceId raceId, ClassId classId) {
+        creationState = null;
+        Player player = session.getPlayer();
+        if (player == null) {
+            return;
+        }
+        if (raceId != null) {
+            player = player.withIdentity(player.identity().withRace(raceId));
+        }
+        if (classId != null) {
+            player = player.withIdentity(player.identity().withClassId(classId));
+        }
+        session.setPlayer(player);
+        playerRepository.savePlayer(player);
+        connection.writeLine(
+            "You are now a " + player.getRace().getValue()
+            + " " + player.getClassId().getValue() + ". Welcome to the realm!"
         );
         String correlationId = auditService.newCorrelationId();
         session.enqueueCommand(() -> {

--- a/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
@@ -526,12 +526,22 @@ class GameActionServiceTest {
         public Optional<Race> findById(RaceId id) throws RaceRepositoryException {
             return Optional.empty();
         }
+
+        @Override
+        public java.util.List<Race> findAll() throws RaceRepositoryException {
+            return java.util.List.of();
+        }
     }
 
     private static class StubClassRepository implements ClassRepository {
         @Override
         public Optional<ClassDefinition> findById(ClassId id) throws ClassRepositoryException {
             return Optional.empty();
+        }
+
+        @Override
+        public java.util.List<ClassDefinition> findAll() throws ClassRepositoryException {
+            return java.util.List.of();
         }
     }
 

--- a/src/test/java/io/taanielo/jmud/core/character/JsonClassRepositoryFindAllTest.java
+++ b/src/test/java/io/taanielo/jmud/core/character/JsonClassRepositoryFindAllTest.java
@@ -1,0 +1,46 @@
+package io.taanielo.jmud.core.character;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.character.repository.ClassRepositoryException;
+import io.taanielo.jmud.core.character.repository.json.JsonClassRepository;
+
+/**
+ * Verifies that {@link JsonClassRepository#findAll()} loads all classes from
+ * the {@code data/classes/} directory.
+ */
+class JsonClassRepositoryFindAllTest {
+
+    @Test
+    void findAll_returnsAllThreeClasses() throws ClassRepositoryException {
+        JsonClassRepository repo = new JsonClassRepository(Path.of("data"));
+
+        List<ClassDefinition> classes = repo.findAll();
+
+        assertFalse(classes.isEmpty(), "Expected at least one class");
+        Set<String> ids = classes.stream()
+            .map(c -> c.id().getValue())
+            .collect(Collectors.toSet());
+
+        assertTrue(ids.contains("warrior"), "Expected 'warrior' class");
+        assertTrue(ids.contains("mage"), "Expected 'mage' class");
+        assertTrue(ids.contains("adventurer"), "Expected 'adventurer' class");
+        assertEquals(3, classes.size(), "Expected exactly 3 classes");
+    }
+
+    @Test
+    void findAll_returnsEmptyForEmptyDir() throws ClassRepositoryException {
+        JsonClassRepository repo = new JsonClassRepository(Path.of("data-nonexistent-xyz"));
+        List<ClassDefinition> classes = repo.findAll();
+        assertTrue(classes.isEmpty());
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/character/JsonRaceRepositoryFindAllTest.java
+++ b/src/test/java/io/taanielo/jmud/core/character/JsonRaceRepositoryFindAllTest.java
@@ -1,0 +1,47 @@
+package io.taanielo.jmud.core.character;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.character.repository.RaceRepositoryException;
+import io.taanielo.jmud.core.character.repository.json.JsonRaceRepository;
+
+/**
+ * Verifies that {@link JsonRaceRepository#findAll()} loads all races from the
+ * {@code data/races/} directory.
+ */
+class JsonRaceRepositoryFindAllTest {
+
+    @Test
+    void findAll_returnsAllThreeRaces() throws RaceRepositoryException {
+        JsonRaceRepository repo = new JsonRaceRepository(Path.of("data"));
+
+        List<Race> races = repo.findAll();
+
+        assertFalse(races.isEmpty(), "Expected at least one race");
+        Set<String> ids = races.stream()
+            .map(r -> r.id().getValue())
+            .collect(Collectors.toSet());
+
+        assertTrue(ids.contains("human"), "Expected 'human' race");
+        assertTrue(ids.contains("elf"), "Expected 'elf' race");
+        assertTrue(ids.contains("troll"), "Expected 'troll' race");
+        assertEquals(3, races.size(), "Expected exactly 3 races");
+    }
+
+    @Test
+    void findAll_returnsEmptyForEmptyDir() throws RaceRepositoryException {
+        // Requesting a non-existent data root must return empty rather than throw.
+        JsonRaceRepository repo = new JsonRaceRepository(Path.of("data-nonexistent-xyz"));
+        List<Race> races = repo.findAll();
+        assertTrue(races.isEmpty());
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/creation/CharacterCreationServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/creation/CharacterCreationServiceTest.java
@@ -1,0 +1,186 @@
+package io.taanielo.jmud.core.creation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.character.ClassDefinition;
+import io.taanielo.jmud.core.character.ClassId;
+import io.taanielo.jmud.core.character.Race;
+import io.taanielo.jmud.core.character.RaceId;
+import io.taanielo.jmud.core.character.repository.ClassRepository;
+import io.taanielo.jmud.core.character.repository.ClassRepositoryException;
+import io.taanielo.jmud.core.character.repository.RaceRepository;
+import io.taanielo.jmud.core.character.repository.RaceRepositoryException;
+
+/**
+ * Unit tests for {@link CharacterCreationService} using stub repositories.
+ */
+class CharacterCreationServiceTest {
+
+    private static final Race HUMAN = new Race(RaceId.of("human"), "Human", 0, 50);
+    private static final Race ELF = new Race(RaceId.of("elf"), "Elf", -2, 40);
+    private static final Race TROLL = new Race(RaceId.of("troll"), "Troll", 2, 80);
+
+    private static final ClassDefinition WARRIOR = new ClassDefinition(ClassId.of("warrior"), "Warrior", 3, 20);
+    private static final ClassDefinition MAGE = new ClassDefinition(ClassId.of("mage"), "Mage", -1, 5);
+    private static final ClassDefinition ADVENTURER = new ClassDefinition(ClassId.of("adventurer"), "Adventurer", 0, 10);
+
+    private CharacterCreationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CharacterCreationService(new StubRaceRepository(), new StubClassRepository());
+    }
+
+    // ── resolveRace ────────────────────────────────────────────────────
+
+    @Test
+    void resolveRace_byId_exactMatch() throws CharacterCreationException {
+        Optional<RaceId> result = service.resolveRace("human");
+        assertTrue(result.isPresent());
+        assertEquals("human", result.get().getValue());
+    }
+
+    @Test
+    void resolveRace_byId_caseInsensitive() throws CharacterCreationException {
+        Optional<RaceId> result = service.resolveRace("ELF");
+        assertTrue(result.isPresent());
+        assertEquals("elf", result.get().getValue());
+    }
+
+    @Test
+    void resolveRace_byName() throws CharacterCreationException {
+        Optional<RaceId> result = service.resolveRace("Troll");
+        assertTrue(result.isPresent());
+        assertEquals("troll", result.get().getValue());
+    }
+
+    @Test
+    void resolveRace_unknown_returnsEmpty() throws CharacterCreationException {
+        Optional<RaceId> result = service.resolveRace("gnome");
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void resolveRace_blank_returnsEmpty() throws CharacterCreationException {
+        assertFalse(service.resolveRace("").isPresent());
+        assertFalse(service.resolveRace("   ").isPresent());
+        assertFalse(service.resolveRace(null).isPresent());
+    }
+
+    // ── resolveClass ───────────────────────────────────────────────────
+
+    @Test
+    void resolveClass_byId_exactMatch() throws CharacterCreationException {
+        Optional<ClassId> result = service.resolveClass("warrior");
+        assertTrue(result.isPresent());
+        assertEquals("warrior", result.get().getValue());
+    }
+
+    @Test
+    void resolveClass_byId_caseInsensitive() throws CharacterCreationException {
+        Optional<ClassId> result = service.resolveClass("MAGE");
+        assertTrue(result.isPresent());
+        assertEquals("mage", result.get().getValue());
+    }
+
+    @Test
+    void resolveClass_byName() throws CharacterCreationException {
+        Optional<ClassId> result = service.resolveClass("Adventurer");
+        assertTrue(result.isPresent());
+        assertEquals("adventurer", result.get().getValue());
+    }
+
+    @Test
+    void resolveClass_unknown_returnsEmpty() throws CharacterCreationException {
+        assertFalse(service.resolveClass("druid").isPresent());
+    }
+
+    // ── prompt content ─────────────────────────────────────────────────
+
+    @Test
+    void buildRacePrompt_containsAllRaceIds() throws CharacterCreationException {
+        String prompt = service.buildRacePrompt();
+        assertTrue(prompt.contains("human"), "Prompt should contain 'human'");
+        assertTrue(prompt.contains("elf"), "Prompt should contain 'elf'");
+        assertTrue(prompt.contains("troll"), "Prompt should contain 'troll'");
+    }
+
+    @Test
+    void buildClassPrompt_containsAllClassIds() throws CharacterCreationException {
+        String prompt = service.buildClassPrompt();
+        assertTrue(prompt.contains("warrior"), "Prompt should contain 'warrior'");
+        assertTrue(prompt.contains("mage"), "Prompt should contain 'mage'");
+        assertTrue(prompt.contains("adventurer"), "Prompt should contain 'adventurer'");
+    }
+
+    @Test
+    void buildRacePrompt_throwsWhenNoRaces() {
+        CharacterCreationService emptyService = new CharacterCreationService(
+            new EmptyRaceRepository(), new StubClassRepository()
+        );
+        assertThrows(CharacterCreationException.class, emptyService::buildRacePrompt);
+    }
+
+    @Test
+    void buildClassPrompt_throwsWhenNoClasses() {
+        CharacterCreationService emptyService = new CharacterCreationService(
+            new StubRaceRepository(), new EmptyClassRepository()
+        );
+        assertThrows(CharacterCreationException.class, emptyService::buildClassPrompt);
+    }
+
+    // ── stub repositories ──────────────────────────────────────────────
+
+    private static class StubRaceRepository implements RaceRepository {
+        private final List<Race> races = List.of(HUMAN, ELF, TROLL);
+
+        @Override
+        public Optional<Race> findById(RaceId id) {
+            return races.stream().filter(r -> r.id().equals(id)).findFirst();
+        }
+
+        @Override
+        public List<Race> findAll() {
+            return races;
+        }
+    }
+
+    private static class StubClassRepository implements ClassRepository {
+        private final List<ClassDefinition> classes = List.of(WARRIOR, MAGE, ADVENTURER);
+
+        @Override
+        public Optional<ClassDefinition> findById(ClassId id) {
+            return classes.stream().filter(c -> c.id().equals(id)).findFirst();
+        }
+
+        @Override
+        public List<ClassDefinition> findAll() {
+            return classes;
+        }
+    }
+
+    private static class EmptyRaceRepository implements RaceRepository {
+        @Override
+        public Optional<Race> findById(RaceId id) { return Optional.empty(); }
+
+        @Override
+        public List<Race> findAll() { return List.of(); }
+    }
+
+    private static class EmptyClassRepository implements ClassRepository {
+        @Override
+        public Optional<ClassDefinition> findById(ClassId id) { return Optional.empty(); }
+
+        @Override
+        public List<ClassDefinition> findAll() { return List.of(); }
+    }
+}


### PR DESCRIPTION
## Summary
- New players are prompted to choose a race (human/elf/troll) then a class (warrior/mage/adventurer) before entering the world
- Two-state sealed interface (`ChoosingRace` / `ChoosingClass`) wired into `SocketClient`'s read loop
- Existing players skip the flow entirely and connect normally
- Added `findAll()` to `RaceRepository` and `ClassRepository` with JSON implementations
- 17 new tests covering service logic and repository integration

Closes #113

## Test plan
- [ ] Build passes (`./gradlew build`)
- [ ] New player sees race list, picks one, sees class list, picks one, then enters world
- [ ] Existing player connects normally without seeing creation prompts
- [ ] Invalid input during creation shows an error and re-prompts
- [ ] Chosen race/class are saved and visible in SCORE

🤖 Generated with [Claude Code](https://claude.ai/claude-code)