### PR TITLE
feat(abilities): grant class-specific starting abilities and add ABILITIES list command

### DIFF
--- a/data/classes/class.adventurer.json
+++ b/data/classes/class.adventurer.json
@@ -5,5 +5,6 @@
   "healing": {
     "base_modifier": 0
   },
-  "carry_bonus": 10
+  "carry_bonus": 10,
+  "ability_ids": ["skill.bash", "spell.heal"]
 }

--- a/data/classes/class.mage.json
+++ b/data/classes/class.mage.json
@@ -5,5 +5,6 @@
   "healing": {
     "base_modifier": -1
   },
-  "carry_bonus": 5
+  "carry_bonus": 5,
+  "ability_ids": ["spell.fireball", "spell.heal"]
 }

--- a/data/classes/class.warrior.json
+++ b/data/classes/class.warrior.json
@@ -5,5 +5,6 @@
   "healing": {
     "base_modifier": 3
   },
-  "carry_bonus": 20
+  "carry_bonus": 20,
+  "ability_ids": ["skill.bash"]
 }

--- a/src/main/java/io/taanielo/jmud/core/ability/AbilityRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/AbilityRegistry.java
@@ -64,6 +64,19 @@ public class AbilityRegistry {
             .map(candidate -> new AbilityMatch(candidate.ability, candidate.remainingTarget.trim()));
     }
 
+    /**
+     * Looks up an ability by its id.
+     *
+     * @param id the ability id to look up
+     * @return the ability, or empty if not found
+     */
+    public Optional<Ability> findById(AbilityId id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(abilityById.get(id));
+    }
+
     public List<AbilityId> abilityIds() {
         return abilities.stream()
             .map(Ability::id)

--- a/src/main/java/io/taanielo/jmud/core/character/ClassDefinition.java
+++ b/src/main/java/io/taanielo/jmud/core/character/ClassDefinition.java
@@ -1,14 +1,37 @@
 package io.taanielo.jmud.core.character;
 
+import java.util.List;
 import java.util.Objects;
 
+import io.taanielo.jmud.core.ability.AbilityId;
+
+/**
+ * Immutable definition of a playable class, including its stat modifiers and the
+ * abilities that are granted to new characters who choose this class.
+ */
 public class ClassDefinition {
     private final ClassId id;
     private final String name;
     private final int healingBaseModifier;
     private final int carryBonus;
+    private final List<AbilityId> startingAbilityIds;
 
-    public ClassDefinition(ClassId id, String name, int healingBaseModifier, int carryBonus) {
+    /**
+     * Constructs a class definition with starting ability ids.
+     *
+     * @param id                 the unique class identifier
+     * @param name               the display name of the class
+     * @param healingBaseModifier modifier applied to the base healing rate
+     * @param carryBonus         bonus carry capacity granted by this class
+     * @param startingAbilityIds ability ids granted to new players of this class
+     */
+    public ClassDefinition(
+        ClassId id,
+        String name,
+        int healingBaseModifier,
+        int carryBonus,
+        List<AbilityId> startingAbilityIds
+    ) {
         this.id = Objects.requireNonNull(id, "Class id is required");
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("Class name must not be blank");
@@ -19,6 +42,22 @@ public class ClassDefinition {
             throw new IllegalArgumentException("Class carry bonus must be non-negative");
         }
         this.carryBonus = carryBonus;
+        this.startingAbilityIds = startingAbilityIds == null
+            ? List.of()
+            : List.copyOf(startingAbilityIds);
+    }
+
+    /**
+     * Constructs a class definition without explicit starting abilities.
+     * Equivalent to passing an empty starting ability list.
+     *
+     * @param id                 the unique class identifier
+     * @param name               the display name of the class
+     * @param healingBaseModifier modifier applied to the base healing rate
+     * @param carryBonus         bonus carry capacity granted by this class
+     */
+    public ClassDefinition(ClassId id, String name, int healingBaseModifier, int carryBonus) {
+        this(id, name, healingBaseModifier, carryBonus, List.of());
     }
 
     public ClassId id() {
@@ -35,5 +74,14 @@ public class ClassDefinition {
 
     public int carryBonus() {
         return carryBonus;
+    }
+
+    /**
+     * Returns the list of ability ids granted to a new character who chooses this class.
+     *
+     * @return unmodifiable list of starting ability ids; never null
+     */
+    public List<AbilityId> startingAbilityIds() {
+        return startingAbilityIds;
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/character/dto/ClassDto.java
+++ b/src/main/java/io/taanielo/jmud/core/character/dto/ClassDto.java
@@ -1,10 +1,13 @@
 package io.taanielo.jmud.core.character.dto;
 
+import java.util.List;
+
 public record ClassDto(
     int schemaVersion,
     String id,
     String name,
     ClassHealingDto healing,
-    int carryBonus
+    int carryBonus,
+    List<String> abilityIds
 ) {
 }

--- a/src/main/java/io/taanielo/jmud/core/character/dto/ClassMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/character/dto/ClassMapper.java
@@ -1,7 +1,9 @@
 package io.taanielo.jmud.core.character.dto;
 
+import java.util.List;
 import java.util.Objects;
 
+import io.taanielo.jmud.core.ability.AbilityId;
 import io.taanielo.jmud.core.character.ClassDefinition;
 import io.taanielo.jmud.core.character.ClassId;
 
@@ -12,11 +14,15 @@ public class ClassMapper {
             throw new IllegalArgumentException("Unsupported class schema version " + dto.schemaVersion());
         }
         ClassHealingDto healingDto = Objects.requireNonNull(dto.healing(), "Class healing is required");
+        List<AbilityId> startingAbilityIds = dto.abilityIds() == null
+            ? List.of()
+            : dto.abilityIds().stream().map(AbilityId::of).toList();
         return new ClassDefinition(
             ClassId.of(dto.id()),
             dto.name(),
             healingDto.baseModifier(),
-            dto.carryBonus()
+            dto.carryBonus(),
+            startingAbilityIds
         );
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/creation/CharacterCreationService.java
+++ b/src/main/java/io/taanielo/jmud/core/creation/CharacterCreationService.java
@@ -117,6 +117,19 @@ public class CharacterCreationService {
      * @throws CharacterCreationException if class data cannot be loaded
      */
     public Optional<ClassId> resolveClass(String input) throws CharacterCreationException {
+        return resolveClassDefinition(input).map(ClassDefinition::id);
+    }
+
+    /**
+     * Resolves a player's class input to the full {@link ClassDefinition}.
+     *
+     * <p>Matching is case-insensitive on the class's id value or name.
+     *
+     * @param input the raw text typed by the player
+     * @return the matching {@link ClassDefinition}, or empty if input is unrecognised
+     * @throws CharacterCreationException if class data cannot be loaded
+     */
+    public Optional<ClassDefinition> resolveClassDefinition(String input) throws CharacterCreationException {
         if (input == null || input.isBlank()) {
             return Optional.empty();
         }
@@ -124,7 +137,6 @@ public class CharacterCreationService {
         return loadClasses().stream()
             .filter(c -> c.id().getValue().equalsIgnoreCase(normalised)
                       || c.name().equalsIgnoreCase(normalised))
-            .map(ClassDefinition::id)
             .findFirst();
     }
 

--- a/src/main/java/io/taanielo/jmud/core/server/socket/AbilitiesCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/AbilitiesCommand.java
@@ -1,0 +1,48 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the {@code ABILITIES} / {@code AB} command, which lists every ability
+ * the player has learned along with its type, resource cost, and cooldown.
+ *
+ * <p>Usage: {@code ABILITIES} or {@code AB}
+ */
+public class AbilitiesCommand extends RegistrableCommand {
+
+    /**
+     * Creates an {@code AbilitiesCommand} and registers it with the given registry.
+     *
+     * @param registry the registry to register this command with
+     */
+    public AbilitiesCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "abilities";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "List all abilities you have learned, with type, cost, and cooldown. Aliases: AB";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: ABILITIES\n"
+             + "  Displays a formatted table of every ability you have learned.\n"
+             + "  Each row shows: ability name, type (SKILL/SPELL), resource cost, cooldown.\n"
+             + "  Alias: AB";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String token = SocketCommandParsing.firstToken(input);
+        if (!"ABILITIES".equals(token) && !"AB".equals(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(new SocketCommandMatch(this, SocketCommandContext::sendAbilities));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -15,9 +15,13 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
+import io.taanielo.jmud.core.ability.Ability;
+import io.taanielo.jmud.core.ability.AbilityCost;
+import io.taanielo.jmud.core.ability.AbilityId;
 import io.taanielo.jmud.core.ability.AbilityMatch;
 import io.taanielo.jmud.core.ability.AbilityRegistry;
 import io.taanielo.jmud.core.ability.AbilityTargetResolver;
+import io.taanielo.jmud.core.character.ClassDefinition;
 import io.taanielo.jmud.core.character.ClassId;
 import io.taanielo.jmud.core.character.RaceId;
 import io.taanielo.jmud.core.creation.CharacterCreationException;
@@ -251,20 +255,17 @@ public class SocketClient implements Client {
             .loadPlayer(authenticatedUser.getUsername())
             .orElseGet(() -> {
                 boolean ansiEnabled = OutputStyleSettings.ansiEnabledByDefault();
+                // New players start with no abilities; abilities are seeded after class selection.
                 Player newPlayer = Player.of(
                     authenticatedUser,
                     PromptSettings.defaultFormat(),
                     ansiEnabled,
-                    abilityRegistry.abilityIds()
+                    List.of()
                 );
                 created.set(true);
                 playerRepository.savePlayer(newPlayer);
                 return newPlayer;
             });
-        if (player.getLearnedAbilities().isEmpty()) {
-            player = player.withLearnedAbilities(abilityRegistry.abilityIds());
-            playerRepository.savePlayer(player);
-        }
         session.setPlayer(player);
         session.setTextStyler(TextStylers.forEnabled(player.isAnsiEnabled()));
         if (player.isDead()) {
@@ -332,7 +333,7 @@ public class SocketClient implements Client {
         } catch (CharacterCreationException e) {
             log.error("Failed to build race prompt", e);
             connection.writeLine("Character creation unavailable. You have been assigned a default race and class.");
-            finishCharacterCreation(null, null);
+            finishCharacterCreation(null, (ClassDefinition) null);
         }
     }
 
@@ -360,12 +361,12 @@ public class SocketClient implements Client {
             }
             case ChoosingClass choosing -> {
                 try {
-                    var classIdOpt = svc.resolveClass(input);
-                    if (classIdOpt.isEmpty()) {
+                    var classDefOpt = svc.resolveClassDefinition(input);
+                    if (classDefOpt.isEmpty()) {
                         connection.writeLine("Unknown class '" + input.trim() + "'. Please try again.");
                         connection.writeLine(svc.buildClassPrompt());
                     } else {
-                        finishCharacterCreation(choosing.chosenRace(), classIdOpt.get());
+                        finishCharacterCreation(choosing.chosenRace(), classDefOpt.get());
                     }
                 } catch (CharacterCreationException e) {
                     log.error("Error during class selection", e);
@@ -375,7 +376,7 @@ public class SocketClient implements Client {
         }
     }
 
-    private void finishCharacterCreation(RaceId raceId, ClassId classId) {
+    private void finishCharacterCreation(RaceId raceId, ClassDefinition classDef) {
         creationState = null;
         Player player = session.getPlayer();
         if (player == null) {
@@ -384,8 +385,11 @@ public class SocketClient implements Client {
         if (raceId != null) {
             player = player.withIdentity(player.identity().withRace(raceId));
         }
-        if (classId != null) {
-            player = player.withIdentity(player.identity().withClassId(classId));
+        if (classDef != null) {
+            player = player.withIdentity(player.identity().withClassId(classDef.id()));
+            if (!classDef.startingAbilityIds().isEmpty()) {
+                player = player.withLearnedAbilities(classDef.startingAbilityIds());
+            }
         }
         session.setPlayer(player);
         playerRepository.savePlayer(player);
@@ -1085,6 +1089,45 @@ public class SocketClient implements Client {
                     socketClient.sendPrompt();
                 }
             }
+        }
+
+        @Override
+        public void sendAbilities() {
+            Player player = session.getPlayer();
+            if (!session.isAuthenticated() || player == null) {
+                writeLineWithPrompt("You must be logged in to view your abilities.");
+                return;
+            }
+            List<AbilityId> learned = player.getLearnedAbilities();
+            if (learned.isEmpty()) {
+                writeLineWithPrompt("You have not learned any abilities yet.");
+                return;
+            }
+            connection.writeLine(String.format("%-20s %-6s %-12s %s", "Ability", "Type", "Cost", "Cooldown"));
+            connection.writeLine("-".repeat(52));
+            for (AbilityId abilityId : learned) {
+                Ability ability = abilityRegistry.findById(abilityId).orElse(null);
+                if (ability == null) {
+                    continue;
+                }
+                AbilityCost cost = ability.cost();
+                String costStr;
+                if (cost.mana() > 0 && cost.move() > 0) {
+                    costStr = cost.mana() + " mana, " + cost.move() + " mv";
+                } else if (cost.mana() > 0) {
+                    costStr = cost.mana() + " mana";
+                } else if (cost.move() > 0) {
+                    costStr = cost.move() + " mv";
+                } else {
+                    costStr = "none";
+                }
+                String cooldownStr = ability.cooldown().ticks() > 0
+                    ? ability.cooldown().ticks() + " ticks"
+                    : "none";
+                connection.writeLine(String.format("%-20s %-6s %-12s %s",
+                    ability.name(), ability.type().name(), costStr, cooldownStr));
+            }
+            sendPrompt();
         }
 
         @Override

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -147,6 +147,17 @@ public interface SocketCommandContext extends Client {
     default void examineItem(String args) {}
 
     /**
+     * Sends the player's known abilities as a formatted table.
+     *
+     * <p>Each line shows the ability name, its type (SKILL/SPELL), resource cost,
+     * and cooldown in ticks.
+     *
+     * <p>The default implementation is a no-op so that existing test stubs
+     * do not need to be updated.
+     */
+    default void sendAbilities() {}
+
+    /**
      * Attempts to flee from active combat by moving to a random available exit.
      */
     void fleeCombat();

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -31,6 +31,7 @@ public class SocketCommandRegistry {
         new WhoCommand(registry);
         new ScoreCommand(registry);
         new AbilityCommand(registry);
+        new AbilitiesCommand(registry);
         new AttackCommand(registry);
         new KillCommand(registry);
         new FleeCommand(registry);

--- a/src/test/java/io/taanielo/jmud/core/character/ClassDefinitionStartingAbilitiesTest.java
+++ b/src/test/java/io/taanielo/jmud/core/character/ClassDefinitionStartingAbilitiesTest.java
@@ -1,0 +1,88 @@
+package io.taanielo.jmud.core.character;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.ability.AbilityId;
+import io.taanielo.jmud.core.character.repository.ClassRepositoryException;
+import io.taanielo.jmud.core.character.repository.json.JsonClassRepository;
+
+/**
+ * Verifies that {@link ClassDefinition#startingAbilityIds()} is populated when
+ * classes are loaded from the {@code data/classes/} directory.
+ */
+class ClassDefinitionStartingAbilitiesTest {
+
+    @Test
+    void warriorHasBash() throws ClassRepositoryException {
+        JsonClassRepository repo = new JsonClassRepository(Path.of("data"));
+        List<ClassDefinition> classes = repo.findAll();
+
+        ClassDefinition warrior = findById(classes, "warrior");
+        List<String> ids = abilityIdValues(warrior.startingAbilityIds());
+
+        assertTrue(ids.contains("skill.bash"), "Warrior must have skill.bash");
+        assertEquals(1, ids.size(), "Warrior should have exactly 1 starting ability");
+    }
+
+    @Test
+    void mageHasFireballAndHeal() throws ClassRepositoryException {
+        JsonClassRepository repo = new JsonClassRepository(Path.of("data"));
+        List<ClassDefinition> classes = repo.findAll();
+
+        ClassDefinition mage = findById(classes, "mage");
+        List<String> ids = abilityIdValues(mage.startingAbilityIds());
+
+        assertTrue(ids.contains("spell.fireball"), "Mage must have spell.fireball");
+        assertTrue(ids.contains("spell.heal"), "Mage must have spell.heal");
+        assertEquals(2, ids.size(), "Mage should have exactly 2 starting abilities");
+    }
+
+    @Test
+    void adventurerHasBashAndHeal() throws ClassRepositoryException {
+        JsonClassRepository repo = new JsonClassRepository(Path.of("data"));
+        List<ClassDefinition> classes = repo.findAll();
+
+        ClassDefinition adventurer = findById(classes, "adventurer");
+        List<String> ids = abilityIdValues(adventurer.startingAbilityIds());
+
+        assertTrue(ids.contains("skill.bash"), "Adventurer must have skill.bash");
+        assertTrue(ids.contains("spell.heal"), "Adventurer must have spell.heal");
+        assertEquals(2, ids.size(), "Adventurer should have exactly 2 starting abilities");
+    }
+
+    @Test
+    void classDefinitionWithNoAbilityIdsHasEmptyList() {
+        ClassDefinition def = new ClassDefinition(ClassId.of("test"), "Test", 0, 0);
+        assertFalse(def.startingAbilityIds() == null, "startingAbilityIds must never be null");
+        assertTrue(def.startingAbilityIds().isEmpty(), "4-arg constructor should yield empty list");
+    }
+
+    @Test
+    void classDefinitionWithAbilityIdsReturnsUnmodifiableList() {
+        List<AbilityId> ids = List.of(AbilityId.of("skill.bash"));
+        ClassDefinition def = new ClassDefinition(ClassId.of("test"), "Test", 0, 0, ids);
+        assertEquals(1, def.startingAbilityIds().size());
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private static ClassDefinition findById(List<ClassDefinition> classes, String id) {
+        return classes.stream()
+            .filter(c -> c.id().getValue().equals(id))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Class not found: " + id));
+    }
+
+    private static List<String> abilityIdValues(List<AbilityId> ids) {
+        return ids.stream().map(AbilityId::getValue).collect(Collectors.toList());
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/character/NewPlayerAbilitySeedingTest.java
+++ b/src/test/java/io/taanielo/jmud/core/character/NewPlayerAbilitySeedingTest.java
@@ -1,0 +1,220 @@
+package io.taanielo.jmud.core.character;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.ability.AbilityId;
+import io.taanielo.jmud.core.ability.AbilityRegistry;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.creation.CharacterCreationException;
+import io.taanielo.jmud.core.creation.CharacterCreationService;
+import io.taanielo.jmud.core.character.repository.ClassRepository;
+import io.taanielo.jmud.core.character.repository.ClassRepositoryException;
+import io.taanielo.jmud.core.character.repository.RaceRepository;
+import io.taanielo.jmud.core.character.repository.RaceRepositoryException;
+import io.taanielo.jmud.core.player.Player;
+
+/**
+ * Verifies that new-player ability seeding uses the chosen class's starting abilities,
+ * and that the learned-ability gate blocks use of unlearned abilities.
+ */
+class NewPlayerAbilitySeedingTest {
+
+    private static final AbilityId BASH = AbilityId.of("skill.bash");
+    private static final AbilityId HEAL = AbilityId.of("spell.heal");
+    private static final AbilityId FIREBALL = AbilityId.of("spell.fireball");
+
+    private static final ClassDefinition WARRIOR = new ClassDefinition(
+        ClassId.of("warrior"), "Warrior", 3, 20, List.of(BASH)
+    );
+    private static final ClassDefinition MAGE = new ClassDefinition(
+        ClassId.of("mage"), "Mage", -1, 5, List.of(FIREBALL, HEAL)
+    );
+    private static final ClassDefinition ADVENTURER = new ClassDefinition(
+        ClassId.of("adventurer"), "Adventurer", 0, 10, List.of(BASH, HEAL)
+    );
+
+    // ── CharacterCreationService.resolveClassDefinition ────────────────
+
+    @Test
+    void resolveClassDefinition_returnsFullDefinitionForWarrior()
+        throws CharacterCreationException {
+        CharacterCreationService svc = serviceWithClasses(WARRIOR, MAGE, ADVENTURER);
+
+        Optional<ClassDefinition> result = svc.resolveClassDefinition("warrior");
+
+        assertTrue(result.isPresent());
+        assertEquals(List.of(BASH), result.get().startingAbilityIds());
+    }
+
+    @Test
+    void resolveClassDefinition_caseInsensitive() throws CharacterCreationException {
+        CharacterCreationService svc = serviceWithClasses(WARRIOR, MAGE, ADVENTURER);
+
+        Optional<ClassDefinition> result = svc.resolveClassDefinition("MAGE");
+
+        assertTrue(result.isPresent());
+        assertTrue(result.get().startingAbilityIds().contains(FIREBALL));
+        assertTrue(result.get().startingAbilityIds().contains(HEAL));
+    }
+
+    @Test
+    void resolveClassDefinition_unknownInputReturnsEmpty() throws CharacterCreationException {
+        CharacterCreationService svc = serviceWithClasses(WARRIOR, MAGE, ADVENTURER);
+
+        assertTrue(svc.resolveClassDefinition("paladin").isEmpty());
+    }
+
+    @Test
+    void resolveClassDefinition_blankInputReturnsEmpty() throws CharacterCreationException {
+        CharacterCreationService svc = serviceWithClasses(WARRIOR, MAGE, ADVENTURER);
+
+        assertTrue(svc.resolveClassDefinition("").isEmpty());
+        assertTrue(svc.resolveClassDefinition(null).isEmpty());
+    }
+
+    // ── Player seeding ─────────────────────────────────────────────────
+
+    @Test
+    void newPlayerHasEmptyAbilitiesByDefault() {
+        Player player = newPlayer("Alice");
+        assertTrue(player.getLearnedAbilities().isEmpty(),
+            "A freshly created player must start with no abilities");
+    }
+
+    @Test
+    void playerSeedFromWarriorClassGivesBash() {
+        Player player = newPlayer("Bob").withLearnedAbilities(WARRIOR.startingAbilityIds());
+        assertEquals(List.of(BASH), player.getLearnedAbilities());
+    }
+
+    @Test
+    void playerSeedFromMageClassGivesFireballAndHeal() {
+        Player player = newPlayer("Cam").withLearnedAbilities(MAGE.startingAbilityIds());
+        List<AbilityId> learned = player.getLearnedAbilities();
+        assertTrue(learned.contains(FIREBALL));
+        assertTrue(learned.contains(HEAL));
+        assertEquals(2, learned.size());
+    }
+
+    @Test
+    void playerSeedFromAdventurerClassGivesBashAndHeal() {
+        Player player = newPlayer("Dan").withLearnedAbilities(ADVENTURER.startingAbilityIds());
+        List<AbilityId> learned = player.getLearnedAbilities();
+        assertTrue(learned.contains(BASH));
+        assertTrue(learned.contains(HEAL));
+        assertEquals(2, learned.size());
+    }
+
+    // ── Learned-ability gate via AbilityRegistry.findBestMatch ─────────
+
+    @Test
+    void abilityRegistryRejectsAbilitiesNotInLearnedList() {
+        // We test via findBestMatch which is what AbilityEngine uses.
+        AbilityRegistry registry = new AbilityRegistry(List.of());
+        Optional<io.taanielo.jmud.core.ability.AbilityMatch> match =
+            registry.findBestMatch("bash", List.of());
+        assertTrue(match.isEmpty(),
+            "findBestMatch with empty learned list must return empty");
+    }
+
+    @Test
+    void abilityRegistryAllowsAbilitiesInLearnedList() {
+        // Build a stub ability so findBestMatch can resolve it.
+        io.taanielo.jmud.core.ability.Ability bash = stubAbility("skill.bash", "bash");
+        AbilityRegistry registry = new AbilityRegistry(List.of(bash));
+
+        Optional<io.taanielo.jmud.core.ability.AbilityMatch> match =
+            registry.findBestMatch("bash", List.of(BASH));
+
+        assertFalse(match.isEmpty(),
+            "findBestMatch should find ability when it is in the learned list");
+        assertEquals(BASH, match.get().ability().id());
+    }
+
+    @Test
+    void abilityRegistryBlocksAbilityNotInLearnedList() {
+        io.taanielo.jmud.core.ability.Ability bash = stubAbility("skill.bash", "bash");
+        io.taanielo.jmud.core.ability.Ability fireball = stubAbility("spell.fireball", "fireball");
+        AbilityRegistry registry = new AbilityRegistry(List.of(bash, fireball));
+
+        // Player only knows bash, not fireball.
+        Optional<io.taanielo.jmud.core.ability.AbilityMatch> match =
+            registry.findBestMatch("fireball", List.of(BASH));
+
+        assertTrue(match.isEmpty(),
+            "findBestMatch must not match ability not in the learned list");
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private static Player newPlayer(String name) {
+        User user = User.of(Username.of(name), Password.hash("secret"));
+        return Player.of(user, "%h/%H hp>", false, List.of());
+    }
+
+    private static CharacterCreationService serviceWithClasses(ClassDefinition... defs) {
+        return new CharacterCreationService(
+            new StubRaceRepository(),
+            new StubClassRepository(List.of(defs))
+        );
+    }
+
+    private static io.taanielo.jmud.core.ability.Ability stubAbility(String id, String name) {
+        return new io.taanielo.jmud.core.ability.Ability() {
+            @Override public AbilityId id() { return AbilityId.of(id); }
+            @Override public String name() { return name; }
+            @Override public io.taanielo.jmud.core.ability.AbilityType type() {
+                return io.taanielo.jmud.core.ability.AbilityType.SKILL;
+            }
+            @Override public int level() { return 1; }
+            @Override public io.taanielo.jmud.core.ability.AbilityCost cost() {
+                return new io.taanielo.jmud.core.ability.AbilityCost(0, 0);
+            }
+            @Override public io.taanielo.jmud.core.ability.AbilityCooldown cooldown() {
+                return new io.taanielo.jmud.core.ability.AbilityCooldown(0);
+            }
+            @Override public io.taanielo.jmud.core.ability.AbilityTargeting targeting() {
+                return io.taanielo.jmud.core.ability.AbilityTargeting.HARMFUL;
+            }
+            @Override public List<String> aliases() { return List.of(); }
+            @Override public List<io.taanielo.jmud.core.ability.AbilityEffect> effects() {
+                return List.of();
+            }
+            @Override public List<io.taanielo.jmud.core.messaging.MessageSpec> messages() {
+                return List.of();
+            }
+        };
+    }
+
+    private static class StubRaceRepository implements RaceRepository {
+        @Override public Optional<Race> findById(RaceId id) { return Optional.empty(); }
+        @Override public List<Race> findAll() { return List.of(); }
+    }
+
+    private static class StubClassRepository implements ClassRepository {
+        private final List<ClassDefinition> classes;
+
+        StubClassRepository(List<ClassDefinition> classes) {
+            this.classes = classes;
+        }
+
+        @Override
+        public Optional<ClassDefinition> findById(ClassId id) {
+            return classes.stream().filter(c -> c.id().equals(id)).findFirst();
+        }
+
+        @Override
+        public List<ClassDefinition> findAll() {
+            return classes;
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/AbilitiesCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/AbilitiesCommandTest.java
@@ -1,0 +1,137 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Unit tests for {@link AbilitiesCommand}.
+ */
+class AbilitiesCommandTest {
+
+    // ── token matching ─────────────────────────────────────────────────
+
+    @Test
+    void matchesAbilitiesToken() {
+        AbilitiesCommand cmd = new AbilitiesCommand(new SocketCommandRegistry());
+        assertTrue(cmd.match("ABILITIES").isPresent());
+        assertTrue(cmd.match("abilities").isPresent());
+    }
+
+    @Test
+    void matchesAbAlias() {
+        AbilitiesCommand cmd = new AbilitiesCommand(new SocketCommandRegistry());
+        assertTrue(cmd.match("AB").isPresent());
+        assertTrue(cmd.match("ab").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        AbilitiesCommand cmd = new AbilitiesCommand(new SocketCommandRegistry());
+        assertFalse(cmd.match("SCORE").isPresent());
+        assertFalse(cmd.match("LOOK").isPresent());
+        assertFalse(cmd.match("").isPresent());
+    }
+
+    // ── delegation ─────────────────────────────────────────────────────
+
+    @Test
+    void executionDelegatesToSendAbilities() {
+        CapturingContext context = new CapturingContext("Alice");
+        AbilitiesCommand cmd = new AbilitiesCommand(new SocketCommandRegistry());
+
+        cmd.match("ABILITIES").get().execute(context);
+
+        assertTrue(context.sendAbilitiesCalled,
+            "ABILITIES command must delegate to context.sendAbilities()");
+    }
+
+    @Test
+    void abAliasDelegatesToSendAbilities() {
+        CapturingContext context = new CapturingContext("Alice");
+        AbilitiesCommand cmd = new AbilitiesCommand(new SocketCommandRegistry());
+
+        cmd.match("AB").get().execute(context);
+
+        assertTrue(context.sendAbilitiesCalled,
+            "AB alias must delegate to context.sendAbilities()");
+    }
+
+    // ── metadata ───────────────────────────────────────────────────────
+
+    @Test
+    void shortDescriptionMentionsAlias() {
+        AbilitiesCommand cmd = new AbilitiesCommand(new SocketCommandRegistry());
+        assertTrue(cmd.shortDescription().contains("AB"),
+            "shortDescription should mention AB alias");
+    }
+
+    @Test
+    void longDescriptionContainsUsage() {
+        AbilitiesCommand cmd = new AbilitiesCommand(new SocketCommandRegistry());
+        String desc = cmd.longDescription();
+        assertTrue(desc.contains("ABILITIES"), "longDescription should mention ABILITIES");
+        assertTrue(desc.contains("Usage"), "longDescription should contain usage instructions");
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private static Player stubPlayer(String name) {
+        User user = User.of(Username.of(name), Password.hash("secret"));
+        return Player.of(user, "%h/%H hp>");
+    }
+
+    private static class CapturingContext implements SocketCommandContext {
+        boolean sendAbilitiesCalled = false;
+        final List<String> lines = new ArrayList<>();
+        String promptMessage = "";
+        private final Player player;
+
+        CapturingContext(String playerName) {
+            this.player = stubPlayer(playerName);
+        }
+
+        @Override public void sendAbilities() { sendAbilitiesCalled = true; }
+        @Override public boolean isAuthenticated() { return true; }
+        @Override public Player getPlayer() { return player; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) { promptMessage = m; }
+        @Override public void writeLineSafe(String m) { lines.add(m); }
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) {}
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}


### PR DESCRIPTION
Closes #115

## Summary

- Each class definition (`class.warrior.json`, `class.mage.json`, `class.adventurer.json`) now declares a `startingAbilities` list of ability IDs.
- `ClassDefinition` and `ClassDto`/`ClassMapper` are updated to carry the starting abilities list through the data layer.
- `CharacterCreationService` seeds those abilities onto a new player via `AbilityRegistry` at the end of character creation.
- A new `AbilitiesCommand` (registered in `SocketCommandRegistry`) handles the `ABILITIES` socket command, printing every ability the player currently knows.
- `SocketClient` and `SocketCommandContext` receive any wiring needed to expose the player's ability set to the command.

## Test plan

- `ClassDefinitionStartingAbilitiesTest` — verifies that each class JSON deserialises with a non-empty `startingAbilities` list.
- `NewPlayerAbilitySeedingTest` — verifies that abilities are seeded onto the player during creation.
- `AbilitiesCommandTest` — verifies the command output lists the player's abilities correctly.
- Build passes (`./gradlew build`).