### PR TITLE
feat(server): add EMOTE command so players can express free-form actions in a room

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/EmoteCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/EmoteCommand.java
@@ -1,0 +1,80 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+import io.taanielo.jmud.core.player.Player;
+
+/**
+ * Handles the {@code EMOTE} / {@code ME} command, which lets a player express
+ * a free-form action from the third-person perspective.
+ *
+ * <p>Usage: {@code EMOTE <text>}  or  {@code ME <text>}
+ *
+ * <p>The player's name is automatically prepended to the action text:
+ * <ul>
+ *   <li>The acting player sees: {@code You emote: <Name> <text>}</li>
+ *   <li>Every other player in the same room sees: {@code <Name> <text>}</li>
+ *   <li>Players in other rooms see nothing.</li>
+ * </ul>
+ *
+ * <p>Invoking the command without any text prints: {@code Emote what?}
+ */
+public class EmoteCommand extends RegistrableCommand {
+
+    /**
+     * Creates an {@code EmoteCommand} and registers it with the given registry.
+     *
+     * @param registry the registry to register this command with
+     */
+    public EmoteCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "emote";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Express a free-form action visible to everyone in the room. Aliases: ME";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: EMOTE <text>  |  ME <text>\n"
+             + "  Describes an action from the third-person perspective.\n"
+             + "  Your name is prepended automatically.\n"
+             + "  You see: You emote: <YourName> <text>\n"
+             + "  Others in the room see: <YourName> <text>\n"
+             + "  Aliases: ME";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        String token = parts[0];
+        if (!"EMOTE".equals(token) && !"ME".equals(token)) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> handleEmote(context, args)));
+    }
+
+    private void handleEmote(SocketCommandContext context, String text) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to emote.");
+            return;
+        }
+        if (text == null || text.isBlank()) {
+            context.writeLineWithPrompt("Emote what?");
+            return;
+        }
+        Player player = context.getPlayer();
+        String playerName = player.getUsername().getValue();
+        String action = playerName + " " + text.trim();
+        context.sendToRoom(player, action);
+        context.writeLineSafe("You emote: " + action);
+        context.sendPrompt();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -26,6 +26,7 @@ public class SocketCommandRegistry {
         new InventoryCommand(registry);
         new EquipmentCommand(registry);
         new SayCommand(registry);
+        new EmoteCommand(registry);
         new TellCommand(registry);
         new GossipCommand(registry);
         new WhoCommand(registry);

--- a/src/test/java/io/taanielo/jmud/core/server/socket/EmoteCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/EmoteCommandTest.java
@@ -1,0 +1,192 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Unit tests for {@link EmoteCommand}.
+ */
+class EmoteCommandTest {
+
+    // --- token matching ---
+
+    @Test
+    void matchesEmoteToken() {
+        EmoteCommand cmd = new EmoteCommand(new SocketCommandRegistry());
+        assertTrue(cmd.match("EMOTE waves at the goblin.").isPresent());
+        assertTrue(cmd.match("emote waves at the goblin.").isPresent());
+    }
+
+    @Test
+    void matchesMeAlias() {
+        EmoteCommand cmd = new EmoteCommand(new SocketCommandRegistry());
+        assertTrue(cmd.match("ME bows deeply.").isPresent());
+        assertTrue(cmd.match("me bows deeply.").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        EmoteCommand cmd = new EmoteCommand(new SocketCommandRegistry());
+        assertFalse(cmd.match("SAY hello").isPresent());
+        assertFalse(cmd.match("GOSSIP hello").isPresent());
+        assertFalse(cmd.match("LOOK").isPresent());
+        assertFalse(cmd.match("").isPresent());
+    }
+
+    // --- room-broadcast behaviour ---
+
+    @Test
+    void actingPlayerSeesYouEmoteLine() {
+        CapturingContext context = new CapturingContext("Taaniel");
+
+        EmoteCommand cmd = new EmoteCommand(new SocketCommandRegistry());
+        cmd.match("EMOTE waves at the goblin.").get().execute(context);
+
+        assertTrue(context.lines.stream().anyMatch(l -> l.equals("You emote: Taaniel waves at the goblin.")),
+                "Acting player should see 'You emote: <Name> <text>'");
+    }
+
+    @Test
+    void roomReceivesNamePrependedAction() {
+        CapturingContext context = new CapturingContext("Taaniel");
+
+        EmoteCommand cmd = new EmoteCommand(new SocketCommandRegistry());
+        cmd.match("EMOTE waves at the goblin.").get().execute(context);
+
+        assertEquals("Taaniel waves at the goblin.", context.lastRoomMessage,
+                "Room occupants should see '<Name> <text>'");
+    }
+
+    @Test
+    void meAliasAlsoBroadcastsToRoom() {
+        CapturingContext context = new CapturingContext("Taaniel");
+
+        EmoteCommand cmd = new EmoteCommand(new SocketCommandRegistry());
+        cmd.match("ME bows deeply.").get().execute(context);
+
+        assertEquals("Taaniel bows deeply.", context.lastRoomMessage,
+                "ME alias should also broadcast to the room");
+        assertTrue(context.lines.stream().anyMatch(l -> l.equals("You emote: Taaniel bows deeply.")),
+                "ME alias should show 'You emote:' to the acting player");
+    }
+
+    @Test
+    void playersOutsideRoomReceiveNothing() {
+        // sendToRoom is the sole broadcast mechanism; players outside are not
+        // reachable via that call. We verify only the room message is set and
+        // no global broadcast (gossip) was triggered.
+        CapturingContext context = new CapturingContext("Taaniel");
+
+        EmoteCommand cmd = new EmoteCommand(new SocketCommandRegistry());
+        cmd.match("EMOTE waves.").get().execute(context);
+
+        assertNull(context.gossipSender, "Emote must NOT trigger a gossip broadcast");
+    }
+
+    // --- blank / empty text ---
+
+    @Test
+    void blankEmoteShowsUsageHint() {
+        CapturingContext context = new CapturingContext("Taaniel");
+
+        EmoteCommand cmd = new EmoteCommand(new SocketCommandRegistry());
+        cmd.match("EMOTE").get().execute(context);
+
+        assertEquals("Emote what?", context.promptMessage,
+                "Blank EMOTE should print 'Emote what?'");
+    }
+
+    @Test
+    void whitespaceOnlyEmoteShowsUsageHint() {
+        CapturingContext context = new CapturingContext("Taaniel");
+
+        EmoteCommand cmd = new EmoteCommand(new SocketCommandRegistry());
+        cmd.match("EMOTE    ").get().execute(context);
+
+        assertEquals("Emote what?", context.promptMessage,
+                "Whitespace-only EMOTE should print 'Emote what?'");
+    }
+
+    // --- help metadata ---
+
+    @Test
+    void shortDescriptionMentionsMeAlias() {
+        EmoteCommand cmd = new EmoteCommand(new SocketCommandRegistry());
+        assertTrue(cmd.shortDescription().contains("ME"),
+                "shortDescription should mention ME alias");
+    }
+
+    @Test
+    void longDescriptionContainsUsageAndAliases() {
+        EmoteCommand cmd = new EmoteCommand(new SocketCommandRegistry());
+        String desc = cmd.longDescription();
+        assertTrue(desc.contains("EMOTE"), "longDescription should mention EMOTE");
+        assertTrue(desc.contains("ME"), "longDescription should mention ME alias");
+        assertTrue(desc.contains("Usage"), "longDescription should contain usage instructions");
+    }
+
+    // --- helpers ---
+
+    private static Player stubPlayer(String name) {
+        User user = User.of(Username.of(name), Password.hash("secret"));
+        return Player.of(user, "%h/%H hp>");
+    }
+
+    private static class CapturingContext implements SocketCommandContext {
+        final List<String> lines = new ArrayList<>();
+        String promptMessage = "";
+        String lastRoomMessage = null;
+        String gossipSender = null;
+        private final Player player;
+
+        CapturingContext(String playerName) {
+            this.player = stubPlayer(playerName);
+        }
+
+        @Override public void gossip(String senderName, String message) { this.gossipSender = senderName; }
+        @Override public boolean isAuthenticated() { return true; }
+        @Override public Player getPlayer() { return player; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) { promptMessage = m; }
+        @Override public void writeLineSafe(String m) { lines.add(m); }
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) {}
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) { lastRoomMessage = m; }
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `EMOTE` command that lets players express free-form actions visible to everyone in the same room
- Registers `EmoteCommand` in `SocketCommandRegistry` alongside other communication commands
- Includes unit tests covering the emote broadcast behaviour

## Test plan

- [ ] Connect as a player, type `EMOTE waves hello` and verify all players in the room see `<PlayerName> waves hello`
- [ ] Verify the emote is NOT sent to players in other rooms
- [ ] Verify an empty emote argument is handled gracefully
- [ ] Run `./gradlew test` and confirm `EmoteCommandTest` passes

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)