### PR TITLE
feat(combat): wire aggressive mob combat so hostile mobs attack players on sight

### DIFF
--- a/data/mobs/giant-spider.json
+++ b/data/mobs/giant-spider.json
@@ -4,7 +4,7 @@
   "name": "Giant Spider",
   "max_hp": 14,
   "attack_id": "attack.spider",
-  "aggressive": false,
+  "aggressive": true,
   "spawn_room_id": "dark-burrow",
   "max_count": 2,
   "respawn_ticks": 20,

--- a/data/mobs/kobold.json
+++ b/data/mobs/kobold.json
@@ -4,7 +4,7 @@
   "name": "Kobold",
   "max_hp": 12,
   "attack_id": "attack.kobold",
-  "aggressive": false,
+  "aggressive": true,
   "spawn_room_id": "rocky-alcove",
   "max_count": 2,
   "respawn_ticks": 25,

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -197,6 +197,11 @@ public class MobRegistry implements Tickable {
         if (attack == null) {
             return;
         }
+
+        boolean firstEngagement = !mob.engagedPlayers().contains(targetUsername);
+        mob.engage(targetUsername);
+        playerCombatTargets.put(targetUsername, mob.instanceId());
+
         int damage = rollDamage(attack);
         Player damagedPlayer = target.withVitals(target.getVitals().damage(damage));
 
@@ -204,9 +209,15 @@ public class MobRegistry implements Tickable {
             handleMobKill(mob, damagedPlayer, candidates);
         } else {
             playerRepository.savePlayer(damagedPlayer);
-            String hitMsg = "The " + mob.template().name() + " hits you for " + damage + " damage!";
+            List<GameMessage> messages = new ArrayList<>();
+            if (firstEngagement) {
+                messages.add(GameMessage.toSource(
+                    "The " + mob.template().name() + " lunges at you!"));
+            }
+            messages.add(GameMessage.toSource(
+                "The " + mob.template().name() + " hits you for " + damage + " damage!"));
             playerEventBus.publish(targetUsername,
-                new GameActionResult(damagedPlayer, null, List.of(GameMessage.toSource(hitMsg))));
+                new GameActionResult(damagedPlayer, null, messages));
         }
     }
 

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryAggressiveMobTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryAggressiveMobTest.java
@@ -1,0 +1,176 @@
+package io.taanielo.jmud.core.mob;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.action.GameActionResult;
+import io.taanielo.jmud.core.action.PlayerEventBus;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.combat.AttackDefinition;
+import io.taanielo.jmud.core.combat.AttackId;
+import io.taanielo.jmud.core.combat.CombatSettings;
+import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.combat.repository.AttackRepositoryException;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.ItemRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Unit tests verifying that an aggressive mob automatically initiates combat
+ * against a player in the same room on the next tick.
+ */
+class MobRegistryAggressiveMobTest {
+
+    private static final RoomId ROOM_ID = RoomId.of("room.test");
+    private static final AttackId DEFAULT_ATTACK =
+        AttackId.of(CombatSettings.DEFAULT_ATTACK_ID);
+    private static final AttackDefinition ONE_DMG_ATTACK =
+        new AttackDefinition(DEFAULT_ATTACK, "punch", 1, 1, 0, 0, 0, List.of());
+
+    private Player player(String name) {
+        User user = User.of(Username.of(name), Password.hash("pw", 1));
+        return Player.of(user, "%hp> ");
+    }
+
+    /**
+     * Builds a {@link MobRegistry} containing a single aggressive mob with a
+     * valid attack definition, and places the given player in the mob's room.
+     */
+    private MobRegistry buildRegistryWithAggressiveMob(Player target, int mobHp) {
+        MobTemplate template = new MobTemplate(
+            MobId.of("mob.spider"),
+            "Giant Spider",
+            mobHp,
+            DEFAULT_ATTACK,
+            true,   // aggressive
+            List.of(),
+            ROOM_ID,
+            1,
+            10,
+            5
+        );
+        MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
+        AttackRepository attackRepo = new StubAttackRepository(Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));
+        ItemRepository itemRepo = new StubItemRepository(Map.of());
+
+        RoomService roomService = new RoomService(new StubRoomRepository(ROOM_ID), ROOM_ID);
+        roomService.ensurePlayerLocation(target.getUsername());
+
+        PlayerRepository playerRepo = new StubPlayerRepository(target);
+        PlayerEventBus bus = new PlayerEventBus();
+
+        MobRegistry registry = new MobRegistry(
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo, bus);
+        registry.init();
+        return registry;
+    }
+
+    @Test
+    void aggressiveMob_addsPlayerToCombatTargets_afterTick() {
+        Player target = player("hero");
+        MobRegistry registry = buildRegistryWithAggressiveMob(target, 100);
+
+        assertFalse(registry.isInCombat(target.getUsername()),
+            "Player should not be in combat before the first tick");
+
+        registry.tick();
+
+        assertTrue(registry.isInCombat(target.getUsername()),
+            "Player should be in combat after the aggressive mob's first tick");
+    }
+
+    @Test
+    void aggressiveMob_playerCanFleeAfterAggressiveEngagement() {
+        Player target = player("hero");
+        MobRegistry registry = buildRegistryWithAggressiveMob(target, 100);
+
+        registry.tick();
+        assertTrue(registry.isInCombat(target.getUsername()),
+            "Precondition: aggressive mob should have engaged the player");
+
+        registry.fleeCombat(target.getUsername());
+
+        assertFalse(registry.isInCombat(target.getUsername()),
+            "Player should no longer be in combat after fleeing from aggressive mob");
+    }
+
+    // ── stubs ─────────────────────────────────────────────────────────
+
+    private record StubMobTemplateRepository(List<MobTemplate> templates)
+        implements MobTemplateRepository {
+        @Override
+        public List<MobTemplate> findAll() { return templates; }
+    }
+
+    private record StubAttackRepository(Map<AttackId, AttackDefinition> attacks)
+        implements AttackRepository {
+        @Override
+        public Optional<AttackDefinition> findById(AttackId id) throws AttackRepositoryException {
+            return Optional.ofNullable(attacks.get(id));
+        }
+    }
+
+    private static class StubItemRepository implements ItemRepository {
+        private final Map<ItemId, Item> items;
+
+        StubItemRepository(Map<ItemId, Item> items) { this.items = Map.copyOf(items); }
+
+        @Override
+        public void save(Item item) throws RepositoryException {}
+
+        @Override
+        public Optional<Item> findById(ItemId id) throws RepositoryException {
+            return Optional.ofNullable(items.get(id));
+        }
+    }
+
+    private static class StubPlayerRepository implements PlayerRepository {
+        private final ConcurrentHashMap<Username, Player> store = new ConcurrentHashMap<>();
+
+        StubPlayerRepository(Player initial) {
+            store.put(initial.getUsername(), initial);
+        }
+
+        @Override
+        public void savePlayer(Player player) { store.put(player.getUsername(), player); }
+
+        @Override
+        public Optional<Player> loadPlayer(Username username) {
+            return Optional.ofNullable(store.get(username));
+        }
+    }
+
+    private static class StubRoomRepository implements RoomRepository {
+        private final Room room;
+
+        StubRoomRepository(RoomId roomId) {
+            this.room = new Room(
+                roomId, "Test Room", "A featureless void.", Map.of(), List.of(), List.of());
+        }
+
+        @Override
+        public void save(Room room) throws RepositoryException {}
+
+        @Override
+        public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return room.getId().equals(id) ? Optional.of(room) : Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
Closes #123

## Summary

- `MobRegistry.runMobAi` now calls `mob.engage()` and `playerCombatTargets.put()` before attacking, and sends a distinct lunge initiation message on first engagement so players know combat has started
- Set `"aggressive": true` in `data/mobs/giant-spider.json` and `data/mobs/kobold.json` so those mobs attack players on sight
- Added `MobRegistryAggressiveMobTest` with tests verifying a player enters combat after an AI tick and can successfully FLEE

## Test plan

- [ ] Run `./gradlew test` and confirm `MobRegistryAggressiveMobTest` passes
- [ ] Start the server, enter a room with a giant-spider or kobold, and confirm the mob lunges and initiates combat immediately
- [ ] Confirm the FLEE command works to exit combat against an aggressive mob
- [ ] Confirm non-aggressive mobs do not auto-attack on player entry