### PR TITLE
feat(economy): add gold currency, mob gold drops, and shop NPC with BUY/LIST/SELL commands

### DIFF
--- a/data/mobs/goblin.json
+++ b/data/mobs/goblin.json
@@ -13,5 +13,9 @@
       "item_id": "health-potion",
       "drop_chance": 0.5
     }
-  ]
+  ],
+  "gold_drop": {
+    "min": 4,
+    "max": 10
+  }
 }

--- a/data/mobs/kobold.json
+++ b/data/mobs/kobold.json
@@ -13,5 +13,9 @@
       "item_id": "health-potion",
       "drop_chance": 0.3
     }
-  ]
+  ],
+  "gold_drop": {
+    "min": 2,
+    "max": 7
+  }
 }

--- a/data/mobs/rat.json
+++ b/data/mobs/rat.json
@@ -8,5 +8,9 @@
   "spawn_room_id": "muddy-hollow",
   "max_count": 3,
   "respawn_ticks": 15,
-  "loot": []
+  "loot": [],
+  "gold_drop": {
+    "min": 1,
+    "max": 4
+  }
 }

--- a/data/shops/shop.armory.json
+++ b/data/shops/shop.armory.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "armory-shop",
+  "name": "Torbal the Armorer",
+  "room_id": "armory",
+  "stock": [
+    {"item_id": "iron-sword"},
+    {"item_id": "training-shield"},
+    {"item_id": "health-potion"}
+  ],
+  "sell_ratio": 0.5
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/GoldDrop.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/GoldDrop.java
@@ -1,0 +1,35 @@
+package io.taanielo.jmud.core.mob;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Defines the gold-drop range for a mob template.
+ *
+ * <p>When a mob carrying a {@code GoldDrop} is killed, a random integer
+ * in {@code [min, max]} (inclusive) is awarded to the killing player.
+ */
+public record GoldDrop(int min, int max) {
+
+    public GoldDrop {
+        if (min < 0) {
+            throw new IllegalArgumentException("GoldDrop min must be non-negative, got " + min);
+        }
+        if (max < min) {
+            throw new IllegalArgumentException(
+                "GoldDrop max must be >= min, got min=" + min + " max=" + max);
+        }
+    }
+
+    /**
+     * Rolls a random gold amount within {@code [min, max]} using the calling
+     * thread's {@link ThreadLocalRandom}.
+     *
+     * @return a value in {@code [min, max]} inclusive
+     */
+    public int roll() {
+        if (min == max) {
+            return min;
+        }
+        return min + ThreadLocalRandom.current().nextInt(max - min + 1);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -163,12 +163,22 @@ public class MobRegistry implements Tickable {
             endCombatForMob(mob);
             Player reloaded = playerRepository.loadPlayer(attacker.getUsername()).orElse(attacker);
             LevelUpResult levelUpResult = levelUpService.awardXp(reloaded, mob.template().xpReward());
-            playerRepository.savePlayer(levelUpResult.player());
+            Player afterXp = levelUpResult.player();
+            if (mob.template().goldDrop() != null) {
+                int gold = mob.template().goldDrop().roll();
+                if (gold > 0) {
+                    afterXp = afterXp.addGold(gold);
+                    messages.add(GameMessage.toSource(
+                        "The " + mob.template().name() + " drops " + gold + " gold coin"
+                            + (gold == 1 ? "" : "s") + "."));
+                }
+            }
+            playerRepository.savePlayer(afterXp);
             messages.add(GameMessage.toSource(
                 "You gain " + mob.template().xpReward() + " experience points."));
             if (levelUpResult.leveledUp()) {
                 messages.add(GameMessage.toSource(
-                    "You have advanced to level " + levelUpResult.player().getLevel() + "!"));
+                    "You have advanced to level " + afterXp.getLevel() + "!"));
             }
         }
         return new GameActionResult(null, null, messages);
@@ -292,12 +302,22 @@ public class MobRegistry implements Tickable {
                 endCombatForMob(mob);
                 Player reloaded = playerRepository.loadPlayer(username).orElse(player);
                 LevelUpResult levelUpResult = levelUpService.awardXp(reloaded, mob.template().xpReward());
-                playerRepository.savePlayer(levelUpResult.player());
+                Player afterXp = levelUpResult.player();
+                if (mob.template().goldDrop() != null) {
+                    int gold = mob.template().goldDrop().roll();
+                    if (gold > 0) {
+                        afterXp = afterXp.addGold(gold);
+                        messages.add(GameMessage.toSource(
+                            "The " + mob.template().name() + " drops " + gold + " gold coin"
+                                + (gold == 1 ? "" : "s") + "."));
+                    }
+                }
+                playerRepository.savePlayer(afterXp);
                 messages.add(GameMessage.toSource(
                     "You gain " + mob.template().xpReward() + " experience points."));
                 if (levelUpResult.leveledUp()) {
                     messages.add(GameMessage.toSource(
-                        "You have advanced to level " + levelUpResult.player().getLevel() + "!"));
+                        "You have advanced to level " + afterXp.getLevel() + "!"));
                 }
             }
             playerEventBus.publish(username, new GameActionResult(null, null, messages));

--- a/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
@@ -19,7 +19,9 @@ public record MobTemplate(
     RoomId spawnRoomId,
     int maxCount,
     int respawnTicks,
-    int xpReward
+    int xpReward,
+    /** Optional gold-drop range; {@code null} means this mob drops no gold. */
+    GoldDrop goldDrop
 ) {
     public MobTemplate {
         if (maxHp <= 0) {

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/GoldDropDto.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/GoldDropDto.java
@@ -1,0 +1,7 @@
+package io.taanielo.jmud.core.mob.dto;
+
+/**
+ * JSON transfer object for the optional {@code gold_drop} block inside a mob template.
+ */
+public record GoldDropDto(int min, int max) {
+}

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
@@ -13,6 +13,7 @@ public record MobTemplateDto(
     String spawnRoomId,
     int maxCount,
     int respawnTicks,
-    Integer xpReward
+    Integer xpReward,
+    GoldDropDto goldDrop
 ) {
 }

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 import io.taanielo.jmud.core.combat.AttackId;
+import io.taanielo.jmud.core.mob.GoldDrop;
 import io.taanielo.jmud.core.mob.LootEntry;
 import io.taanielo.jmud.core.mob.MobId;
 import io.taanielo.jmud.core.mob.MobTemplate;
@@ -20,6 +21,9 @@ public class MobTemplateDtoMapper {
             .toList();
         boolean aggressive = dto.aggressive() == null || dto.aggressive();
         int xpReward = dto.xpReward() != null ? dto.xpReward() : dto.maxHp();
+        GoldDrop goldDrop = dto.goldDrop() != null
+            ? new GoldDrop(dto.goldDrop().min(), dto.goldDrop().max())
+            : null;
         return new MobTemplate(
             MobId.of(dto.id()),
             dto.name(),
@@ -30,7 +34,8 @@ public class MobTemplateDtoMapper {
             RoomId.of(dto.spawnRoomId()),
             dto.maxCount(),
             dto.respawnTicks(),
-            xpReward
+            xpReward,
+            goldDrop
         );
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/player/Player.java
+++ b/src/main/java/io/taanielo/jmud/core/player/Player.java
@@ -25,6 +25,8 @@ public class Player implements EffectTarget, Combatant {
     private final PlayerAbilities abilities;
     private final PlayerInventory inventory;
     private final PlayerEquipment equipment;
+    /** Persisted gold balance; never negative. */
+    private final int gold;
     /** In-memory only — never serialised to JSON; cleared on disconnect/reload. */
     private final boolean resting;
 
@@ -65,6 +67,7 @@ public class Player implements EffectTarget, Combatant {
             classId,
             false,
             null,
+            null,
             null
         );
     }
@@ -83,7 +86,8 @@ public class Player implements EffectTarget, Combatant {
         @JsonProperty("class") ClassId classId,
         @JsonProperty("dead") Boolean dead,
         @JsonProperty("inventory") List<Item> inventory,
-        @JsonProperty("equipment") PlayerEquipment equipment
+        @JsonProperty("equipment") PlayerEquipment equipment,
+        @JsonProperty("gold") Integer gold
     ) {
         this(
             new PlayerIdentity(user, level, experience, race, classId),
@@ -91,7 +95,9 @@ public class Player implements EffectTarget, Combatant {
             new PlayerPreferences(promptFormat, ansiEnabled),
             new PlayerAbilities(learnedAbilities),
             new PlayerInventory(inventory),
-            equipment == null ? PlayerEquipment.empty() : equipment
+            equipment == null ? PlayerEquipment.empty() : equipment,
+            false,
+            gold == null ? 0 : Math.max(0, gold)
         );
     }
 
@@ -103,7 +109,7 @@ public class Player implements EffectTarget, Combatant {
         PlayerInventory inventory,
         PlayerEquipment equipment
     ) {
-        this(identity, combatState, preferences, abilities, inventory, equipment, false);
+        this(identity, combatState, preferences, abilities, inventory, equipment, false, 0);
     }
 
     private Player(
@@ -113,7 +119,8 @@ public class Player implements EffectTarget, Combatant {
         PlayerAbilities abilities,
         PlayerInventory inventory,
         PlayerEquipment equipment,
-        boolean resting
+        boolean resting,
+        int gold
     ) {
         this.identity = Objects.requireNonNull(identity, "Identity is required");
         this.combatState = Objects.requireNonNull(combatState, "Combat state is required");
@@ -121,6 +128,7 @@ public class Player implements EffectTarget, Combatant {
         this.abilities = Objects.requireNonNull(abilities, "Abilities are required");
         this.inventory = Objects.requireNonNull(inventory, "Inventory is required");
         this.equipment = Objects.requireNonNull(equipment, "Equipment is required");
+        this.gold = Math.max(0, gold);
         this.resting = resting;
     }
 
@@ -189,6 +197,11 @@ public class Player implements EffectTarget, Combatant {
         return equipment;
     }
 
+    @JsonProperty("gold")
+    public int getGold() {
+        return gold;
+    }
+
     public PlayerIdentity identity() {
         return identity;
     }
@@ -249,54 +262,54 @@ public class Player implements EffectTarget, Combatant {
             return this;
         }
         // Dying always clears the resting flag.
-        return new Player(identity, combatState.die(), preferences, abilities, inventory, equipment, false);
+        return new Player(identity, combatState.die(), preferences, abilities, inventory, equipment, false, gold);
     }
 
     public Player respawn() {
-        return new Player(identity, combatState.respawn(), preferences, abilities, inventory, equipment, false);
+        return new Player(identity, combatState.respawn(), preferences, abilities, inventory, equipment, false, gold);
     }
 
     public Player withoutEffects() {
-        return new Player(identity, combatState.withoutEffects(), preferences, abilities, inventory, equipment, resting);
+        return new Player(identity, combatState.withoutEffects(), preferences, abilities, inventory, equipment, resting, gold);
     }
 
     public Player withAnsiEnabled(boolean enabled) {
-        return new Player(identity, combatState, preferences.withAnsiEnabled(enabled), abilities, inventory, equipment, resting);
+        return new Player(identity, combatState, preferences.withAnsiEnabled(enabled), abilities, inventory, equipment, resting, gold);
     }
 
     public Player withVitals(PlayerVitals updatedVitals) {
-        return new Player(identity, combatState.withVitals(updatedVitals), preferences, abilities, inventory, equipment, resting);
+        return new Player(identity, combatState.withVitals(updatedVitals), preferences, abilities, inventory, equipment, resting, gold);
     }
 
     public Player withDead(boolean dead) {
-        return new Player(identity, combatState.withDead(dead), preferences, abilities, inventory, equipment, resting);
+        return new Player(identity, combatState.withDead(dead), preferences, abilities, inventory, equipment, resting, gold);
     }
 
     public Player withLearnedAbilities(List<AbilityId> learnedAbilities) {
-        return new Player(identity, combatState, preferences, abilities.withLearned(learnedAbilities), inventory, equipment, resting);
+        return new Player(identity, combatState, preferences, abilities.withLearned(learnedAbilities), inventory, equipment, resting, gold);
     }
 
     public Player withInventory(List<Item> items) {
-        return new Player(identity, combatState, preferences, abilities, inventory.withItems(items), equipment, resting);
+        return new Player(identity, combatState, preferences, abilities, inventory.withItems(items), equipment, resting, gold);
     }
 
     public Player addItem(Item item) {
-        return new Player(identity, combatState, preferences, abilities, inventory.addItem(item), equipment, resting);
+        return new Player(identity, combatState, preferences, abilities, inventory.addItem(item), equipment, resting, gold);
     }
 
     public Player removeItem(Item item) {
-        return new Player(identity, combatState, preferences, abilities, inventory.removeItem(item), equipment, resting);
+        return new Player(identity, combatState, preferences, abilities, inventory.removeItem(item), equipment, resting, gold);
     }
 
     public Player withEquipment(PlayerEquipment nextEquipment) {
-        return new Player(identity, combatState, preferences, abilities, inventory, nextEquipment, resting);
+        return new Player(identity, combatState, preferences, abilities, inventory, nextEquipment, resting, gold);
     }
 
     /**
      * Returns a copy of this player with the given identity (level and experience).
      */
     public Player withIdentity(PlayerIdentity nextIdentity) {
-        return new Player(nextIdentity, combatState, preferences, abilities, inventory, equipment, resting);
+        return new Player(nextIdentity, combatState, preferences, abilities, inventory, equipment, resting, gold);
     }
 
     /**
@@ -307,6 +320,24 @@ public class Player implements EffectTarget, Combatant {
      * @param resting {@code true} to enter a resting state, {@code false} to wake up
      */
     public Player withResting(boolean resting) {
-        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting);
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold);
+    }
+
+    /**
+     * Returns a copy of this player with the given gold balance.
+     *
+     * @param newGold the new gold amount; negative values are clamped to 0
+     */
+    public Player withGold(int newGold) {
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, newGold);
+    }
+
+    /**
+     * Returns a copy of this player with the given amount of gold added.
+     *
+     * @param amount amount to add; may be negative (clamped so balance never goes below 0)
+     */
+    public Player addGold(int amount) {
+        return withGold(gold + amount);
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/BuyCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/BuyCommand.java
@@ -1,0 +1,40 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the {@code BUY <item>} command, purchasing an item from the shop in the current room.
+ */
+public class BuyCommand extends RegistrableCommand {
+
+    public BuyCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "buy";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Buy an item from the shop in the current room.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: BUY <item name>\n"
+             + "  Purchases the named item from the shopkeeper. Deducts the item's price from\n"
+             + "  your gold. Use LIST to see what is available and the prices.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"BUY".equals(parts[0])) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> context.buyFromShop(args)));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
@@ -36,6 +36,10 @@ import io.taanielo.jmud.core.healing.HealingEngine;
 import io.taanielo.jmud.core.mob.MobRegistry;
 import io.taanielo.jmud.core.mob.MobRepositoryException;
 import io.taanielo.jmud.core.mob.repository.json.JsonMobTemplateRepository;
+import io.taanielo.jmud.core.shop.ShopRepository;
+import io.taanielo.jmud.core.shop.ShopRepositoryException;
+import io.taanielo.jmud.core.shop.ShopService;
+import io.taanielo.jmud.core.shop.repository.json.JsonShopRepository;
 import io.taanielo.jmud.core.player.EncumbranceService;
 import io.taanielo.jmud.core.player.JsonPlayerRepository;
 import io.taanielo.jmud.core.player.PlayerRepository;
@@ -76,7 +80,8 @@ public record GameContext(
     SocketCommandRegistry commandRegistry,
     PlayerEventBus playerEventBus,
     MobRegistry mobRegistry,
-    CharacterCreationService characterCreationService
+    CharacterCreationService characterCreationService,
+    ShopService shopService
 ) {
 
     /**
@@ -122,6 +127,7 @@ public record GameContext(
         }
 
         CharacterCreationService characterCreationService = createCharacterCreationService();
+        ShopService shopService = createShopService();
 
         return new GameContext(
             userRegistry,
@@ -146,7 +152,8 @@ public record GameContext(
             commandRegistry,
             playerEventBus,
             mobRegistry,
-            characterCreationService
+            characterCreationService,
+            shopService
         );
     }
 
@@ -230,6 +237,16 @@ public record GameContext(
             return new CharacterCreationService(new JsonRaceRepository(), new JsonClassRepository());
         } catch (RaceRepositoryException | ClassRepositoryException e) {
             throw new IllegalStateException("Failed to initialize character creation service: " + e.getMessage(), e);
+        }
+    }
+
+    private static ShopService createShopService() {
+        try {
+            ShopRepository shopRepository = new JsonShopRepository();
+            ItemRepository itemRepository = new JsonItemRepository();
+            return new ShopService(shopRepository, itemRepository);
+        } catch (ShopRepositoryException | RepositoryException e) {
+            throw new IllegalStateException("Failed to initialize shop service: " + e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GoldCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GoldCommand.java
@@ -1,0 +1,50 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+import io.taanielo.jmud.core.player.Player;
+
+/**
+ * Handles the {@code GOLD} command, displaying the player's current gold balance.
+ */
+public class GoldCommand extends RegistrableCommand {
+
+    public GoldCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "gold";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Display your current gold balance.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: GOLD\n"
+             + "  Shows how many gold coins you are currently carrying.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String token = SocketCommandParsing.firstToken(input);
+        if (!"GOLD".equals(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(new SocketCommandMatch(this, GoldCommand::handleGold));
+    }
+
+    private static void handleGold(SocketCommandContext context) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to check your gold.");
+            return;
+        }
+        Player player = context.getPlayer();
+        context.writeLineWithPrompt("You are carrying " + player.getGold() + " gold coin"
+            + (player.getGold() == 1 ? "" : "s") + ".");
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/ListCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/ListCommand.java
@@ -1,0 +1,41 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the {@code LIST} command, showing the shop's inventory in the current room.
+ *
+ * <p>If there is no shop in the current room, an appropriate error is printed.
+ */
+public class ListCommand extends RegistrableCommand {
+
+    public ListCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "list";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "List a nearby shop's inventory and prices.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: LIST\n"
+             + "  When a shopkeeper is present in the room, shows available wares with prices.\n"
+             + "  Prints an error if there is no shop here.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String token = SocketCommandParsing.firstToken(input);
+        if (!"LIST".equals(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(new SocketCommandMatch(this, SocketCommandContext::listShopInventory));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/ScoreCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/ScoreCommand.java
@@ -60,6 +60,7 @@ public class ScoreCommand extends RegistrableCommand {
         context.writeLineSafe(String.format("HP    : %d / %d", vitals.hp(), vitals.maxHp()));
         context.writeLineSafe(String.format("Mana  : %d / %d", vitals.mana(), vitals.maxMana()));
         context.writeLineSafe(String.format("Move  : %d / %d", vitals.move(), vitals.maxMove()));
+        context.writeLineSafe(String.format("Gold  : %d", player.getGold()));
         context.sendPrompt();
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SellCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SellCommand.java
@@ -1,0 +1,42 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the {@code SELL <item>} command, selling an item from the player's
+ * inventory to the shop in the current room.
+ */
+public class SellCommand extends RegistrableCommand {
+
+    public SellCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "sell";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Sell an item from your inventory to the shop in the current room.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: SELL <item name>\n"
+             + "  Sells the named item from your inventory to the shopkeeper for a fraction\n"
+             + "  of its base value (typically 50%). The item is removed from your inventory\n"
+             + "  and you receive gold in return.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"SELL".equals(parts[0])) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> context.sellToShop(args)));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -56,10 +56,13 @@ import io.taanielo.jmud.core.server.Client;
 import io.taanielo.jmud.core.server.ClientPool;
 import io.taanielo.jmud.core.server.connection.ClientConnection;
 import io.taanielo.jmud.core.server.connection.TransportSecurity;
+import io.taanielo.jmud.core.shop.Shop;
+import io.taanielo.jmud.core.shop.ShopTransactionResult;
 import io.taanielo.jmud.core.world.Direction;
 import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
 import io.taanielo.jmud.core.world.RoomService;
 
 @Slf4j
@@ -519,9 +522,15 @@ public class SocketClient implements Client {
             Map.of()
         );
         connection.writeLines(result.lines());
-        if (context.mobRegistry() != null && result.room() != null) {
-            var mobs = context.mobRegistry().getMobsInRoom(result.room().getId());
-            connection.writeLine(formatMonstersLine(mobs));
+        if (result.room() != null) {
+            if (context.mobRegistry() != null) {
+                var mobs = context.mobRegistry().getMobsInRoom(result.room().getId());
+                connection.writeLine(formatMonstersLine(mobs));
+            }
+            String shopLine = formatShopNpcLine(result.room().getId());
+            if (!shopLine.isEmpty()) {
+                connection.writeLine(shopLine);
+            }
         }
         sendPrompt();
     }
@@ -728,6 +737,24 @@ public class SocketClient implements Client {
         return "Monsters: " + body;
     }
 
+    /**
+     * Builds a shopkeeper NPC line for the given room, using the context's shop service.
+     *
+     * <p>Returns an empty string when there is no shop in the room or the service is unavailable.
+     *
+     * @param roomId the room to check for a shop
+     * @return a formatted line such as {@code "Merchant: Torbal the Armorer"}, or {@code ""}
+     */
+    private String formatShopNpcLine(RoomId roomId) {
+        if (context.shopService() == null || roomId == null) {
+            return "";
+        }
+        return context.shopService()
+            .findShopInRoom(roomId)
+            .map(shop -> "Merchant: " + shop.name())
+            .orElse("");
+    }
+
     private boolean isAuthenticatedUser(Username username) {
         return session.isAuthenticated()
             && session.getPlayer() != null
@@ -816,6 +843,12 @@ public class SocketClient implements Client {
                 var mobs = context.mobRegistry().getMobsInRoom(result.room().getId());
                 connection.writeLine(formatMonstersLine(mobs));
             }
+            if (result.room() != null) {
+                String shopLine = formatShopNpcLine(result.room().getId());
+                if (!shopLine.isEmpty()) {
+                    connection.writeLine(shopLine);
+                }
+            }
             sendPrompt();
         }
 
@@ -885,9 +918,15 @@ public class SocketClient implements Client {
                 deliverRoomMessage(player.getUsername(), null, arriveMessage);
             }
             connection.writeLines(result.lines());
-            if (result.moved() && context.mobRegistry() != null && result.room() != null) {
-                var mobs = context.mobRegistry().getMobsInRoom(result.room().getId());
-                connection.writeLine(formatMonstersLine(mobs));
+            if (result.moved() && result.room() != null) {
+                if (context.mobRegistry() != null) {
+                    var mobs = context.mobRegistry().getMobsInRoom(result.room().getId());
+                    connection.writeLine(formatMonstersLine(mobs));
+                }
+                String shopLine = formatShopNpcLine(result.room().getId());
+                if (!shopLine.isEmpty()) {
+                    connection.writeLine(shopLine);
+                }
             }
             sendPrompt();
         }
@@ -1313,6 +1352,89 @@ public class SocketClient implements Client {
             } else {
                 sendPrompt();
             }
+        }
+
+        @Override
+        public void listShopInventory() {
+            if (!session.isAuthenticated() || session.getPlayer() == null) {
+                writeLineWithPrompt("You must be logged in to browse a shop.");
+                return;
+            }
+            if (context.shopService() == null) {
+                writeLineWithPrompt("There is no shop here.");
+                return;
+            }
+            Player player = session.getPlayer();
+            var roomIdOpt = roomService.findPlayerLocation(player.getUsername());
+            if (roomIdOpt.isEmpty()) {
+                writeLineWithPrompt("You are nowhere.");
+                return;
+            }
+            var shopOpt = context.shopService().findShopInRoom(roomIdOpt.get());
+            if (shopOpt.isEmpty()) {
+                writeLineWithPrompt("There is no shop here.");
+                return;
+            }
+            for (String line : context.shopService().formatListing(shopOpt.get())) {
+                connection.writeLine(line);
+            }
+            sendPrompt();
+        }
+
+        @Override
+        public void buyFromShop(String args) {
+            if (!session.isAuthenticated() || session.getPlayer() == null) {
+                writeLineWithPrompt("You must be logged in to buy items.");
+                return;
+            }
+            if (context.shopService() == null) {
+                writeLineWithPrompt("There is no shop here.");
+                return;
+            }
+            Player player = session.getPlayer();
+            var roomIdOpt = roomService.findPlayerLocation(player.getUsername());
+            if (roomIdOpt.isEmpty()) {
+                writeLineWithPrompt("You are nowhere.");
+                return;
+            }
+            var shopOpt = context.shopService().findShopInRoom(roomIdOpt.get());
+            if (shopOpt.isEmpty()) {
+                writeLineWithPrompt("There is no shop here.");
+                return;
+            }
+            ShopTransactionResult result = context.shopService().buy(player, shopOpt.get(), args);
+            if (result.success()) {
+                session.replacePlayer(result.updatedPlayer());
+            }
+            writeLineWithPrompt(result.message());
+        }
+
+        @Override
+        public void sellToShop(String args) {
+            if (!session.isAuthenticated() || session.getPlayer() == null) {
+                writeLineWithPrompt("You must be logged in to sell items.");
+                return;
+            }
+            if (context.shopService() == null) {
+                writeLineWithPrompt("There is no shop here.");
+                return;
+            }
+            Player player = session.getPlayer();
+            var roomIdOpt = roomService.findPlayerLocation(player.getUsername());
+            if (roomIdOpt.isEmpty()) {
+                writeLineWithPrompt("You are nowhere.");
+                return;
+            }
+            var shopOpt = context.shopService().findShopInRoom(roomIdOpt.get());
+            if (shopOpt.isEmpty()) {
+                writeLineWithPrompt("There is no shop here.");
+                return;
+            }
+            ShopTransactionResult result = context.shopService().sell(player, shopOpt.get(), args);
+            if (result.success()) {
+                session.replacePlayer(result.updatedPlayer());
+            }
+            writeLineWithPrompt(result.message());
         }
 
         /** Called by the resting ticker to apply regenerated vitals. */

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -207,4 +207,41 @@ public interface SocketCommandContext extends Client {
      */
     default void stopResting(String message) {}
 
+    /**
+     * Lists the inventory of the shop in the current room.
+     *
+     * <p>Prints an error message when there is no shop here.
+     *
+     * <p>The default implementation is a no-op so that existing test stubs
+     * do not need to be updated.
+     */
+    default void listShopInventory() {}
+
+    /**
+     * Buys the named item from the shop in the current room.
+     *
+     * <p>Deducts the item's price from the player's gold and places the item
+     * in the player's inventory. Prints an error if the item is unknown or
+     * the player cannot afford it.
+     *
+     * <p>The default implementation is a no-op so that existing test stubs
+     * do not need to be updated.
+     *
+     * @param args the item name to buy
+     */
+    default void buyFromShop(String args) {}
+
+    /**
+     * Sells the named item from the player's inventory to the shop in the current room.
+     *
+     * <p>Removes the item from inventory and adds gold at the shop's sell ratio.
+     * Prints an error if the item is not in inventory.
+     *
+     * <p>The default implementation is a no-op so that existing test stubs
+     * do not need to be updated.
+     *
+     * @param args the item name to sell
+     */
+    default void sellToShop(String args) {}
+
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -40,6 +40,10 @@ public class SocketCommandRegistry {
         new RestCommand(registry);
         new WakeCommand(registry);
         new AnsiCommand(registry);
+        new GoldCommand(registry);
+        new ListCommand(registry);
+        new BuyCommand(registry);
+        new SellCommand(registry);
         new QuitCommand(registry);
         new HelpCommand(registry);
         return registry;

--- a/src/main/java/io/taanielo/jmud/core/shop/Shop.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/Shop.java
@@ -1,0 +1,34 @@
+package io.taanielo.jmud.core.shop;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * Immutable definition of a shopkeeper NPC loaded from data files.
+ *
+ * <p>A shop is associated with a single room via {@link #roomId()}.
+ * Its {@link #stock()} lists the items available for purchase and optional
+ * per-item prices. {@link #sellRatio()} determines what fraction of an
+ * item's base value the shop pays when a player sells an item.
+ */
+public record Shop(
+    ShopId id,
+    String name,
+    RoomId roomId,
+    List<StockEntry> stock,
+    double sellRatio
+) {
+    public Shop {
+        Objects.requireNonNull(id, "Shop id is required");
+        Objects.requireNonNull(name, "Shop name is required");
+        Objects.requireNonNull(roomId, "Shop roomId is required");
+        Objects.requireNonNull(stock, "Shop stock is required");
+        stock = List.copyOf(stock);
+        if (sellRatio < 0.0 || sellRatio > 1.0) {
+            throw new IllegalArgumentException(
+                "sellRatio must be between 0.0 and 1.0, got " + sellRatio);
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/shop/ShopId.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/ShopId.java
@@ -1,0 +1,21 @@
+package io.taanielo.jmud.core.shop;
+
+import java.util.Objects;
+
+/**
+ * Value object identifying a shop by its string id.
+ */
+public record ShopId(String value) {
+
+    public ShopId {
+        Objects.requireNonNull(value, "ShopId value is required");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("ShopId value must not be blank");
+        }
+    }
+
+    /** Creates a {@link ShopId} from a raw string. */
+    public static ShopId of(String value) {
+        return new ShopId(value);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/shop/ShopRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/ShopRepository.java
@@ -1,0 +1,27 @@
+package io.taanielo.jmud.core.shop;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * Data-access contract for {@link Shop} definitions.
+ */
+public interface ShopRepository {
+
+    /**
+     * Returns all shop definitions.
+     *
+     * @throws ShopRepositoryException when data cannot be read
+     */
+    List<Shop> findAll() throws ShopRepositoryException;
+
+    /**
+     * Returns the shop whose {@code roomId} matches the given room, or empty
+     * when there is no shop in that room.
+     *
+     * @throws ShopRepositoryException when data cannot be read
+     */
+    Optional<Shop> findByRoomId(RoomId roomId) throws ShopRepositoryException;
+}

--- a/src/main/java/io/taanielo/jmud/core/shop/ShopRepositoryException.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/ShopRepositoryException.java
@@ -1,0 +1,13 @@
+package io.taanielo.jmud.core.shop;
+
+/** Thrown when shop data cannot be loaded from persistent storage. */
+public class ShopRepositoryException extends Exception {
+
+    public ShopRepositoryException(String message) {
+        super(message);
+    }
+
+    public ShopRepositoryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/shop/ShopService.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/ShopService.java
@@ -1,0 +1,184 @@
+package io.taanielo.jmud.core.shop;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.repository.ItemRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+
+/**
+ * Application service for shop interactions: listing stock, buying, and selling items.
+ *
+ * <p>All operations are stateless with respect to the shop; the {@link Player}
+ * passed in is never mutated. Callers receive an updated {@link Player} in the
+ * returned {@link ShopTransactionResult} on success.
+ */
+@Slf4j
+public class ShopService {
+
+    private final ShopRepository shopRepository;
+    private final ItemRepository itemRepository;
+
+    public ShopService(ShopRepository shopRepository, ItemRepository itemRepository) {
+        this.shopRepository = Objects.requireNonNull(shopRepository, "shopRepository is required");
+        this.itemRepository = Objects.requireNonNull(itemRepository, "itemRepository is required");
+    }
+
+    /**
+     * Returns the shop located in the given room, if any.
+     */
+    public Optional<Shop> findShopInRoom(RoomId roomId) {
+        Objects.requireNonNull(roomId, "roomId is required");
+        try {
+            return shopRepository.findByRoomId(roomId);
+        } catch (ShopRepositoryException e) {
+            log.warn("Failed to look up shop in room {}: {}", roomId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Produces a formatted listing of the shop's available stock.
+     *
+     * @param shop the shop to list
+     * @return lines ready to be sent to the player's connection
+     */
+    public List<String> formatListing(Shop shop) {
+        Objects.requireNonNull(shop, "shop is required");
+        List<String> lines = new ArrayList<>();
+        lines.add(shop.name() + " — wares for sale:");
+        lines.add(String.format("  %-24s %-30s %s", "Item", "Description", "Price"));
+        lines.add("  " + "-".repeat(62));
+        for (StockEntry entry : shop.stock()) {
+            try {
+                Optional<Item> itemOpt = itemRepository.findById(entry.itemId());
+                if (itemOpt.isEmpty()) {
+                    log.warn("Shop {} references unknown item {}", shop.id(), entry.itemId());
+                    continue;
+                }
+                Item item = itemOpt.get();
+                int price = entry.price() != null ? entry.price() : item.getValue();
+                String desc = item.getDescription();
+                if (desc.length() > 29) {
+                    desc = desc.substring(0, 26) + "...";
+                }
+                lines.add(String.format("  %-24s %-30s %d gold", item.getName(), desc, price));
+            } catch (RepositoryException e) {
+                log.warn("Failed to load item {} for shop listing: {}", entry.itemId(), e.getMessage());
+            }
+        }
+        return lines;
+    }
+
+    /**
+     * Attempts to buy the named item from the shop on behalf of the player.
+     *
+     * @param player    the buying player
+     * @param shop      the shop being visited
+     * @param itemInput the name (or prefix) of the item to buy
+     * @return a result describing success or failure
+     */
+    public ShopTransactionResult buy(Player player, Shop shop, String itemInput) {
+        Objects.requireNonNull(player, "player is required");
+        Objects.requireNonNull(shop, "shop is required");
+        if (itemInput == null || itemInput.isBlank()) {
+            return ShopTransactionResult.failure("Buy what?");
+        }
+        String normalized = itemInput.trim().toLowerCase(Locale.ROOT);
+
+        // Find the stock entry matching the input.
+        StockEntry entry = null;
+        Item item = null;
+        for (StockEntry e : shop.stock()) {
+            try {
+                Optional<Item> itemOpt = itemRepository.findById(e.itemId());
+                if (itemOpt.isEmpty()) {
+                    continue;
+                }
+                Item candidate = itemOpt.get();
+                String name = candidate.getName().toLowerCase(Locale.ROOT);
+                if (name.equals(normalized) || name.startsWith(normalized)) {
+                    entry = e;
+                    item = candidate;
+                    break;
+                }
+            } catch (RepositoryException ex) {
+                log.warn("Failed to load item {} during buy lookup: {}", e.itemId(), ex.getMessage());
+            }
+        }
+
+        if (entry == null || item == null) {
+            return ShopTransactionResult.failure(
+                "The shop does not carry '" + itemInput.trim() + "'.");
+        }
+
+        int price = entry.price() != null ? entry.price() : item.getValue();
+        if (player.getGold() < price) {
+            return ShopTransactionResult.failure(
+                "You cannot afford that. It costs " + price + " gold and you only have "
+                    + player.getGold() + " gold.");
+        }
+
+        Player updated = player.addGold(-price).addItem(item);
+        return ShopTransactionResult.success(
+            "You buy a " + item.getName() + " for " + price + " gold. "
+                + "You now have " + updated.getGold() + " gold.",
+            updated
+        );
+    }
+
+    /**
+     * Attempts to sell the named item from the player's inventory to the shop.
+     *
+     * <p>The shop pays {@code floor(item.value * shop.sellRatio)} gold, minimum 0.
+     *
+     * @param player    the selling player
+     * @param shop      the shop being visited
+     * @param itemInput the name (or prefix) of the item to sell
+     * @return a result describing success or failure
+     */
+    public ShopTransactionResult sell(Player player, Shop shop, String itemInput) {
+        Objects.requireNonNull(player, "player is required");
+        Objects.requireNonNull(shop, "shop is required");
+        if (itemInput == null || itemInput.isBlank()) {
+            return ShopTransactionResult.failure("Sell what?");
+        }
+        String normalized = itemInput.trim().toLowerCase(Locale.ROOT);
+
+        Item found = null;
+        for (Item invItem : player.getInventory()) {
+            String name = invItem.getName().toLowerCase(Locale.ROOT);
+            if (name.equals(normalized) || name.startsWith(normalized)) {
+                found = invItem;
+                break;
+            }
+            String id = invItem.getId().getValue().toLowerCase(Locale.ROOT);
+            if (id.equals(normalized) || id.startsWith(normalized)) {
+                found = invItem;
+                break;
+            }
+        }
+
+        if (found == null) {
+            return ShopTransactionResult.failure(
+                "You are not carrying '" + itemInput.trim() + "'.");
+        }
+
+        int earned = (int) Math.floor(found.getValue() * shop.sellRatio());
+        Player updated = player.removeItem(found).addGold(earned);
+        return ShopTransactionResult.success(
+            "You sell the " + found.getName() + " for " + earned + " gold. "
+                + "You now have " + updated.getGold() + " gold.",
+            updated
+        );
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/shop/ShopTransactionResult.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/ShopTransactionResult.java
@@ -1,0 +1,22 @@
+package io.taanielo.jmud.core.shop;
+
+import io.taanielo.jmud.core.player.Player;
+
+/**
+ * Outcome of a {@link ShopService} buy or sell operation.
+ *
+ * <p>On success {@link #updatedPlayer()} holds the mutated player (inventory
+ * and/or gold changed). On failure {@link #updatedPlayer()} is {@code null}.
+ */
+public record ShopTransactionResult(boolean success, String message, Player updatedPlayer) {
+
+    /** Constructs a successful result with an updated player state. */
+    public static ShopTransactionResult success(String message, Player updatedPlayer) {
+        return new ShopTransactionResult(true, message, updatedPlayer);
+    }
+
+    /** Constructs a failure result with no player change. */
+    public static ShopTransactionResult failure(String message) {
+        return new ShopTransactionResult(false, message, null);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/shop/StockEntry.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/StockEntry.java
@@ -1,0 +1,18 @@
+package io.taanielo.jmud.core.shop;
+
+import java.util.Objects;
+
+import io.taanielo.jmud.core.world.ItemId;
+
+/**
+ * A single line in a shop's stock list.
+ *
+ * <p>{@code price} is optional; when {@code null} the shop uses the item's own
+ * {@code value} field as the buy price.
+ */
+public record StockEntry(ItemId itemId, Integer price) {
+
+    public StockEntry {
+        Objects.requireNonNull(itemId, "itemId is required");
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/shop/repository/json/JsonDataMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/repository/json/JsonDataMapper.java
@@ -1,0 +1,20 @@
+package io.taanielo.jmud.core.shop.repository.json;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+final class JsonDataMapper {
+    private JsonDataMapper() {
+    }
+
+    static ObjectMapper create() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        return mapper;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/shop/repository/json/JsonShopRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/repository/json/JsonShopRepository.java
@@ -1,0 +1,119 @@
+package io.taanielo.jmud.core.shop.repository.json;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.taanielo.jmud.core.shop.Shop;
+import io.taanielo.jmud.core.shop.ShopId;
+import io.taanielo.jmud.core.shop.ShopRepository;
+import io.taanielo.jmud.core.shop.ShopRepositoryException;
+import io.taanielo.jmud.core.shop.StockEntry;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * Loads {@link Shop} definitions from {@code data/shops/shop.*.json} files.
+ *
+ * <p>All shops are eagerly loaded and cached at construction time.
+ */
+@Slf4j
+public class JsonShopRepository implements ShopRepository {
+
+    private static final int SCHEMA_VERSION = 1;
+    private static final double DEFAULT_SELL_RATIO = 0.5;
+    private static final String SHOPS_DIR = "shops";
+
+    private final ObjectMapper objectMapper;
+    private final Path shopsDirPath;
+    private List<Shop> cache;
+
+    public JsonShopRepository() throws ShopRepositoryException {
+        this(Path.of("data"));
+    }
+
+    public JsonShopRepository(Path dataRoot) throws ShopRepositoryException {
+        this.objectMapper = JsonDataMapper.create();
+        this.shopsDirPath = Objects.requireNonNull(dataRoot, "Data root is required").resolve(SHOPS_DIR);
+        ensureDirectory(shopsDirPath);
+    }
+
+    @Override
+    public List<Shop> findAll() throws ShopRepositoryException {
+        if (cache == null) {
+            cache = load();
+        }
+        return cache;
+    }
+
+    @Override
+    public Optional<Shop> findByRoomId(RoomId roomId) throws ShopRepositoryException {
+        Objects.requireNonNull(roomId, "roomId is required");
+        return findAll().stream()
+            .filter(s -> s.roomId().equals(roomId))
+            .findFirst();
+    }
+
+    // ── private helpers ───────────────────────────────────────────────
+
+    private List<Shop> load() throws ShopRepositoryException {
+        List<Shop> shops = new ArrayList<>();
+        try (var stream = Files.list(shopsDirPath)) {
+            for (Path path : stream.filter(p -> p.toString().endsWith(".json")).toList()) {
+                ShopDto dto = readDto(path);
+                if (dto.schemaVersion() != SCHEMA_VERSION) {
+                    throw new ShopRepositoryException(
+                        "Unsupported shop schema version " + dto.schemaVersion() + " in " + path);
+                }
+                shops.add(toDomain(dto, path));
+            }
+        } catch (IOException e) {
+            throw new ShopRepositoryException("Failed to list shop data files: " + e.getMessage(), e);
+        }
+        log.info("Loaded {} shop(s) from {}", shops.size(), shopsDirPath);
+        return List.copyOf(shops);
+    }
+
+    private Shop toDomain(ShopDto dto, Path source) throws ShopRepositoryException {
+        try {
+            List<StockEntry> stock = dto.stock() == null ? List.of() : dto.stock().stream()
+                .map(e -> new StockEntry(ItemId.of(e.itemId()), e.price()))
+                .toList();
+            double sellRatio = dto.sellRatio() != null ? dto.sellRatio() : DEFAULT_SELL_RATIO;
+            return new Shop(
+                ShopId.of(dto.id()),
+                dto.name(),
+                RoomId.of(dto.roomId()),
+                stock,
+                sellRatio
+            );
+        } catch (IllegalArgumentException e) {
+            throw new ShopRepositoryException("Invalid shop data in " + source + ": " + e.getMessage(), e);
+        }
+    }
+
+    private ShopDto readDto(Path path) throws ShopRepositoryException {
+        try {
+            return objectMapper.readValue(path.toFile(), ShopDto.class);
+        } catch (IOException e) {
+            throw new ShopRepositoryException(
+                "Failed to read shop data from " + path + ": " + e.getMessage(), e);
+        }
+    }
+
+    private void ensureDirectory(Path path) throws ShopRepositoryException {
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new ShopRepositoryException("Failed to create shops directory " + path, e);
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/shop/repository/json/ShopDto.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/repository/json/ShopDto.java
@@ -1,0 +1,16 @@
+package io.taanielo.jmud.core.shop.repository.json;
+
+import java.util.List;
+
+/**
+ * JSON transfer object for a shop definition file ({@code shop.*.json}).
+ */
+record ShopDto(
+    int schemaVersion,
+    String id,
+    String name,
+    String roomId,
+    List<StockEntryDto> stock,
+    Double sellRatio
+) {
+}

--- a/src/main/java/io/taanielo/jmud/core/shop/repository/json/StockEntryDto.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/repository/json/StockEntryDto.java
@@ -1,0 +1,7 @@
+package io.taanielo.jmud.core.shop.repository.json;
+
+/**
+ * JSON transfer object for a single stock entry inside a shop definition.
+ */
+record StockEntryDto(String itemId, Integer price) {
+}

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryAggressiveMobTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryAggressiveMobTest.java
@@ -64,7 +64,8 @@ class MobRegistryAggressiveMobTest {
             ROOM_ID,
             1,
             10,
-            5
+            5,
+            null
         );
         MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
         AttackRepository attackRepo = new StubAttackRepository(Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryFleeCombatTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryFleeCombatTest.java
@@ -60,7 +60,8 @@ class MobRegistryFleeCombatTest {
             ROOM_ID,
             1,
             10,
-            5
+            5,
+            null
         );
         MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
         AttackRepository attackRepo = new StubAttackRepository(Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryGoldDropTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryGoldDropTest.java
@@ -1,0 +1,256 @@
+package io.taanielo.jmud.core.mob;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.action.GameActionResult;
+import io.taanielo.jmud.core.action.GameMessage;
+import io.taanielo.jmud.core.action.PlayerEventBus;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.combat.AttackDefinition;
+import io.taanielo.jmud.core.combat.AttackId;
+import io.taanielo.jmud.core.combat.CombatSettings;
+import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.combat.repository.AttackRepositoryException;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemAttributes;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.ItemRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Tests that gold is awarded to the killing player when a mob has a
+ * {@link GoldDrop} configured, via both the instant-kill
+ * ({@code processPlayerAttack}) and tick-based ({@code runPlayerCombat}) paths.
+ */
+class MobRegistryGoldDropTest {
+
+    private static final RoomId ROOM_ID = RoomId.of("room.test");
+    private static final AttackId DEFAULT_ATTACK =
+        AttackId.of(CombatSettings.DEFAULT_ATTACK_ID);
+    private static final AttackDefinition ONE_DMG_ATTACK =
+        new AttackDefinition(DEFAULT_ATTACK, "punch", 1, 1, 0, 0, 0, List.of());
+
+    // ── helpers ───────────────────────────────────────────────────────
+
+    private Player player(String name) {
+        User user = User.of(Username.of(name), Password.hash("pw", 1));
+        return Player.of(user, "%hp> ");
+    }
+
+    /** Creates a mob that drops a fixed [5, 5] range of gold (always 5). */
+    private MobTemplate templateWithFixedGoldDrop(int maxHp) {
+        GoldDrop drop = new GoldDrop(5, 5);
+        return new MobTemplate(
+            MobId.of("mob.goblin"),
+            "Goblin",
+            maxHp,
+            null,
+            false,
+            List.of(),
+            ROOM_ID,
+            1,
+            10,
+            5,
+            drop
+        );
+    }
+
+    /** Creates a mob with no gold drop. */
+    private MobTemplate templateWithNoGoldDrop(int maxHp) {
+        return new MobTemplate(
+            MobId.of("mob.rat"),
+            "Rat",
+            maxHp,
+            null,
+            false,
+            List.of(),
+            ROOM_ID,
+            1,
+            10,
+            5,
+            null
+        );
+    }
+
+    private MobRegistry buildRegistry(
+        MobTemplate template,
+        Player attacker,
+        StubPlayerRepository playerRepo,
+        List<GameActionResult> captured
+    ) {
+        MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
+        AttackRepository attackRepo = new StubAttackRepository(Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));
+        ItemRepository itemRepo = new StubItemRepository(Map.of());
+
+        RoomService roomService = new RoomService(new StubRoomRepository(ROOM_ID), ROOM_ID);
+        roomService.ensurePlayerLocation(attacker.getUsername());
+
+        PlayerEventBus bus = new PlayerEventBus();
+        bus.register(attacker.getUsername(), captured::add);
+
+        MobRegistry registry = new MobRegistry(
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo, bus);
+        registry.init();
+        return registry;
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────
+
+    /**
+     * When a player kills a mob in one hit via {@code processPlayerAttack}
+     * and the mob has a gold drop, the returned messages must contain a gold
+     * announcement and the player's saved gold must increase.
+     */
+    @Test
+    void processPlayerAttack_awardsGoldOnKill() {
+        Player attacker = player("hero");
+        MobTemplate template = templateWithFixedGoldDrop(1); // 1 HP → one-shot kill
+
+        StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        List<GameActionResult> captured = new ArrayList<>();
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured);
+
+        GameActionResult result = registry.processPlayerAttack(attacker, "Goblin", ROOM_ID);
+
+        List<String> texts = result.messages().stream()
+            .map(GameMessage::text)
+            .toList();
+
+        assertTrue(
+            texts.stream().anyMatch(t -> t.contains("gold coin")),
+            "Expected a gold drop message but got: " + texts);
+
+        Player saved = playerRepo.load(attacker.getUsername());
+        assertTrue(saved.getGold() > 0,
+            "Expected saved player to have gold > 0, got " + saved.getGold());
+        assertEquals(5, saved.getGold(), "Expected exactly 5 gold (fixed drop range 5-5)");
+    }
+
+    /**
+     * When a mob with no gold drop is killed, no gold message is emitted and
+     * the player's gold remains at 0.
+     */
+    @Test
+    void processPlayerAttack_noGoldMessage_whenGoldDropAbsent() {
+        Player attacker = player("hero");
+        MobTemplate template = templateWithNoGoldDrop(1);
+
+        StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        List<GameActionResult> captured = new ArrayList<>();
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured);
+
+        GameActionResult result = registry.processPlayerAttack(attacker, "Rat", ROOM_ID);
+
+        List<String> texts = result.messages().stream()
+            .map(GameMessage::text)
+            .toList();
+
+        assertTrue(
+            texts.stream().noneMatch(t -> t.contains("gold coin")),
+            "Expected no gold message for mob with no gold drop, but got: " + texts);
+
+        Player saved = playerRepo.load(attacker.getUsername());
+        assertEquals(0, saved.getGold(), "Expected 0 gold for mob with no gold drop");
+    }
+
+    /**
+     * When the killing blow lands during a combat tick ({@code runPlayerCombat}),
+     * the gold award must be published to the player via the event bus and
+     * the player's persisted gold must increase.
+     */
+    @Test
+    void runPlayerCombat_awardsGoldOnKill() {
+        Player attacker = player("hero");
+        // 2 HP: first attack leaves 1 HP, second tick finishes the mob.
+        MobTemplate template = templateWithFixedGoldDrop(2);
+
+        StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        List<GameActionResult> captured = new ArrayList<>();
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured);
+
+        // First hit — mob survives, combat is registered.
+        registry.processPlayerAttack(attacker, "Goblin", ROOM_ID);
+        captured.clear();
+
+        // Tick — killing blow via runPlayerCombat.
+        registry.tick();
+
+        List<String> allTexts = captured.stream()
+            .flatMap(r -> r.messages().stream())
+            .map(GameMessage::text)
+            .toList();
+
+        assertTrue(
+            allTexts.stream().anyMatch(t -> t.contains("gold coin")),
+            "Expected gold drop message on tick kill, but got: " + allTexts);
+
+        Player saved = playerRepo.load(attacker.getUsername());
+        assertTrue(saved.getGold() > 0,
+            "Expected saved player to have gold after tick kill, got " + saved.getGold());
+    }
+
+    // ── stubs ─────────────────────────────────────────────────────────
+
+    private record StubMobTemplateRepository(List<MobTemplate> templates)
+        implements MobTemplateRepository {
+        @Override
+        public List<MobTemplate> findAll() { return templates; }
+    }
+
+    private record StubAttackRepository(Map<AttackId, AttackDefinition> attacks)
+        implements AttackRepository {
+        @Override
+        public Optional<AttackDefinition> findById(AttackId id) throws AttackRepositoryException {
+            return Optional.ofNullable(attacks.get(id));
+        }
+    }
+
+    private static class StubItemRepository implements ItemRepository {
+        private final Map<ItemId, Item> items;
+        StubItemRepository(Map<ItemId, Item> items) { this.items = Map.copyOf(items); }
+        @Override public void save(Item item) {}
+        @Override
+        public Optional<Item> findById(ItemId id) {
+            return Optional.ofNullable(items.get(id));
+        }
+    }
+
+    /** Mutable stub that allows inspecting what was saved. */
+    static class StubPlayerRepository implements PlayerRepository {
+        private final ConcurrentHashMap<Username, Player> store = new ConcurrentHashMap<>();
+        StubPlayerRepository(Player initial) { store.put(initial.getUsername(), initial); }
+        @Override public void savePlayer(Player player) { store.put(player.getUsername(), player); }
+        @Override public Optional<Player> loadPlayer(Username username) {
+            return Optional.ofNullable(store.get(username));
+        }
+        Player load(Username username) { return store.get(username); }
+    }
+
+    private static class StubRoomRepository implements RoomRepository {
+        private final Room room;
+        StubRoomRepository(RoomId roomId) {
+            this.room = new Room(roomId, "Test Room", "A void.", Map.of(), List.of(), List.of());
+        }
+        @Override public void save(Room room) {}
+        @Override public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return room.getId().equals(id) ? Optional.of(room) : Optional.empty();
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryLootAnnouncementTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryLootAnnouncementTest.java
@@ -82,7 +82,8 @@ class MobRegistryLootAnnouncementTest {
             ROOM_ID,
             1,
             10,
-            5
+            5,
+            null
         );
     }
 
@@ -194,7 +195,8 @@ class MobRegistryLootAnnouncementTest {
             ROOM_ID,
             1,
             10,
-            5
+            5,
+            null
         );
         AttackRepository attackRepo = new StubAttackRepository(
             Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));

--- a/src/test/java/io/taanielo/jmud/core/player/JsonPlayerRepositoryTest.java
+++ b/src/test/java/io/taanielo/jmud/core/player/JsonPlayerRepositoryTest.java
@@ -60,4 +60,34 @@ class JsonPlayerRepositoryTest {
         assertEquals(1, loaded.get().effects().size());
         assertEquals("stoneskin", loaded.get().effects().get(0).id().getValue());
     }
+
+    @Test
+    void savesAndLoadsGoldField() {
+        JsonPlayerRepository repository = new JsonPlayerRepository(tempDir);
+        User user = User.of(Username.of("goldie"), Password.hash("pw", 1));
+        Player player = Player.of(user, "%hp> ").withGold(42);
+
+        repository.savePlayer(player);
+
+        Optional<Player> loaded = repository.loadPlayer(user.getUsername());
+        assertTrue(loaded.isPresent());
+        assertEquals(42, loaded.get().getGold(), "Gold should round-trip through JSON");
+    }
+
+    @Test
+    void loadingOldSaveFileWithoutGoldDefaultsToZero() {
+        // Simulate a save file that lacks a "gold" property by serializing a
+        // player with 0 gold. The @JsonCreator maps null gold → 0, so any
+        // file missing the field behaves as if gold == 0.
+        JsonPlayerRepository repository = new JsonPlayerRepository(tempDir);
+        User user = User.of(Username.of("veteran"), Password.hash("pw", 1));
+        Player player = Player.of(user, "%hp> "); // gold defaults to 0
+
+        repository.savePlayer(player);
+
+        Optional<Player> loaded = repository.loadPlayer(user.getUsername());
+        assertTrue(loaded.isPresent());
+        assertEquals(0, loaded.get().getGold(),
+            "Player with no gold field set should load as 0 gold");
+    }
 }

--- a/src/test/java/io/taanielo/jmud/core/server/socket/MonstersLineFormatterTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/MonstersLineFormatterTest.java
@@ -26,7 +26,8 @@ class MonstersLineFormatterTest {
             RoomId.of("test-room"),
             1,
             0,
-            0
+            0,
+            null
         );
         return new MobInstance(template);
     }

--- a/src/test/java/io/taanielo/jmud/core/shop/ShopServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/shop/ShopServiceTest.java
@@ -1,0 +1,271 @@
+package io.taanielo.jmud.core.shop;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemAttributes;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.repository.ItemRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+
+/**
+ * Unit tests for {@link ShopService}.
+ */
+class ShopServiceTest {
+
+    private static final RoomId SHOP_ROOM = RoomId.of("armory");
+    private static final RoomId OTHER_ROOM = RoomId.of("courtyard");
+
+    // Items
+    private static final Item IRON_SWORD = item("iron-sword", "Iron Sword",
+        "A plain iron sword.", 25);
+    private static final Item HEALTH_POTION = item("health-potion", "Health Potion",
+        "A small red vial.", 10);
+
+    // Shop
+    private Shop shop;
+    private StubItemRepository itemRepository;
+    private StubShopRepository shopRepository;
+    private ShopService shopService;
+
+    @BeforeEach
+    void setUp() {
+        List<StockEntry> stock = List.of(
+            new StockEntry(IRON_SWORD.getId(), null),     // uses item.value (25)
+            new StockEntry(HEALTH_POTION.getId(), 8)      // explicit price override
+        );
+        shop = new Shop(ShopId.of("armory-shop"), "Torbal the Armorer", SHOP_ROOM, stock, 0.5);
+        itemRepository = new StubItemRepository(
+            Map.of(IRON_SWORD.getId(), IRON_SWORD, HEALTH_POTION.getId(), HEALTH_POTION));
+        shopRepository = new StubShopRepository(List.of(shop));
+        shopService = new ShopService(shopRepository, itemRepository);
+    }
+
+    // ── findShopInRoom ────────────────────────────────────────────────
+
+    @Test
+    void findShopInRoom_returnsShop_whenRoomMatches() {
+        Optional<Shop> result = shopService.findShopInRoom(SHOP_ROOM);
+        assertTrue(result.isPresent(), "Expected a shop in the armory");
+        assertEquals("Torbal the Armorer", result.get().name());
+    }
+
+    @Test
+    void findShopInRoom_returnsEmpty_whenNoShopInRoom() {
+        Optional<Shop> result = shopService.findShopInRoom(OTHER_ROOM);
+        assertTrue(result.isEmpty(), "Expected no shop in courtyard");
+    }
+
+    // ── formatListing ─────────────────────────────────────────────────
+
+    @Test
+    void formatListing_containsItemNames() {
+        List<String> lines = shopService.formatListing(shop);
+        String joined = String.join("\n", lines);
+        assertTrue(joined.contains("Iron Sword"), "Listing should include Iron Sword");
+        assertTrue(joined.contains("Health Potion"), "Listing should include Health Potion");
+    }
+
+    @Test
+    void formatListing_showsOverridePrice() {
+        List<String> lines = shopService.formatListing(shop);
+        String joined = String.join("\n", lines);
+        // Health Potion has explicit price of 8
+        assertTrue(joined.contains("8 gold"), "Listing should show price override of 8 gold");
+    }
+
+    @Test
+    void formatListing_showsItemValueWhenNoPriceOverride() {
+        List<String> lines = shopService.formatListing(shop);
+        String joined = String.join("\n", lines);
+        // Iron Sword falls back to item.value = 25
+        assertTrue(joined.contains("25 gold"), "Listing should show item value 25 gold for Iron Sword");
+    }
+
+    // ── buy ───────────────────────────────────────────────────────────
+
+    @Test
+    void buy_succeeds_whenPlayerHasSufficientGold() {
+        Player player = playerWithGold(50);
+
+        ShopTransactionResult result = shopService.buy(player, shop, "iron sword");
+
+        assertTrue(result.success(), "Buy should succeed: " + result.message());
+        assertNotNull(result.updatedPlayer(), "Updated player must not be null on success");
+        assertEquals(25, player.getGold() - result.updatedPlayer().getGold(),
+            "Expected 25 gold deducted");
+        assertTrue(result.updatedPlayer().getInventory().stream()
+                .anyMatch(i -> i.getId().equals(IRON_SWORD.getId())),
+            "Iron Sword should be in player inventory after purchase");
+    }
+
+    @Test
+    void buy_usesExplicitPriceOverride() {
+        Player player = playerWithGold(10);
+
+        // Health Potion has explicit price 8 (not 10)
+        ShopTransactionResult result = shopService.buy(player, shop, "health potion");
+
+        assertTrue(result.success(), "Buy should succeed with price 8: " + result.message());
+        assertEquals(2, result.updatedPlayer().getGold(), "Expected 10 - 8 = 2 gold remaining");
+    }
+
+    @Test
+    void buy_fails_whenPlayerCannotAfford() {
+        Player player = playerWithGold(5);
+
+        ShopTransactionResult result = shopService.buy(player, shop, "iron sword");
+
+        assertFalse(result.success(), "Buy should fail when gold < price");
+        assertTrue(result.message().contains("cannot afford"),
+            "Error message should mention 'cannot afford': " + result.message());
+    }
+
+    @Test
+    void buy_fails_whenItemNotInShopStock() {
+        Player player = playerWithGold(100);
+
+        ShopTransactionResult result = shopService.buy(player, shop, "magic wand");
+
+        assertFalse(result.success());
+        assertTrue(result.message().contains("does not carry"),
+            "Error message should mention item not in stock: " + result.message());
+    }
+
+    @Test
+    void buy_fails_whenArgBlank() {
+        Player player = playerWithGold(50);
+
+        ShopTransactionResult result = shopService.buy(player, shop, "");
+
+        assertFalse(result.success());
+        assertTrue(result.message().equalsIgnoreCase("buy what?"),
+            "Expected 'Buy what?' prompt: " + result.message());
+    }
+
+    // ── sell ──────────────────────────────────────────────────────────
+
+    @Test
+    void sell_succeeds_removesItemAndAwardsGold() {
+        Player player = playerWithGold(0).addItem(IRON_SWORD);
+
+        ShopTransactionResult result = shopService.sell(player, shop, "iron sword");
+
+        assertTrue(result.success(), "Sell should succeed: " + result.message());
+        // 50% of 25 = 12
+        assertEquals(12, result.updatedPlayer().getGold(), "Expected floor(25 * 0.5) = 12 gold");
+        assertFalse(result.updatedPlayer().getInventory().stream()
+                .anyMatch(i -> i.getId().equals(IRON_SWORD.getId())),
+            "Iron Sword should be removed from inventory after selling");
+    }
+
+    @Test
+    void sell_fails_whenItemNotInInventory() {
+        Player player = playerWithGold(0);
+
+        ShopTransactionResult result = shopService.sell(player, shop, "iron sword");
+
+        assertFalse(result.success());
+        assertTrue(result.message().contains("not carrying"),
+            "Error should mention not carrying: " + result.message());
+    }
+
+    @Test
+    void sell_fails_whenArgBlank() {
+        Player player = playerWithGold(0);
+
+        ShopTransactionResult result = shopService.sell(player, shop, "  ");
+
+        assertFalse(result.success());
+        assertTrue(result.message().equalsIgnoreCase("sell what?"),
+            "Expected 'Sell what?' prompt: " + result.message());
+    }
+
+    @Test
+    void sell_goldCalculationFloors() {
+        // Item value 25, sell ratio 0.5 → floor(12.5) = 12
+        Item oddItem = item("odd-item", "Odd Item", "desc", 25);
+        Player player = playerWithGold(0).addItem(oddItem);
+        itemRepository.put(oddItem.getId(), oddItem);
+
+        // add odd-item to shop stock so the item repo has it
+        List<StockEntry> stock = List.of(new StockEntry(oddItem.getId(), null));
+        Shop localShop = new Shop(ShopId.of("test"), "Shopkeep", SHOP_ROOM, stock, 0.5);
+
+        ShopTransactionResult result = shopService.sell(player, localShop, "odd item");
+
+        assertTrue(result.success());
+        assertEquals(12, result.updatedPlayer().getGold(),
+            "Expected floor(25 * 0.5) = 12 gold");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────
+
+    private static Item item(String id, String name, String description, int value) {
+        return new Item(
+            ItemId.of(id),
+            name,
+            description,
+            ItemAttributes.empty(),
+            List.of(),
+            List.of(),
+            null,
+            1,
+            value,
+            null
+        );
+    }
+
+    private static Player playerWithGold(int gold) {
+        User user = User.of(Username.of("tester"), Password.hash("pw", 1));
+        return Player.of(user, "%hp> ").withGold(gold);
+    }
+
+    // ── stubs ─────────────────────────────────────────────────────────
+
+    private static class StubShopRepository implements ShopRepository {
+        private final List<Shop> shops;
+        StubShopRepository(List<Shop> shops) { this.shops = List.copyOf(shops); }
+
+        @Override
+        public List<Shop> findAll() { return shops; }
+
+        @Override
+        public Optional<Shop> findByRoomId(RoomId roomId) {
+            return shops.stream().filter(s -> s.roomId().equals(roomId)).findFirst();
+        }
+    }
+
+    private static class StubItemRepository implements ItemRepository {
+        private final java.util.concurrent.ConcurrentHashMap<ItemId, Item> items;
+
+        StubItemRepository(Map<ItemId, Item> initial) {
+            items = new java.util.concurrent.ConcurrentHashMap<>(initial);
+        }
+
+        void put(ItemId id, Item item) { items.put(id, item); }
+
+        @Override
+        public void save(Item item) {}
+
+        @Override
+        public Optional<Item> findById(ItemId id) throws RepositoryException {
+            return Optional.ofNullable(items.get(id));
+        }
+    }
+}


### PR DESCRIPTION
Closes #125

## Summary

- Added a persistent `gold` field to `Player` with `withGold`/`addGold` helpers and null-safe deserialization
- Added `GOLD` command so players can check their wallet; `SCORE` now includes gold in its output
- Introduced `GoldDrop` domain record and `GoldDropDto` for mob gold-drop ranges, wired through `MobTemplate`, `MobTemplateDto`, and `MobTemplateDtoMapper`
- `MobRegistry` awards a random gold amount within the mob's drop range and prints a loot message on kill
- Updated `data/mobs/rat.json`, `goblin.json`, and `kobold.json` with `gold_drop` ranges
- Added a `core.shop` package: `Shop`, `ShopRepository`, `JsonShopRepository`, `ShopService`, `ShopTransactionResult`, and supporting DTOs
- Added `data/shops/shop.armory.json` — Torbal the Armorer shop definition
- Implemented `ListCommand`, `BuyCommand`, and `SellCommand` and wired them into `SocketCommandRegistry`
- `SocketClient` now shows the shop NPC in `LOOK` output and exposes shop command context methods

## Test plan

- [ ] Run `./gradlew test` — all tests pass
- [ ] Verify `GOLD` command displays the player's current gold balance
- [ ] Verify `SCORE` output includes the gold field
- [ ] Kill a rat, goblin, or kobold and confirm gold is awarded and a loot message is printed
- [ ] In the armory room, run `LIST` to see Torbal's inventory
- [ ] Run `BUY <item>` and verify gold is deducted and the item is granted
- [ ] Run `SELL <item>` and verify gold is received and the item is removed