### PR TITLE
feat(quests): add goblin, kobold, and spider kill quests

### DIFF
--- a/data/quests/quest.goblin-thrasher.json
+++ b/data/quests/quest.goblin-thrasher.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "goblin-thrasher",
+  "name": "Goblin Thrasher",
+  "description": "Thin the goblin ranks threatening the surrounding villages.",
+  "target_mob_id": "goblin",
+  "required_kills": 5,
+  "gold_reward": 60,
+  "xp_reward": 150
+}

--- a/data/quests/quest.kobold-hunter.json
+++ b/data/quests/quest.kobold-hunter.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "kobold-hunter",
+  "name": "Kobold Hunter",
+  "description": "Drive back the kobold menace lurking in the tunnels below.",
+  "target_mob_id": "kobold",
+  "required_kills": 4,
+  "gold_reward": 80,
+  "xp_reward": 200
+}

--- a/data/quests/quest.spider-slayer.json
+++ b/data/quests/quest.spider-slayer.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "spider-slayer",
+  "name": "Spider Slayer",
+  "description": "Exterminate the giant spiders weaving their webs in the old ruins.",
+  "target_mob_id": "giant-spider",
+  "required_kills": 3,
+  "gold_reward": 100,
+  "xp_reward": 250
+}


### PR DESCRIPTION
## Summary

- Adds `quest.goblin-thrasher.json` — 5 goblin kills, rewards 60g / 150xp
- Adds `quest.kobold-hunter.json` — 4 kobold kills, rewards 80g / 200xp
- Adds `quest.spider-slayer.json` — 3 giant-spider kills, rewards 100g / 250xp

These three data-only quest files extend the kill-quest progression tier, giving players a natural path after early quests and before higher-level content.

Closes #129

## Test plan

- [ ] Build passes (`./gradlew build`)
- [ ] All existing tests pass
- [ ] Load each quest file in-game via the quest system and verify rewards are displayed correctly
- [ ] Confirm quest completion triggers correct gold and XP grants

🤖 Generated with [Claude Code](https://claude.com/claude-code)