### PR TITLE
feat(zones): add The Catacombs zone with skeleton and crypt-warden mobs

### DIFF
--- a/data/attacks/attack.crypt-warden.json
+++ b/data/attacks/attack.crypt-warden.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "attack.crypt-warden",
+  "name": "warden's smash",
+  "min_damage": 6,
+  "max_damage": 14,
+  "hit_bonus": 1,
+  "crit_bonus": 1,
+  "damage_bonus": 2,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The crypt warden smashes you with its fists for {damage}."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The crypt warden swings at you but you dodge aside."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The crypt warden delivers a crushing blow for {damage}!"
+    }
+  ]
+}

--- a/data/attacks/attack.skeleton.json
+++ b/data/attacks/attack.skeleton.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "attack.skeleton",
+  "name": "bony strike",
+  "min_damage": 3,
+  "max_damage": 7,
+  "hit_bonus": 0,
+  "crit_bonus": 0,
+  "damage_bonus": 0,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The skeleton rakes you with its bony fingers for {damage}."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The skeleton swipes at you with its bony fingers but misses."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The skeleton strikes you with a vicious blow for {damage}!"
+    }
+  ]
+}

--- a/data/items/bone-fragment.json
+++ b/data/items/bone-fragment.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 3,
+  "id": "bone-fragment",
+  "name": "Bone Fragment",
+  "description": "A shard of yellowed bone, dry and brittle. It holds no obvious use but might be worth something to the right collector.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [],
+  "messages": [],
+  "weight": 1,
+  "value": 2
+}

--- a/data/items/crypt-key.json
+++ b/data/items/crypt-key.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 3,
+  "id": "crypt-key",
+  "name": "Crypt Key",
+  "description": "A heavy iron key engraved with a skull motif. It looks like it once opened something deep within the catacombs, though whatever it unlocked is long since lost.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [],
+  "messages": [],
+  "weight": 1,
+  "value": 15
+}

--- a/data/mobs/crypt-warden.json
+++ b/data/mobs/crypt-warden.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "crypt-warden",
+  "name": "Crypt Warden",
+  "max_hp": 40,
+  "attack_id": "attack.crypt-warden",
+  "aggressive": true,
+  "spawn_room_id": "warden-chamber",
+  "max_count": 1,
+  "respawn_ticks": 60,
+  "loot": [
+    {
+      "item_id": "crypt-key",
+      "drop_chance": 0.8
+    }
+  ],
+  "gold_drop": {
+    "min": 10,
+    "max": 25
+  }
+}

--- a/data/mobs/skeleton.json
+++ b/data/mobs/skeleton.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "skeleton",
+  "name": "Skeleton",
+  "max_hp": 20,
+  "attack_id": "attack.skeleton",
+  "aggressive": true,
+  "spawn_room_id": "ossuary-hall",
+  "max_count": 3,
+  "respawn_ticks": 25,
+  "loot": [
+    {
+      "item_id": "bone-fragment",
+      "drop_chance": 0.6
+    }
+  ],
+  "gold_drop": {
+    "min": 3,
+    "max": 9
+  }
+}

--- a/data/quests/quest.bonecrusher.json
+++ b/data/quests/quest.bonecrusher.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "bonecrusher",
+  "name": "Bonecrusher",
+  "description": "The skeletons in the catacombs are a menace to anyone who dares venture below. Destroy five of them and put them to rest for good.",
+  "target_mob_id": "skeleton",
+  "required_kills": 5,
+  "gold_reward": 80,
+  "xp_reward": 200
+}

--- a/data/quests/quest.crypt-clearer.json
+++ b/data/quests/quest.crypt-clearer.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "crypt-clearer",
+  "name": "Crypt Clearer",
+  "description": "The crypt wardens are ancient guardians twisted by dark magic. Slay three of them to restore some peace to the depths of the catacombs.",
+  "target_mob_id": "crypt-warden",
+  "required_kills": 3,
+  "gold_reward": 120,
+  "xp_reward": 300
+}

--- a/data/rooms/burial-alcove.json
+++ b/data/rooms/burial-alcove.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 2,
+  "id": "burial-alcove",
+  "name": "Burial Alcove",
+  "description": "A narrow side chamber carved from the bedrock. Shallow niches in the walls once held the remains of the forgotten dead. Most have been disturbed, their contents scattered across the dusty floor.",
+  "item_ids": [],
+  "exits": {
+    "west": "ossuary-hall"
+  }
+}

--- a/data/rooms/catacombs-entrance.json
+++ b/data/rooms/catacombs-entrance.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "catacombs-entrance",
+  "name": "Catacombs Entrance",
+  "description": "Crumbling stone steps descend into a cold, musty passage. Ancient runes are carved into the archway above, their meaning long forgotten. The smell of dry bone and stale air drifts upward from below.",
+  "item_ids": [],
+  "exits": {
+    "north": "dark-burrow",
+    "south": "ossuary-hall"
+  }
+}

--- a/data/rooms/crypt-corridor.json
+++ b/data/rooms/crypt-corridor.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "crypt-corridor",
+  "name": "Crypt Corridor",
+  "description": "A long stone corridor stretching deeper into the earth. Torch sconces line the walls but have long since burned out, leaving only cold darkness. The passage ends at a heavy iron door to the south.",
+  "item_ids": [],
+  "exits": {
+    "north": "ossuary-hall",
+    "south": "warden-chamber"
+  }
+}

--- a/data/rooms/dark-burrow.json
+++ b/data/rooms/dark-burrow.json
@@ -6,6 +6,7 @@
   "item_ids": [],
   "exits": {
     "south": "muddy-hollow",
-    "west": "courtyard"
+    "west": "courtyard",
+    "east": "catacombs-entrance"
   }
 }

--- a/data/rooms/ossuary-hall.json
+++ b/data/rooms/ossuary-hall.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 2,
+  "id": "ossuary-hall",
+  "name": "Ossuary Hall",
+  "description": "A wide underground hall lined with rows of skulls and bones stacked in alcoves along every wall. The bones rattle softly as you move through the chamber. The dead do not rest easy here.",
+  "item_ids": [],
+  "exits": {
+    "north": "catacombs-entrance",
+    "east": "burial-alcove",
+    "south": "crypt-corridor"
+  }
+}

--- a/data/rooms/warden-chamber.json
+++ b/data/rooms/warden-chamber.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 2,
+  "id": "warden-chamber",
+  "name": "Warden Chamber",
+  "description": "A vaulted burial chamber dominated by a stone sarcophagus in its center. Chains hang from the ceiling, and the air is thick with a cold, unnatural chill. Something powerful guards this place.",
+  "item_ids": [],
+  "exits": {
+    "north": "crypt-corridor"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds 5 new rooms forming The Catacombs zone: `catacombs-entrance`, `ossuary-hall`, `burial-alcove`, `crypt-corridor`, and `warden-chamber`
- Connects the zone to the existing world via a new east exit from `dark-burrow`
- Introduces `skeleton` and `crypt-warden` aggressive mobs with attack templates (`attack.skeleton.json`, `attack.crypt-warden.json`)
- Adds two cosmetic loot items: `bone-fragment` and `crypt-key`
- Adds two new kill quests: `quest.bonecrusher` (skeleton kills) and `quest.crypt-clearer` (crypt-warden kills)

## Test plan

- [ ] Connect to the MUD and navigate east from dark-burrow — confirm arrival at catacombs-entrance
- [ ] Traverse all 5 rooms and verify exits are consistent
- [ ] Encounter skeleton and crypt-warden mobs — confirm they are aggressive and attack on sight
- [ ] Kill mobs and confirm bone-fragment / crypt-key drop as loot
- [ ] Accept and complete `bonecrusher` quest by killing skeletons
- [ ] Accept and complete `crypt-clearer` quest by killing crypt-wardens
- [ ] Run full build and test suite — confirm no regressions

Closes #131

Generated with [Claude Code](https://claude.com/claude-code)