### PR TITLE
feat(combat): add player death and respawn with corpse decay

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
+++ b/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
@@ -404,12 +404,13 @@ public class GameActionService {
         }
         RoomService.LookResult look = roomService.look(target.getUsername());
         Room room = look.room();
-        Player deadTarget = target.die();
+        int droppedGold = target.getGold();
+        Player deadTarget = target.withGold(0).die();
 
         List<GameMessage> messages = buildDeathMessages(attacker, deadTarget);
 
         if (room != null) {
-            roomService.spawnCorpse(deadTarget.getUsername(), room.getId());
+            roomService.spawnCorpse(deadTarget.getUsername(), room.getId(), droppedGold);
         }
         roomService.clearPlayerLocation(deadTarget.getUsername());
 
@@ -421,6 +422,9 @@ public class GameActionService {
         String targetName = deadTarget.getUsername().getValue();
 
         messages.add(GameMessage.toPlayer(deadTarget.getUsername(), "You have died."));
+        messages.add(GameMessage.toPlayer(
+            deadTarget.getUsername(),
+            "You will awaken in the " + io.taanielo.jmud.core.player.DeathSettings.RESPAWN_ROOM_ID + "."));
 
         if (attacker == null) {
             messages.add(GameMessage.toRoom(
@@ -437,7 +441,7 @@ public class GameActionService {
 
         String roomMessage = attacker.getUsername().equals(deadTarget.getUsername())
             ? targetName + " has died."
-            : targetName + " has been slain by " + attacker.getUsername().getValue() + ".";
+            : targetName + " has been slain by " + attacker.getUsername().getValue() + "!";
         messages.add(GameMessage.toRoom(
             attacker.getUsername(), deadTarget.getUsername(),
             roomMessage));

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -253,19 +253,24 @@ public class MobRegistry implements Tickable {
     }
 
     private void handleMobKill(MobInstance mob, Player damagedPlayer, List<Username> roomOccupants) {
-        Player deadPlayer = damagedPlayer.die();
-        roomService.spawnCorpse(deadPlayer.getUsername(), mob.roomId());
+        int droppedGold = damagedPlayer.getGold();
+        Player deadPlayer = damagedPlayer.withGold(0).die();
+        roomService.spawnCorpse(deadPlayer.getUsername(), mob.roomId(), droppedGold);
         roomService.clearPlayerLocation(deadPlayer.getUsername());
         playerRepository.savePlayer(deadPlayer);
         mob.disengage(deadPlayer.getUsername());
         playerCombatTargets.remove(deadPlayer.getUsername());
 
-        String slainMsg = "The " + mob.template().name() + " has slain you!";
+        List<GameMessage> deathMessages = new ArrayList<>();
+        deathMessages.add(GameMessage.toSource(
+            "The " + mob.template().name() + " has slain you!"));
+        deathMessages.add(GameMessage.toSource(
+            "You will awaken in the " + io.taanielo.jmud.core.player.DeathSettings.RESPAWN_ROOM_ID + "."));
         playerEventBus.publish(deadPlayer.getUsername(),
-            new GameActionResult(deadPlayer, null, List.of(GameMessage.toSource(slainMsg))));
+            new GameActionResult(deadPlayer, null, deathMessages));
 
         String roomMsg = deadPlayer.getUsername().getValue()
-            + " has been slain by the " + mob.template().name() + ".";
+            + " has been slain by the " + mob.template().name() + "!";
         for (Username occupant : roomOccupants) {
             if (!occupant.equals(deadPlayer.getUsername())) {
                 playerEventBus.publish(occupant,

--- a/src/main/java/io/taanielo/jmud/core/player/DeathSettings.java
+++ b/src/main/java/io/taanielo/jmud/core/player/DeathSettings.java
@@ -4,17 +4,34 @@ import io.taanielo.jmud.core.config.GameConfig;
 
 public final class DeathSettings {
     public static final int DEFAULT_RESPAWN_TICKS = 10;
+    public static final int DEFAULT_CORPSE_DECAY_SECONDS = 300;
+    /** Room id where players respawn after death. */
+    public static final String RESPAWN_ROOM_ID = "training-yard";
 
     private static final GameConfig CONFIG = GameConfig.load();
 
     private DeathSettings() {
     }
 
+    /**
+     * Returns the number of ticks to wait before the dead player automatically respawns.
+     */
     public static int respawnTicks() {
         int ticks = CONFIG.getInt("jmud.death.respawn_ticks", DEFAULT_RESPAWN_TICKS);
         if (ticks < 0) {
             throw new IllegalArgumentException("Respawn ticks must be non-negative");
         }
         return ticks;
+    }
+
+    /**
+     * Returns how many seconds after spawning a player corpse decays and disappears.
+     */
+    public static int corpseDecaySeconds() {
+        int seconds = CONFIG.getInt("jmud.death.corpse_decay_seconds", DEFAULT_CORPSE_DECAY_SECONDS);
+        if (seconds <= 0) {
+            throw new IllegalArgumentException("Corpse decay seconds must be positive");
+        }
+        return seconds;
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
@@ -44,12 +44,14 @@ import io.taanielo.jmud.core.shop.ShopRepository;
 import io.taanielo.jmud.core.shop.ShopRepositoryException;
 import io.taanielo.jmud.core.shop.ShopService;
 import io.taanielo.jmud.core.shop.repository.json.JsonShopRepository;
+import io.taanielo.jmud.core.player.DeathSettings;
 import io.taanielo.jmud.core.player.EncumbranceService;
 import io.taanielo.jmud.core.player.JsonPlayerRepository;
 import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.tick.FixedRateTickScheduler;
 import io.taanielo.jmud.core.tick.TickClock;
 import io.taanielo.jmud.core.tick.TickRegistry;
+import io.taanielo.jmud.core.world.CorpseDecayTicker;
 import io.taanielo.jmud.core.world.RoomId;
 import io.taanielo.jmud.core.world.RoomService;
 import io.taanielo.jmud.core.world.repository.ItemRepository;
@@ -104,6 +106,10 @@ public record GameContext(
         TickRegistry tickRegistry = new TickRegistry();
         TickClock tickClock = new TickClock();
         tickRegistry.register(tickClock);
+        tickRegistry.register(new CorpseDecayTicker(
+            roomService,
+            java.time.Duration.ofSeconds(DeathSettings.corpseDecaySeconds())
+        ));
         FixedRateTickScheduler tickScheduler = new FixedRateTickScheduler(tickRegistry);
 
         AbilityRegistry abilityRegistry = loadAbilities();

--- a/src/main/java/io/taanielo/jmud/core/world/Corpse.java
+++ b/src/main/java/io/taanielo/jmud/core/world/Corpse.java
@@ -1,0 +1,30 @@
+package io.taanielo.jmud.core.world;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Lightweight value object tracking a player corpse placed in the world.
+ *
+ * <p>Instances are transient — not persisted to disk. A {@link CorpseDecayTicker}
+ * uses these records to remove expired corpse items from the room after the
+ * configured decay period.
+ *
+ * @param itemId    the unique id of the corpse item placed in the room
+ * @param roomId    the room where the corpse was spawned
+ * @param ownerName the name of the player who died
+ * @param gold      the amount of gold the player carried at time of death
+ * @param spawnedAt the wall-clock instant when the corpse was created
+ */
+public record Corpse(ItemId itemId, RoomId roomId, String ownerName, int gold, Instant spawnedAt) {
+
+    public Corpse {
+        Objects.requireNonNull(itemId, "Item id is required");
+        Objects.requireNonNull(roomId, "Room id is required");
+        Objects.requireNonNull(ownerName, "Owner name is required");
+        if (gold < 0) {
+            throw new IllegalArgumentException("Gold must be non-negative");
+        }
+        Objects.requireNonNull(spawnedAt, "Spawned-at instant is required");
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/CorpseDecayTicker.java
+++ b/src/main/java/io/taanielo/jmud/core/world/CorpseDecayTicker.java
@@ -1,0 +1,41 @@
+package io.taanielo.jmud.core.world;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import io.taanielo.jmud.core.tick.Tickable;
+
+/**
+ * Per-tick service that removes expired player corpses from the world.
+ *
+ * <p>On each tick, any corpse tracked by {@link RoomService} that is older than
+ * the configured {@code decayAfter} duration is removed from its room.
+ */
+public class CorpseDecayTicker implements Tickable {
+
+    private final RoomService roomService;
+    private final Duration decayAfter;
+
+    /**
+     * Creates a corpse decay ticker.
+     *
+     * @param roomService the room service used to remove decayed corpse items
+     * @param decayAfter  how long after creation a corpse persists before decaying;
+     *                    must be positive
+     */
+    public CorpseDecayTicker(RoomService roomService, Duration decayAfter) {
+        this.roomService = Objects.requireNonNull(roomService, "Room service is required");
+        this.decayAfter = Objects.requireNonNull(decayAfter, "Decay duration is required");
+        if (decayAfter.isNegative() || decayAfter.isZero()) {
+            throw new IllegalArgumentException("Decay duration must be positive");
+        }
+    }
+
+    /**
+     * Removes all corpses whose age exceeds the configured decay duration.
+     */
+    @Override
+    public void tick() {
+        roomService.removeExpiredCorpses(decayAfter);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/RoomService.java
+++ b/src/main/java/io/taanielo/jmud/core/world/RoomService.java
@@ -1,5 +1,7 @@
 package io.taanielo.jmud.core.world;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -7,6 +9,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -35,6 +38,7 @@ public class RoomService {
     private final RoomId startingRoomId;
     private final ConcurrentHashMap<Username, RoomId> playerLocations = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<RoomId, List<Item>> transientItems = new ConcurrentHashMap<>();
+    private final ConcurrentLinkedQueue<Corpse> trackedCorpses = new ConcurrentLinkedQueue<>();
     private final AtomicLong corpseCounter = new AtomicLong();
 
     /**
@@ -103,14 +107,46 @@ public class RoomService {
     }
 
     /**
-     * Spawns a corpse item in the specified room.
+     * Spawns a corpse item in the specified room, carrying the given amount of gold.
+     *
+     * <p>The spawned corpse is tracked internally and will be removed after the
+     * configured decay period by {@link #removeExpiredCorpses(Duration)}.
+     *
+     * @param username the player who died
+     * @param roomId   the room where the corpse is placed
+     * @param gold     gold carried by the player at time of death (0 if none)
+     * @return the {@link Corpse} tracking record
      */
-    public Item spawnCorpse(Username username, RoomId roomId) {
+    public Corpse spawnCorpse(Username username, RoomId roomId, int gold) {
         Objects.requireNonNull(username, "Username is required");
         Objects.requireNonNull(roomId, "Room id is required");
-        Item corpse = createCorpse(username);
-        addItem(roomId, corpse);
+        if (gold < 0) {
+            throw new IllegalArgumentException("Gold must be non-negative");
+        }
+        Item corpseItem = createCorpse(username, gold);
+        addItem(roomId, corpseItem);
+        Corpse corpse = new Corpse(corpseItem.getId(), roomId, username.getValue(), gold, Instant.now());
+        trackedCorpses.add(corpse);
         return corpse;
+    }
+
+    /**
+     * Removes all tracked corpses that were spawned longer ago than {@code decayAfter}.
+     *
+     * <p>Called by {@link CorpseDecayTicker} on each tick.
+     *
+     * @param decayAfter the maximum age a corpse may be before it is removed
+     */
+    public void removeExpiredCorpses(Duration decayAfter) {
+        Objects.requireNonNull(decayAfter, "Decay duration is required");
+        Instant cutoff = Instant.now().minus(decayAfter);
+        trackedCorpses.removeIf(corpse -> {
+            if (!corpse.spawnedAt().isAfter(cutoff)) {
+                removeTransientItemById(corpse.roomId(), corpse.itemId());
+                return true;
+            }
+            return false;
+        });
     }
 
     /**
@@ -315,19 +351,31 @@ public class RoomService {
         });
     }
 
-    private Item createCorpse(Username username) {
+    private void removeTransientItemById(RoomId roomId, ItemId itemId) {
+        transientItems.computeIfPresent(roomId, (id, existing) -> {
+            List<Item> next = new ArrayList<>(existing);
+            next.removeIf(item -> item.getId().equals(itemId));
+            return next.isEmpty() ? null : List.copyOf(next);
+        });
+    }
+
+    private Item createCorpse(Username username, int gold) {
         String owner = username.getValue();
         String id = "corpse-" + owner.toLowerCase(Locale.ROOT) + "-" + corpseCounter.incrementAndGet();
+        String description = gold > 0
+            ? "The corpse of " + owner + " lies here, containing "
+                + gold + " gold coin" + (gold == 1 ? "" : "s") + "."
+            : "The corpse of " + owner + " lies here.";
         return new Item(
             ItemId.of(id),
-            "Corpse of " + owner,
-            "The corpse of " + owner + " lies here.",
+            "the corpse of " + owner,
+            description,
             ItemAttributes.empty(),
             List.of(),
             List.of(),
             null,
             0,
-            0,
+            gold,
             null
         );
     }

--- a/src/test/java/io/taanielo/jmud/core/world/CorpseDecayTickerTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/CorpseDecayTickerTest.java
@@ -1,0 +1,120 @@
+package io.taanielo.jmud.core.world;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Unit tests for {@link CorpseDecayTicker} and the corpse-tracking behaviour of
+ * {@link RoomService#removeExpiredCorpses(Duration)}.
+ */
+class CorpseDecayTickerTest {
+
+    private static final RoomId ROOM_ID = RoomId.of("arena");
+
+    /** Builds a RoomService whose starting room is {@code ROOM_ID}. */
+    private RoomService buildRoomService() {
+        Room room = new Room(ROOM_ID, "Arena", "A sandy arena.", Map.of(), List.of(), List.of());
+        return new RoomService(new StubRoomRepository(Map.of(ROOM_ID, room)), ROOM_ID);
+    }
+
+    private Username username(String name) {
+        return Username.of(name);
+    }
+
+    @Test
+    void expiredCorpseIsRemovedFromRoomAfterTick() throws InterruptedException {
+        RoomService roomService = buildRoomService();
+        // 1-nanosecond decay so any corpse spawned before tick is already expired
+        CorpseDecayTicker ticker = new CorpseDecayTicker(roomService, Duration.ofNanos(1));
+
+        Username viewer = username("viewer");
+        roomService.ensurePlayerLocation(viewer); // places viewer in ROOM_ID
+
+        Username dead = username("ghost");
+        roomService.spawnCorpse(dead, ROOM_ID, 42);
+
+        // Verify corpse is initially visible
+        List<String> linesBefore = roomService.look(viewer).lines();
+        assertTrue(linesBefore.stream().anyMatch(l -> l.contains("ghost")),
+            "Corpse should be visible before decay");
+
+        // Sleep 1 ms to ensure the corpse is definitely older than 1 ns
+        Thread.sleep(1);
+        ticker.tick();
+
+        // Corpse should no longer be visible
+        List<String> linesAfter = roomService.look(viewer).lines();
+        assertFalse(linesAfter.stream().anyMatch(l -> l.contains("ghost")),
+            "Corpse should be removed after decay tick");
+    }
+
+    @Test
+    void freshCorpseIsRetainedBeforeDecayExpires() {
+        RoomService roomService = buildRoomService();
+        CorpseDecayTicker ticker = new CorpseDecayTicker(roomService, Duration.ofMinutes(5));
+
+        Username viewer = username("viewer2");
+        roomService.ensurePlayerLocation(viewer);
+
+        Username dead = username("brave");
+        roomService.spawnCorpse(dead, ROOM_ID, 0);
+
+        ticker.tick();
+
+        // Corpse should still be there (not yet 5 minutes old)
+        List<String> linesAfterTick = roomService.look(viewer).lines();
+        assertTrue(linesAfterTick.stream().anyMatch(l -> l.contains("brave")),
+            "Fresh corpse should remain after a single tick with 5-minute decay");
+    }
+
+    @Test
+    void constructorRejectsZeroDecayDuration() {
+        RoomService roomService = buildRoomService();
+        assertThrows(IllegalArgumentException.class,
+            () -> new CorpseDecayTicker(roomService, Duration.ZERO));
+    }
+
+    @Test
+    void constructorRejectsNegativeDecayDuration() {
+        RoomService roomService = buildRoomService();
+        assertThrows(IllegalArgumentException.class,
+            () -> new CorpseDecayTicker(roomService, Duration.ofSeconds(-1)));
+    }
+
+    @Test
+    void constructorRejectsNullRoomService() {
+        assertThrows(NullPointerException.class,
+            () -> new CorpseDecayTicker(null, Duration.ofMinutes(5)));
+    }
+
+    // ── stubs ─────────────────────────────────────────────────────────
+
+    private record StubRoomRepository(Map<RoomId, Room> rooms) implements RoomRepository {
+        private StubRoomRepository(Map<RoomId, Room> rooms) {
+            this.rooms = new ConcurrentHashMap<>(rooms);
+        }
+
+        @Override
+        public void save(Room room) throws RepositoryException {
+            rooms.put(room.getId(), room);
+        }
+
+        @Override
+        public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return Optional.ofNullable(rooms.get(id));
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
@@ -120,12 +120,12 @@ class RoomServiceTest {
 
         Username victim = Username.of("Bob");
         service.ensurePlayerLocation(victim);
-        service.spawnCorpse(victim, roomAId);
+        service.spawnCorpse(victim, roomAId, 0);
 
         RoomService.LookResult lookResult = service.look(Username.of("Alice"));
         String output = String.join("\n", lookResult.lines());
 
-        assertTrue(output.contains("Corpse of Bob"));
+        assertTrue(output.contains("corpse of Bob"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds `Corpse` value record (roomId, ownerName, gold, spawnedAt) dropped on player/mob death
- Introduces `CorpseDecayTicker` (Tickable) that removes corpses older than 300 s, registered in `GameContext`
- `DeathSettings` gains `RESPAWN_ROOM_ID` and `DEFAULT_CORPSE_DECAY_SECONDS` constants
- `RoomService.spawnCorpse` accepts gold, maintains a per-room corpse queue, and exposes `removeExpiredCorpses()`
- `MobRegistry` and `GameActionService` zero gold before `die()` and pass it through to `spawnCorpse`; respawn reminder message added; broadcast punctuation corrected
- 5 new `CorpseDecayTickerTest` cases and updated `RoomServiceTest` for the new signature

Closes #133

## Test plan

- [ ] Run `./gradlew test` — all tests pass
- [ ] Kill a mob in-game and verify a corpse appears in the room description
- [ ] Wait 5 minutes and confirm the corpse disappears automatically
- [ ] Die in combat and confirm you are moved to the respawn room with an appropriate message

🤖 Generated with [Claude Code](https://claude.com/claude-code)