### PR TITLE
feat(combat): add Rogue class with backstab skill for first-strike bonus damage

### DIFF
--- a/data/classes/class.rogue.json
+++ b/data/classes/class.rogue.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 2,
+  "id": "rogue",
+  "name": "Rogue",
+  "healing": {
+    "base_modifier": 1
+  },
+  "carry_bonus": 8,
+  "ability_ids": ["skill.backstab"]
+}

--- a/data/skills/skill.backstab.json
+++ b/data/skills/skill.backstab.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 2,
+  "id": "skill.backstab",
+  "name": "backstab",
+  "type": "SKILL",
+  "level": 1,
+  "cost": {
+    "move": 5
+  },
+  "cooldown": {
+    "ticks": 5
+  },
+  "targeting": "HARMFUL_OPENER",
+  "aliases": [],
+  "effects": [
+    {
+      "kind": "VITALS",
+      "stat": "HP",
+      "operation": "DECREASE",
+      "amount": 10
+    }
+  ],
+  "messages": [
+    {
+      "phase": "use",
+      "channel": "self",
+      "text": "You slip behind {target} and drive your blade deep!"
+    },
+    {
+      "phase": "use",
+      "channel": "target",
+      "text": "{source} backstabs you from the shadows!"
+    },
+    {
+      "phase": "use",
+      "channel": "room",
+      "text": "{source} backstabs {target} from the shadows!"
+    }
+  ]
+}

--- a/src/main/java/io/taanielo/jmud/core/ability/AbilityEngine.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/AbilityEngine.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import io.taanielo.jmud.core.messaging.MessageChannel;
 import io.taanielo.jmud.core.messaging.MessageContext;
@@ -31,6 +32,22 @@ public class AbilityEngine {
         this.messageSink = Objects.requireNonNull(messageSink, "Ability message sink is required");
     }
 
+    /**
+     * Uses an ability identified by {@code input}.
+     *
+     * <p>Equivalent to calling
+     * {@link #use(Player, String, List, AbilityTargetResolver, AbilityCooldownTracker, Predicate)}
+     * with an {@code inCombatCheck} that always returns {@code false} (never in combat).
+     * Prefer the overload that accepts an explicit in-combat predicate when combat state
+     * is available to the caller.
+     *
+     * @param source            the player using the ability
+     * @param input             raw ability input (name and optional target)
+     * @param learnedAbilityIds abilities the player has learned
+     * @param targetResolver    resolves target names to player objects
+     * @param cooldowns         tracks per-ability cooldowns
+     * @return result of the ability use
+     */
     public AbilityUseResult use(
         Player source,
         String input,
@@ -38,9 +55,34 @@ public class AbilityEngine {
         AbilityTargetResolver targetResolver,
         AbilityCooldownTracker cooldowns
     ) {
+        return use(source, input, learnedAbilityIds, targetResolver, cooldowns, _ -> false);
+    }
+
+    /**
+     * Uses an ability identified by {@code input}, enforcing first-strike restrictions for
+     * {@link AbilityTargeting#HARMFUL_OPENER} abilities via the supplied predicate.
+     *
+     * @param source            the player using the ability
+     * @param input             raw ability input (name and optional target)
+     * @param learnedAbilityIds abilities the player has learned
+     * @param targetResolver    resolves target names to player objects
+     * @param cooldowns         tracks per-ability cooldowns
+     * @param inCombatCheck     returns {@code true} when the source is already engaged in combat;
+     *                          used to block opener abilities mid-combat
+     * @return result of the ability use
+     */
+    public AbilityUseResult use(
+        Player source,
+        String input,
+        List<AbilityId> learnedAbilityIds,
+        AbilityTargetResolver targetResolver,
+        AbilityCooldownTracker cooldowns,
+        Predicate<Player> inCombatCheck
+    ) {
         Objects.requireNonNull(source, "Source player is required");
         Objects.requireNonNull(targetResolver, "Target resolver is required");
         Objects.requireNonNull(cooldowns, "Cooldown tracker is required");
+        Objects.requireNonNull(inCombatCheck, "In-combat check is required");
 
         Optional<AbilityMatch> match = registry.findBestMatch(input, learnedAbilityIds);
         if (match.isEmpty()) {
@@ -49,9 +91,14 @@ public class AbilityEngine {
         Ability ability = match.get().ability();
         String targetInput = match.get().remainingTarget();
 
+        if (ability.targeting() == AbilityTargeting.HARMFUL_OPENER && inCombatCheck.test(source)) {
+            return new AbilityUseResult(source, source,
+                List.of("You can only backstab as an opener — you are already in combat."));
+        }
+
         Player target = resolveTarget(ability, source, targetInput, targetResolver);
         if (target == null) {
-            if (ability.targeting() == AbilityTargeting.HARMFUL) {
+            if (isHarmfulTargeting(ability.targeting())) {
                 return new AbilityUseResult(source, source, List.of("You must specify a target."));
             }
             return new AbilityUseResult(source, source, List.of("Target not found."));
@@ -103,6 +150,11 @@ public class AbilityEngine {
             return ability.targeting() == AbilityTargeting.BENEFICIAL ? source : null;
         }
         return targetResolver.resolve(source, targetInput).orElse(null);
+    }
+
+    /** Returns {@code true} for targeting modes that require an explicit hostile target. */
+    private static boolean isHarmfulTargeting(AbilityTargeting targeting) {
+        return targeting == AbilityTargeting.HARMFUL || targeting == AbilityTargeting.HARMFUL_OPENER;
     }
 
     private String formatEffect(AbilityEffect effect, Player target) {

--- a/src/main/java/io/taanielo/jmud/core/ability/AbilityTargeting.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/AbilityTargeting.java
@@ -1,6 +1,13 @@
 package io.taanielo.jmud.core.ability;
 
 public enum AbilityTargeting {
+    /** Targets a hostile entity; usable at any time during or outside combat. */
     HARMFUL,
-    BENEFICIAL
+    /** Targets a friendly entity (defaults to self when no target is provided). */
+    BENEFICIAL,
+    /**
+     * Targets a hostile entity but may only be used as an opening strike —
+     * i.e. the source must not already be engaged in combat with any target.
+     */
+    HARMFUL_OPENER
 }

--- a/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
+++ b/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,10 +57,18 @@ public class GameActionService {
     private final AbilityTargetResolver abilityTargetResolver;
     private final AbilityCooldownTracker cooldownTracker;
     private final EncumbranceService encumbranceService;
+    /**
+     * Predicate that returns {@code true} when the given player is currently engaged in combat.
+     * Used by {@link #useAbility} to enforce first-strike restrictions on
+     * {@link io.taanielo.jmud.core.ability.AbilityTargeting#HARMFUL_OPENER} abilities.
+     */
+    private final Predicate<Player> inCombatCheck;
     private final MessageEmitter messageEmitter = new MessageEmitter();
 
     /**
      * Creates a game action service with the given domain dependencies.
+     * The in-combat check defaults to {@code false} (never in combat), which disables
+     * opener-ability enforcement. Use the full constructor to supply real combat state.
      */
     public GameActionService(
         AbilityRegistry abilityRegistry,
@@ -71,6 +80,29 @@ public class GameActionService {
         AbilityCooldownTracker cooldownTracker,
         EncumbranceService encumbranceService
     ) {
+        this(abilityRegistry, abilityCostResolver, abilityEffectEngine, combatEngine,
+            roomService, abilityTargetResolver, cooldownTracker, encumbranceService,
+            _ -> false);
+    }
+
+    /**
+     * Creates a game action service with an explicit in-combat predicate.
+     *
+     * @param inCombatCheck returns {@code true} when the given player is already engaged in combat;
+     *                      used to block {@link io.taanielo.jmud.core.ability.AbilityTargeting#HARMFUL_OPENER}
+     *                      abilities mid-combat
+     */
+    public GameActionService(
+        AbilityRegistry abilityRegistry,
+        AbilityCostResolver abilityCostResolver,
+        EffectEngine abilityEffectEngine,
+        CombatEngine combatEngine,
+        RoomService roomService,
+        AbilityTargetResolver abilityTargetResolver,
+        AbilityCooldownTracker cooldownTracker,
+        EncumbranceService encumbranceService,
+        Predicate<Player> inCombatCheck
+    ) {
         this.abilityRegistry = Objects.requireNonNull(abilityRegistry, "Ability registry is required");
         this.abilityCostResolver = Objects.requireNonNull(abilityCostResolver, "Ability cost resolver is required");
         this.abilityEffectEngine = Objects.requireNonNull(abilityEffectEngine, "Ability effect engine is required");
@@ -79,6 +111,7 @@ public class GameActionService {
         this.abilityTargetResolver = Objects.requireNonNull(abilityTargetResolver, "Ability target resolver is required");
         this.cooldownTracker = Objects.requireNonNull(cooldownTracker, "Cooldown tracker is required");
         this.encumbranceService = Objects.requireNonNull(encumbranceService, "Encumbrance service is required");
+        this.inCombatCheck = Objects.requireNonNull(inCombatCheck, "In-combat check is required");
     }
 
     /**
@@ -141,7 +174,7 @@ public class GameActionService {
 
         AbilityUseResult result = engine.use(
             source, input, source.getLearnedAbilities(),
-            abilityTargetResolver, cooldownTracker
+            abilityTargetResolver, cooldownTracker, inCombatCheck
         );
 
         List<GameMessage> messages = new ArrayList<>(sink.collected());

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -138,7 +138,9 @@ public class SocketClient implements Client {
             roomService,
             abilityTargetResolver,
             session.getCooldownTracker(),
-            encumbranceService
+            encumbranceService,
+            p -> context.mobRegistry() != null
+                && context.mobRegistry().isInCombat(p.getUsername())
         );
 
         this.commandDispatcher = new SocketCommandDispatcher(context.commandRegistry(), auditService);

--- a/src/test/java/io/taanielo/jmud/core/ability/BackstabSkillTest.java
+++ b/src/test/java/io/taanielo/jmud/core/ability/BackstabSkillTest.java
@@ -1,0 +1,226 @@
+package io.taanielo.jmud.core.ability;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.taanielo.jmud.core.ability.repository.json.JsonAbilityRepository;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.messaging.MessageChannel;
+import io.taanielo.jmud.core.messaging.MessagePhase;
+import io.taanielo.jmud.core.player.Player;
+
+/**
+ * Verifies that the {@code skill.backstab} skill JSON loads correctly and that
+ * the {@link AbilityEngine} enforces the first-strike restriction for
+ * {@link AbilityTargeting#HARMFUL_OPENER} abilities.
+ */
+class BackstabSkillTest {
+
+    private static final AbilityId BACKSTAB = AbilityId.of("skill.backstab");
+
+    @TempDir
+    Path tempDir;
+
+    // ── JSON loading ────────────────────────────────────────────────────
+
+    @Test
+    void backstabJsonLoadsCorrectly() throws Exception {
+        Path skillsDir = tempDir.resolve("skills");
+        Files.createDirectories(skillsDir);
+        Files.writeString(skillsDir.resolve("skill.backstab.json"), backstabJson());
+
+        JsonAbilityRepository repo = new JsonAbilityRepository(tempDir);
+        List<Ability> abilities = repo.findAll();
+
+        assertEquals(1, abilities.size());
+        Ability ability = abilities.getFirst();
+
+        assertEquals("skill.backstab", ability.id().getValue());
+        assertEquals(AbilityType.SKILL, ability.type());
+        assertEquals(1, ability.level());
+        assertEquals(5, ability.cost().move());
+        assertEquals(5, ability.cooldown().ticks());
+        assertEquals(AbilityTargeting.HARMFUL_OPENER, ability.targeting());
+        assertEquals(1, ability.effects().size());
+
+        AbilityEffect effect = ability.effects().getFirst();
+        assertEquals(AbilityEffectKind.VITALS, effect.kind());
+        assertEquals(AbilityStat.HP, effect.stat());
+        assertEquals(AbilityOperation.DECREASE, effect.operation());
+        assertEquals(10, effect.amount());
+
+        long selfMessages = ability.messages().stream()
+            .filter(m -> m.phase() == MessagePhase.USE && m.channel() == MessageChannel.SELF)
+            .count();
+        long targetMessages = ability.messages().stream()
+            .filter(m -> m.phase() == MessagePhase.USE && m.channel() == MessageChannel.TARGET)
+            .count();
+        long roomMessages = ability.messages().stream()
+            .filter(m -> m.phase() == MessagePhase.USE && m.channel() == MessageChannel.ROOM)
+            .count();
+        assertEquals(1, selfMessages, "Expected one SELF message");
+        assertEquals(1, targetMessages, "Expected one TARGET message");
+        assertEquals(1, roomMessages, "Expected one ROOM message");
+
+        assertTrue(repo.findById(BACKSTAB).isPresent());
+    }
+
+    // ── AbilityEngine first-strike enforcement ──────────────────────────
+
+    @Test
+    void backstabIsAllowedWhenNotInCombat() {
+        Ability backstab = stubBackstab();
+        AbilityEngine engine = engineWithAbility(backstab);
+        Player source = player("alice");
+        Player target = player("bob");
+        AbilityTargetResolver resolver = (p, input) -> Optional.of(target);
+        AbilityCooldownTracker cooldowns = noopCooldowns();
+        List<AbilityId> learned = List.of(BACKSTAB);
+
+        // inCombatCheck always returns false → not in combat → should succeed
+        AbilityUseResult result = engine.use(
+            source, "backstab bob", learned, resolver, cooldowns, _ -> false
+        );
+
+        assertFalse(result.messages().stream().anyMatch(m -> m.contains("opener")),
+            "Backstab should not be blocked when source is not in combat");
+    }
+
+    @Test
+    void backstabIsRejectedWhenAlreadyInCombat() {
+        Ability backstab = stubBackstab();
+        AbilityEngine engine = engineWithAbility(backstab);
+        Player source = player("alice");
+        Player target = player("bob");
+        AbilityTargetResolver resolver = (p, input) -> Optional.of(target);
+        AbilityCooldownTracker cooldowns = noopCooldowns();
+        List<AbilityId> learned = List.of(BACKSTAB);
+
+        // inCombatCheck always returns true → already in combat → should be rejected
+        AbilityUseResult result = engine.use(
+            source, "backstab bob", learned, resolver, cooldowns, _ -> true
+        );
+
+        assertTrue(result.messages().stream().anyMatch(m -> m.contains("opener") || m.contains("combat")),
+            "Backstab must be rejected when source is already in combat");
+    }
+
+    @Test
+    void regularHarmfulAbilityIsUnaffectedByCombatCheck() {
+        Ability bash = stubBash();
+        AbilityEngine engine = engineWithAbility(bash);
+        Player source = player("alice");
+        Player target = player("bob");
+        AbilityTargetResolver resolver = (p, input) -> Optional.of(target);
+        AbilityCooldownTracker cooldowns = noopCooldowns();
+        List<AbilityId> learned = List.of(AbilityId.of("skill.bash"));
+
+        // inCombatCheck returns true, but bash is HARMFUL (not HARMFUL_OPENER), so it must succeed
+        AbilityUseResult result = engine.use(
+            source, "bash bob", learned, resolver, cooldowns, _ -> true
+        );
+
+        assertFalse(result.messages().stream().anyMatch(m -> m.contains("opener")),
+            "Regular HARMFUL abilities must not be blocked by the in-combat check");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static Player player(String name) {
+        return Player.of(User.of(Username.of(name), Password.hash("pw")), "prompt", false);
+    }
+
+    private static AbilityEngine engineWithAbility(Ability ability) {
+        AbilityRegistry registry = new AbilityRegistry(List.of(ability));
+        return new AbilityEngine(
+            registry,
+            new BasicAbilityCostResolver(),
+            new NoopAbilityEffectResolver(),
+            new NoopAbilityMessageSink()
+        );
+    }
+
+    private static AbilityCooldownTracker noopCooldowns() {
+        return new AbilityCooldownTracker() {
+            @Override public boolean isOnCooldown(AbilityId id) { return false; }
+            @Override public int remainingTicks(AbilityId id) { return 0; }
+            @Override public void startCooldown(AbilityId id, int ticks) {}
+        };
+    }
+
+    private static Ability stubBackstab() {
+        return new AbilityDefinition(
+            BACKSTAB,
+            "backstab",
+            AbilityType.SKILL,
+            1,
+            new AbilityCost(0, 5),
+            new AbilityCooldown(5),
+            AbilityTargeting.HARMFUL_OPENER,
+            List.of(),
+            List.of(new AbilityEffect(AbilityEffectKind.VITALS, AbilityStat.HP, AbilityOperation.DECREASE, 10, null)),
+            List.of()
+        );
+    }
+
+    private static Ability stubBash() {
+        return new AbilityDefinition(
+            AbilityId.of("skill.bash"),
+            "bash",
+            AbilityType.SKILL,
+            1,
+            new AbilityCost(0, 3),
+            new AbilityCooldown(3),
+            AbilityTargeting.HARMFUL,
+            List.of(),
+            List.of(new AbilityEffect(AbilityEffectKind.VITALS, AbilityStat.HP, AbilityOperation.DECREASE, 4, null)),
+            List.of()
+        );
+    }
+
+    private static String backstabJson() {
+        return """
+            {
+              "schema_version": 2,
+              "id": "skill.backstab",
+              "name": "backstab",
+              "type": "SKILL",
+              "level": 1,
+              "cost": {"move": 5},
+              "cooldown": {"ticks": 5},
+              "targeting": "HARMFUL_OPENER",
+              "aliases": [],
+              "effects": [
+                {"kind": "VITALS", "stat": "HP", "operation": "DECREASE", "amount": 10}
+              ],
+              "messages": [
+                {"phase": "use", "channel": "self", "text": "You slip behind {target} and drive your blade deep!"},
+                {"phase": "use", "channel": "target", "text": "{source} backstabs you from the shadows!"},
+                {"phase": "use", "channel": "room", "text": "{source} backstabs {target} from the shadows!"}
+              ]
+            }
+            """;
+    }
+
+    private static class NoopAbilityEffectResolver implements AbilityEffectResolver {
+        @Override
+        public void apply(AbilityEffect effect, AbilityContext context) {}
+    }
+
+    private static class NoopAbilityMessageSink implements AbilityMessageSink {
+        @Override public void sendToSource(Player source, String message) {}
+        @Override public void sendToTarget(Player target, String message) {}
+        @Override public void sendToRoom(Player source, Player target, String message) {}
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/character/JsonClassRepositoryFindAllTest.java
+++ b/src/test/java/io/taanielo/jmud/core/character/JsonClassRepositoryFindAllTest.java
@@ -34,7 +34,8 @@ class JsonClassRepositoryFindAllTest {
         assertTrue(ids.contains("warrior"), "Expected 'warrior' class");
         assertTrue(ids.contains("mage"), "Expected 'mage' class");
         assertTrue(ids.contains("adventurer"), "Expected 'adventurer' class");
-        assertEquals(3, classes.size(), "Expected exactly 3 classes");
+        assertTrue(ids.contains("rogue"), "Expected 'rogue' class");
+        assertEquals(4, classes.size(), "Expected exactly 4 classes");
     }
 
     @Test

--- a/src/test/java/io/taanielo/jmud/core/character/RogueClassSeedingTest.java
+++ b/src/test/java/io/taanielo/jmud/core/character/RogueClassSeedingTest.java
@@ -1,0 +1,84 @@
+package io.taanielo.jmud.core.character;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.taanielo.jmud.core.ability.AbilityId;
+import io.taanielo.jmud.core.character.repository.json.JsonClassRepository;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+
+/**
+ * Verifies that {@code class.rogue.json} loads correctly and that a new player seeded
+ * from the Rogue class receives the {@code skill.backstab} ability.
+ */
+class RogueClassSeedingTest {
+
+    private static final AbilityId BACKSTAB = AbilityId.of("skill.backstab");
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void rogueClassJsonLoadsCorrectly() throws Exception {
+        Path classesDir = tempDir.resolve("classes");
+        Files.createDirectories(classesDir);
+        Files.writeString(classesDir.resolve("class.rogue.json"), rogueClassJson());
+
+        JsonClassRepository repo = new JsonClassRepository(tempDir);
+        Optional<ClassDefinition> result = repo.findById(ClassId.of("rogue"));
+
+        assertTrue(result.isPresent(), "Rogue class must be found in repository");
+        ClassDefinition rogue = result.get();
+        assertEquals("rogue", rogue.id().getValue());
+        assertEquals("Rogue", rogue.name());
+        assertEquals(1, rogue.healingBaseModifier());
+        assertEquals(8, rogue.carryBonus());
+        assertEquals(List.of(BACKSTAB), rogue.startingAbilityIds());
+    }
+
+    @Test
+    void playerSeededFromRogueClassGetsBackstab() throws Exception {
+        Path classesDir = tempDir.resolve("classes");
+        Files.createDirectories(classesDir);
+        Files.writeString(classesDir.resolve("class.rogue.json"), rogueClassJson());
+
+        JsonClassRepository repo = new JsonClassRepository(tempDir);
+        ClassDefinition rogue = repo.findById(ClassId.of("rogue"))
+            .orElseThrow(() -> new AssertionError("Rogue class not found"));
+
+        User user = User.of(Username.of("Shadow"), Password.hash("secret"));
+        Player player = Player.of(user, "%h/%H hp>", false, List.of())
+            .withLearnedAbilities(rogue.startingAbilityIds());
+
+        List<AbilityId> learned = player.getLearnedAbilities();
+        assertEquals(1, learned.size());
+        assertTrue(learned.contains(BACKSTAB),
+            "Rogue starting abilities must include skill.backstab");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static String rogueClassJson() {
+        return """
+            {
+              "schema_version": 2,
+              "id": "rogue",
+              "name": "Rogue",
+              "healing": {"base_modifier": 1},
+              "carry_bonus": 8,
+              "ability_ids": ["skill.backstab"]
+            }
+            """;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new Rogue character class (`data/classes/class.rogue.json`) with stealth-oriented attributes
- Implements the Backstab skill (`data/skills/skill.backstab.json`) that deals bonus damage on the first strike against a target
- Adds `HARMFUL_OPENER` targeting type to `AbilityTargeting.java` to support opener mechanics
- Updates `AbilityEngine.java` and `GameActionService.java` to handle opener skill logic and track combat state
- Updates `SocketClient.java` to support new ability interaction
- Adds `BackstabSkillTest.java` and `RogueClassSeedingTest.java` for full coverage
- Updates `JsonClassRepositoryFindAllTest.java` to include the Rogue class

Closes #139