### PR TITLE
feat(player): add total mob kill tracking and display in score

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -52,7 +52,7 @@
 - [x] Cleric class with group heal spell and turn undead ability
 
 ## Planned
-- [ ] Add SCORE command enhancements: show current level, XP to next level, and total kills
+- [x] Add SCORE command enhancements: show current level, XP to next level, and total kills
 - [ ] Add TRAIN command and trainer NPC so players can spend practice points on skills
 - [ ] Add multi-kill quest: deliver a fixed number of drops (e.g. rat tails) to an NPC for a reward
 - [ ] Add PARTY system: players can form a group to share XP and see party HP in prompt

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -194,6 +194,7 @@ public class MobRegistry implements Tickable {
                     }
                 }
             }
+            afterXp = afterXp.withTotalKills(afterXp.getTotalKills() + 1);
             playerRepository.savePlayer(afterXp);
             messages.add(GameMessage.toSource(
                 "You gain " + mob.template().xpReward() + " experience points."));
@@ -347,6 +348,7 @@ public class MobRegistry implements Tickable {
                         }
                     }
                 }
+                afterXp = afterXp.withTotalKills(afterXp.getTotalKills() + 1);
                 playerRepository.savePlayer(afterXp);
                 messages.add(GameMessage.toSource(
                     "You gain " + mob.template().xpReward() + " experience points."));

--- a/src/main/java/io/taanielo/jmud/core/player/Player.java
+++ b/src/main/java/io/taanielo/jmud/core/player/Player.java
@@ -32,6 +32,8 @@ public class Player implements EffectTarget, Combatant {
     private final boolean resting;
     /** Currently active quest contract, or {@code null} when none is held. */
     private final ActiveQuest activeQuest;
+    /** Cumulative count of mobs killed; defaults to {@code 0} for existing players. */
+    private final long totalKills;
 
     public static Player of(User user, String promptFormat) {
         return new Player(user, 1, 0, PlayerVitals.defaults(), List.of(), promptFormat, false, List.of(), null, null);
@@ -73,6 +75,7 @@ public class Player implements EffectTarget, Combatant {
             null,
             null,
             null,
+            null,
             null
         );
     }
@@ -93,7 +96,8 @@ public class Player implements EffectTarget, Combatant {
         @JsonProperty("inventory") List<Item> inventory,
         @JsonProperty("equipment") PlayerEquipment equipment,
         @JsonProperty("gold") Integer gold,
-        @JsonProperty("activeQuest") ActiveQuest activeQuest
+        @JsonProperty("activeQuest") ActiveQuest activeQuest,
+        @JsonProperty("totalKills") Long totalKills
     ) {
         this(
             new PlayerIdentity(user, level, experience, race, classId),
@@ -104,7 +108,8 @@ public class Player implements EffectTarget, Combatant {
             equipment == null ? PlayerEquipment.empty() : equipment,
             false,
             gold == null ? 0 : Math.max(0, gold),
-            activeQuest
+            activeQuest,
+            totalKills == null ? 0L : totalKills
         );
     }
 
@@ -116,7 +121,7 @@ public class Player implements EffectTarget, Combatant {
         PlayerInventory inventory,
         PlayerEquipment equipment
     ) {
-        this(identity, combatState, preferences, abilities, inventory, equipment, false, 0, null);
+        this(identity, combatState, preferences, abilities, inventory, equipment, false, 0, null, 0L);
     }
 
     private Player(
@@ -129,7 +134,7 @@ public class Player implements EffectTarget, Combatant {
         boolean resting,
         int gold
     ) {
-        this(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, null);
+        this(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, null, 0L);
     }
 
     private Player(
@@ -143,6 +148,21 @@ public class Player implements EffectTarget, Combatant {
         int gold,
         ActiveQuest activeQuest
     ) {
+        this(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, 0L);
+    }
+
+    private Player(
+        PlayerIdentity identity,
+        PlayerCombatState combatState,
+        PlayerPreferences preferences,
+        PlayerAbilities abilities,
+        PlayerInventory inventory,
+        PlayerEquipment equipment,
+        boolean resting,
+        int gold,
+        ActiveQuest activeQuest,
+        long totalKills
+    ) {
         this.identity = Objects.requireNonNull(identity, "Identity is required");
         this.combatState = Objects.requireNonNull(combatState, "Combat state is required");
         this.preferences = Objects.requireNonNull(preferences, "Preferences are required");
@@ -152,6 +172,7 @@ public class Player implements EffectTarget, Combatant {
         this.gold = Math.max(0, gold);
         this.resting = resting;
         this.activeQuest = activeQuest;
+        this.totalKills = Math.max(0L, totalKills);
     }
 
     @JsonProperty("user")
@@ -229,6 +250,11 @@ public class Player implements EffectTarget, Combatant {
         return activeQuest;
     }
 
+    @JsonProperty("totalKills")
+    public long getTotalKills() {
+        return totalKills;
+    }
+
     public PlayerIdentity identity() {
         return identity;
     }
@@ -289,54 +315,54 @@ public class Player implements EffectTarget, Combatant {
             return this;
         }
         // Dying always clears the resting flag.
-        return new Player(identity, combatState.die(), preferences, abilities, inventory, equipment, false, gold, activeQuest);
+        return new Player(identity, combatState.die(), preferences, abilities, inventory, equipment, false, gold, activeQuest, totalKills);
     }
 
     public Player respawn() {
-        return new Player(identity, combatState.respawn(), preferences, abilities, inventory, equipment, false, gold, activeQuest);
+        return new Player(identity, combatState.respawn(), preferences, abilities, inventory, equipment, false, gold, activeQuest, totalKills);
     }
 
     public Player withoutEffects() {
-        return new Player(identity, combatState.withoutEffects(), preferences, abilities, inventory, equipment, resting, gold, activeQuest);
+        return new Player(identity, combatState.withoutEffects(), preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills);
     }
 
     public Player withAnsiEnabled(boolean enabled) {
-        return new Player(identity, combatState, preferences.withAnsiEnabled(enabled), abilities, inventory, equipment, resting, gold, activeQuest);
+        return new Player(identity, combatState, preferences.withAnsiEnabled(enabled), abilities, inventory, equipment, resting, gold, activeQuest, totalKills);
     }
 
     public Player withVitals(PlayerVitals updatedVitals) {
-        return new Player(identity, combatState.withVitals(updatedVitals), preferences, abilities, inventory, equipment, resting, gold, activeQuest);
+        return new Player(identity, combatState.withVitals(updatedVitals), preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills);
     }
 
     public Player withDead(boolean dead) {
-        return new Player(identity, combatState.withDead(dead), preferences, abilities, inventory, equipment, resting, gold, activeQuest);
+        return new Player(identity, combatState.withDead(dead), preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills);
     }
 
     public Player withLearnedAbilities(List<AbilityId> learnedAbilities) {
-        return new Player(identity, combatState, preferences, abilities.withLearned(learnedAbilities), inventory, equipment, resting, gold, activeQuest);
+        return new Player(identity, combatState, preferences, abilities.withLearned(learnedAbilities), inventory, equipment, resting, gold, activeQuest, totalKills);
     }
 
     public Player withInventory(List<Item> items) {
-        return new Player(identity, combatState, preferences, abilities, inventory.withItems(items), equipment, resting, gold, activeQuest);
+        return new Player(identity, combatState, preferences, abilities, inventory.withItems(items), equipment, resting, gold, activeQuest, totalKills);
     }
 
     public Player addItem(Item item) {
-        return new Player(identity, combatState, preferences, abilities, inventory.addItem(item), equipment, resting, gold, activeQuest);
+        return new Player(identity, combatState, preferences, abilities, inventory.addItem(item), equipment, resting, gold, activeQuest, totalKills);
     }
 
     public Player removeItem(Item item) {
-        return new Player(identity, combatState, preferences, abilities, inventory.removeItem(item), equipment, resting, gold, activeQuest);
+        return new Player(identity, combatState, preferences, abilities, inventory.removeItem(item), equipment, resting, gold, activeQuest, totalKills);
     }
 
     public Player withEquipment(PlayerEquipment nextEquipment) {
-        return new Player(identity, combatState, preferences, abilities, inventory, nextEquipment, resting, gold, activeQuest);
+        return new Player(identity, combatState, preferences, abilities, inventory, nextEquipment, resting, gold, activeQuest, totalKills);
     }
 
     /**
      * Returns a copy of this player with the given identity (level and experience).
      */
     public Player withIdentity(PlayerIdentity nextIdentity) {
-        return new Player(nextIdentity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest);
+        return new Player(nextIdentity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills);
     }
 
     /**
@@ -347,7 +373,7 @@ public class Player implements EffectTarget, Combatant {
      * @param resting {@code true} to enter a resting state, {@code false} to wake up
      */
     public Player withResting(boolean resting) {
-        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest);
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills);
     }
 
     /**
@@ -356,7 +382,7 @@ public class Player implements EffectTarget, Combatant {
      * @param newGold the new gold amount; negative values are clamped to 0
      */
     public Player withGold(int newGold) {
-        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, newGold, activeQuest);
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, newGold, activeQuest, totalKills);
     }
 
     /**
@@ -374,6 +400,15 @@ public class Player implements EffectTarget, Combatant {
      * @param quest the quest to set, or {@code null} to clear the active quest
      */
     public Player withActiveQuest(ActiveQuest quest) {
-        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, quest);
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, quest, totalKills);
+    }
+
+    /**
+     * Returns a copy of this player with the total kill count set to the given value.
+     *
+     * @param newTotalKills the new kill count; negative values are clamped to 0
+     */
+    public Player withTotalKills(long newTotalKills) {
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, newTotalKills);
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/ScoreCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/ScoreCommand.java
@@ -61,6 +61,7 @@ public class ScoreCommand extends RegistrableCommand {
         context.writeLineSafe(String.format("Mana  : %d / %d", vitals.mana(), vitals.maxMana()));
         context.writeLineSafe(String.format("Move  : %d / %d", vitals.move(), vitals.maxMove()));
         context.writeLineSafe(String.format("Gold  : %d", player.getGold()));
+        context.writeLineSafe(String.format("Kills : %d", player.getTotalKills()));
         context.sendPrompt();
     }
 }

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryKillTrackingTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryKillTrackingTest.java
@@ -1,0 +1,213 @@
+package io.taanielo.jmud.core.mob;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.action.GameActionResult;
+import io.taanielo.jmud.core.action.PlayerEventBus;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.combat.AttackDefinition;
+import io.taanielo.jmud.core.combat.AttackId;
+import io.taanielo.jmud.core.combat.CombatSettings;
+import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.combat.repository.AttackRepositoryException;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.ItemRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Verifies that {@code totalKills} is incremented on the killing player each
+ * time a mob is killed, via both the instant-kill ({@code processPlayerAttack})
+ * and the tick-based ({@code runPlayerCombat}) paths.
+ */
+class MobRegistryKillTrackingTest {
+
+    private static final RoomId ROOM_ID = RoomId.of("room.test");
+    private static final AttackId DEFAULT_ATTACK =
+        AttackId.of(CombatSettings.DEFAULT_ATTACK_ID);
+    private static final AttackDefinition ONE_DMG_ATTACK =
+        new AttackDefinition(DEFAULT_ATTACK, "punch", 1, 1, 0, 0, 0, List.of());
+
+    // ── helpers ───────────────────────────────────────────────────────
+
+    private Player player(String name) {
+        User user = User.of(Username.of(name), Password.hash("pw", 1));
+        return Player.of(user, "%hp> ");
+    }
+
+    private MobTemplate templateWithHp(int maxHp) {
+        return new MobTemplate(
+            MobId.of("mob.rat"),
+            "Rat",
+            maxHp,
+            null,
+            false,
+            List.of(),
+            ROOM_ID,
+            1,
+            10,
+            5,
+            null,
+            null
+        );
+    }
+
+    private MobRegistry buildRegistry(
+        MobTemplate template,
+        Player attacker,
+        StubPlayerRepository playerRepo,
+        List<GameActionResult> captured
+    ) {
+        MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
+        AttackRepository attackRepo = new StubAttackRepository(Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));
+        ItemRepository itemRepo = new StubItemRepository();
+
+        RoomService roomService = new RoomService(new StubRoomRepository(ROOM_ID), ROOM_ID);
+        roomService.ensurePlayerLocation(attacker.getUsername());
+
+        PlayerEventBus bus = new PlayerEventBus();
+        bus.register(attacker.getUsername(), captured::add);
+
+        MobRegistry registry = new MobRegistry(
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo, bus);
+        registry.init();
+        return registry;
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────
+
+    /**
+     * Killing a mob via {@code processPlayerAttack} must increment
+     * {@code totalKills} from 0 to 1 on the persisted player.
+     */
+    @Test
+    void processPlayerAttack_incrementsTotalKillsOnKill() {
+        Player attacker = player("hero");
+        assertEquals(0L, attacker.getTotalKills(), "Player should start with 0 kills");
+
+        MobTemplate template = templateWithHp(1); // 1 HP → one-shot
+        StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, new ArrayList<>());
+
+        registry.processPlayerAttack(attacker, "Rat", ROOM_ID);
+
+        Player saved = playerRepo.load(attacker.getUsername());
+        assertEquals(1L, saved.getTotalKills(),
+            "totalKills should be 1 after one kill via processPlayerAttack");
+    }
+
+    /**
+     * Killing a second mob must increment {@code totalKills} to 2.
+     */
+    @Test
+    void processPlayerAttack_accumulatesTotalKillsAcrossMultipleKills() {
+        Player attacker = player("hero");
+
+        // Use two separate registries / mob instances to simulate two distinct kills.
+        StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        List<GameActionResult> captured = new ArrayList<>();
+
+        MobTemplate template = templateWithHp(1);
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured);
+
+        registry.processPlayerAttack(attacker, "Rat", ROOM_ID);
+
+        // Reload the saved state and simulate a second kill.
+        Player afterFirst = playerRepo.load(attacker.getUsername());
+        assertEquals(1L, afterFirst.getTotalKills());
+
+        // The second kill reuses the same registry — mob respawns after scheduleRespawn,
+        // so we rebuild to get a fresh instance.
+        StubPlayerRepository playerRepo2 = new StubPlayerRepository(afterFirst);
+        MobRegistry registry2 = buildRegistry(template, afterFirst, playerRepo2, new ArrayList<>());
+        registry2.processPlayerAttack(afterFirst, "Rat", ROOM_ID);
+
+        Player afterSecond = playerRepo2.load(afterFirst.getUsername());
+        assertEquals(2L, afterSecond.getTotalKills(),
+            "totalKills should be 2 after two kills");
+    }
+
+    /**
+     * Killing a mob via the tick ({@code runPlayerCombat}) must also
+     * increment {@code totalKills}.
+     */
+    @Test
+    void runPlayerCombat_incrementsTotalKillsOnKill() {
+        Player attacker = player("hero");
+
+        // 2 HP: first attack leaves 1 HP, next tick delivers the killing blow.
+        MobTemplate template = templateWithHp(2);
+        StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        List<GameActionResult> captured = new ArrayList<>();
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured);
+
+        // First hit — mob survives, combat registered.
+        registry.processPlayerAttack(attacker, "Rat", ROOM_ID);
+        captured.clear();
+
+        // Tick — killing blow via runPlayerCombat.
+        registry.tick();
+
+        Player saved = playerRepo.load(attacker.getUsername());
+        assertEquals(1L, saved.getTotalKills(),
+            "totalKills should be 1 after a tick kill via runPlayerCombat");
+    }
+
+    // ── stubs ─────────────────────────────────────────────────────────
+
+    private record StubMobTemplateRepository(List<MobTemplate> templates)
+        implements MobTemplateRepository {
+        @Override
+        public List<MobTemplate> findAll() { return templates; }
+    }
+
+    private record StubAttackRepository(Map<AttackId, AttackDefinition> attacks)
+        implements AttackRepository {
+        @Override
+        public Optional<AttackDefinition> findById(AttackId id) throws AttackRepositoryException {
+            return Optional.ofNullable(attacks.get(id));
+        }
+    }
+
+    private static class StubItemRepository implements ItemRepository {
+        @Override public void save(Item item) {}
+        @Override public Optional<Item> findById(ItemId id) { return Optional.empty(); }
+    }
+
+    static class StubPlayerRepository implements PlayerRepository {
+        private final ConcurrentHashMap<Username, Player> store = new ConcurrentHashMap<>();
+        StubPlayerRepository(Player initial) { store.put(initial.getUsername(), initial); }
+        @Override public void savePlayer(Player player) { store.put(player.getUsername(), player); }
+        @Override public Optional<Player> loadPlayer(Username username) {
+            return Optional.ofNullable(store.get(username));
+        }
+        Player load(Username username) { return store.get(username); }
+    }
+
+    private static class StubRoomRepository implements RoomRepository {
+        private final Room room;
+        StubRoomRepository(RoomId roomId) {
+            this.room = new Room(roomId, "Test Room", "A void.", Map.of(), List.of(), List.of());
+        }
+        @Override public void save(Room room) {}
+        @Override public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return room.getId().equals(id) ? Optional.of(room) : Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `totalKills` counter field to the `Player` model
- Increments `totalKills` in `MobRegistry` whenever a mob is killed
- Displays the kill count in `ScoreCommand` output
- Adds `MobRegistryKillTrackingTest` to verify counter increments correctly

Closes #143

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)