### PR TITLE
feat(quest): add delivery quest type with mob drop collection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,7 +54,7 @@
 ## Planned
 - [x] Add SCORE command enhancements: show current level, XP to next level, and total kills
 - [x] Add TRAIN command and trainer NPC so players can spend practice points on skills
-- [ ] Add multi-kill quest: deliver a fixed number of drops (e.g. rat tails) to an NPC for a reward
+- [x] Add multi-kill quest: deliver a fixed number of drops (e.g. rat tails) to an NPC for a reward
 - [ ] Add PARTY system: players can form a group to share XP and see party HP in prompt
 - [ ] Add mob respawn with wander: mobs randomly move between linked rooms on tick
 - [ ] Add LOCK and UNLOCK commands with key items for gated doors between zones

--- a/data/items/rat-tail.json
+++ b/data/items/rat-tail.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 3,
+  "id": "rat-tail",
+  "name": "Rat Tail",
+  "description": "A stiff, scaly rat tail. The Guild Clerk is collecting these as proof of pest control.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [],
+  "messages": [],
+  "weight": 0,
+  "value": 0
+}

--- a/data/mobs/rat.json
+++ b/data/mobs/rat.json
@@ -8,7 +8,9 @@
   "spawn_room_id": "muddy-hollow",
   "max_count": 3,
   "respawn_ticks": 15,
-  "loot": [],
+  "loot": [
+    { "item_id": "rat-tail", "drop_chance": 0.4 }
+  ],
   "gold_drop": {
     "min": 1,
     "max": 4

--- a/data/quests/quest.rat-tail-collector.json
+++ b/data/quests/quest.rat-tail-collector.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 2,
+  "id": "rat-tail-collector",
+  "name": "Rat Tail Collector",
+  "description": "Bring 5 rat tails to the Guild Clerk as proof of pest control in the muddy hollow.",
+  "drop_item_id": "rat-tail",
+  "required_drop_count": 5,
+  "gold_reward": 40,
+  "xp_reward": 100
+}

--- a/src/main/java/io/taanielo/jmud/core/quest/QuestDeliveryService.java
+++ b/src/main/java/io/taanielo/jmud/core/quest/QuestDeliveryService.java
@@ -1,0 +1,179 @@
+package io.taanielo.jmud.core.quest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemId;
+
+/**
+ * Domain service for delivery-type quests where a player must collect a specific
+ * drop item and turn in the required number to claim a reward.
+ *
+ * <p>Progress is determined dynamically by counting qualifying items in the
+ * player's inventory rather than maintaining a separate counter, ensuring
+ * the count is always in sync with actual held items.
+ *
+ * <p>This service is stateless and thread-safe.
+ */
+@Slf4j
+public class QuestDeliveryService {
+
+    private final QuestRepository questRepository;
+
+    public QuestDeliveryService(QuestRepository questRepository) {
+        this.questRepository = Objects.requireNonNull(questRepository, "questRepository is required");
+    }
+
+    /**
+     * Checks whether picking up an item should trigger a delivery quest progress message.
+     *
+     * <p>Returns a progress string (e.g. {@code "Rat Tail: 3/5 collected."}) when the
+     * player has an active delivery quest whose {@code dropItemId} matches the given
+     * item id. Returns empty when there is no delivery quest or the item does not match.
+     *
+     * @param player  the player who just picked up an item (inventory already updated); must not be null
+     * @param itemId  the id of the item that was picked up; must not be null
+     * @return an optional progress message
+     */
+    public Optional<String> checkPickupProgress(Player player, ItemId itemId) {
+        Objects.requireNonNull(player, "player is required");
+        Objects.requireNonNull(itemId, "itemId is required");
+
+        ActiveQuest active = player.getActiveQuest();
+        if (active == null) {
+            return Optional.empty();
+        }
+
+        QuestTemplate template;
+        try {
+            template = questRepository.findById(active.templateId()).orElse(null);
+        } catch (QuestRepositoryException e) {
+            log.warn("Failed to load quest template {}: {}", active.templateId(), e.getMessage());
+            return Optional.empty();
+        }
+
+        if (template == null || !template.isDeliveryQuest()) {
+            return Optional.empty();
+        }
+
+        if (!itemId.getValue().equalsIgnoreCase(template.dropItemId())) {
+            return Optional.empty();
+        }
+
+        int held = countMatchingItems(player, template.dropItemId());
+        return Optional.of(template.name() + ": " + held + "/" + template.requiredDropCount() + " collected.");
+    }
+
+    /**
+     * Attempts to deliver collected items to the NPC for a reward.
+     *
+     * <p>Checks that the player holds at least {@code requiredDropCount} of the qualifying
+     * item. If so, removes exactly that many items from inventory, grants gold and XP,
+     * and clears the active quest. If not, returns a failure message explaining how many
+     * are still needed.
+     *
+     * <p>Callers are responsible for the room/location check before invoking this method.
+     *
+     * @param player the player attempting to deliver; must not be null
+     * @return a {@link DeliverResult} with the outcome
+     */
+    public DeliverResult deliver(Player player) {
+        Objects.requireNonNull(player, "player is required");
+
+        ActiveQuest active = player.getActiveQuest();
+        if (active == null) {
+            return DeliverResult.failure("You have no active delivery contract.");
+        }
+
+        QuestTemplate template;
+        try {
+            template = questRepository.findById(active.templateId()).orElse(null);
+        } catch (QuestRepositoryException e) {
+            log.warn("Failed to load quest template on deliver {}: {}", active.templateId(), e.getMessage());
+            return DeliverResult.failure("Quest data unavailable. Try again.");
+        }
+
+        if (template == null) {
+            return DeliverResult.failure("Unknown quest template. Use QUEST ABANDON to clear it.");
+        }
+
+        if (!template.isDeliveryQuest()) {
+            return DeliverResult.failure(
+                "That contract requires kills, not item delivery. Use QUEST COMPLETE instead.");
+        }
+
+        int held = countMatchingItems(player, template.dropItemId());
+        if (held < template.requiredDropCount()) {
+            int stillNeeded = template.requiredDropCount() - held;
+            return DeliverResult.failure(
+                "You only have " + held + "/" + template.requiredDropCount()
+                + " " + template.name().toLowerCase() + " items. "
+                + "You still need " + stillNeeded + " more.");
+        }
+
+        // Remove exactly requiredDropCount items from inventory
+        Player updated = removeItems(player, template.dropItemId(), template.requiredDropCount());
+        updated = updated.withActiveQuest(null).addGold(template.goldReward());
+
+        // Add XP directly to the player's cumulative experience total
+        long newXp = updated.getExperience() + template.xpReward();
+        updated = updated.withIdentity(updated.identity().withExperience(newXp));
+
+        List<String> messages = new ArrayList<>();
+        messages.add("The Guild Clerk nods approvingly. Contract complete: " + template.name() + ".");
+        messages.add("You receive " + template.goldReward() + " gold and " + template.xpReward() + " experience.");
+
+        return DeliverResult.success(updated, messages);
+    }
+
+    // ── private helpers ────────────────────────────────────────────────
+
+    private int countMatchingItems(Player player, String dropItemId) {
+        int count = 0;
+        for (Item item : player.getInventory()) {
+            if (item.getId().getValue().equalsIgnoreCase(dropItemId)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private Player removeItems(Player player, String dropItemId, int count) {
+        List<Item> inventory = player.getInventory();
+        List<Item> remaining = new ArrayList<>(inventory.size());
+        int stillToRemove = count;
+        for (Item item : inventory) {
+            if (stillToRemove > 0 && item.getId().getValue().equalsIgnoreCase(dropItemId)) {
+                stillToRemove--;
+                // skip — this item is turned in
+            } else {
+                remaining.add(item);
+            }
+        }
+        return player.withInventory(remaining);
+    }
+
+    /**
+     * Result of a delivery attempt.
+     *
+     * @param player   updated player state after a successful delivery; {@code null} on failure
+     * @param messages messages to deliver to the player
+     * @param success  {@code true} when the delivery was accepted and reward granted
+     */
+    public record DeliverResult(Player player, List<String> messages, boolean success) {
+
+        static DeliverResult success(Player player, List<String> messages) {
+            return new DeliverResult(player, List.copyOf(messages), true);
+        }
+
+        static DeliverResult failure(String message) {
+            return new DeliverResult(null, List.of(message), false);
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/quest/QuestKillService.java
+++ b/src/main/java/io/taanielo/jmud/core/quest/QuestKillService.java
@@ -59,6 +59,10 @@ public class QuestKillService {
             return Optional.empty();
         }
 
+        if (template.isDeliveryQuest() || template.targetMobId() == null) {
+            return Optional.empty();
+        }
+
         if (!template.targetMobId().equals(killedMobId)) {
             return Optional.empty();
         }

--- a/src/main/java/io/taanielo/jmud/core/quest/QuestTemplate.java
+++ b/src/main/java/io/taanielo/jmud/core/quest/QuestTemplate.java
@@ -5,13 +5,23 @@ import java.util.Objects;
 /**
  * Immutable definition of a quest contract loaded from data files.
  *
- * @param id            unique quest identifier
- * @param name          display name shown to players
- * @param description   short flavour description of the quest goal
- * @param targetMobId   mob template id that must be killed to progress
- * @param requiredKills number of kills needed to complete the quest
- * @param goldReward    bonus gold awarded on completion
- * @param xpReward      bonus XP awarded on completion
+ * <p>Two quest types are supported:
+ * <ul>
+ *   <li><b>Kill quest</b> — {@code targetMobId} and {@code requiredKills} are set;
+ *       {@code dropItemId} and {@code requiredDropCount} are {@code null}/0.</li>
+ *   <li><b>Delivery quest</b> — {@code dropItemId} and {@code requiredDropCount} are set;
+ *       {@code targetMobId} and {@code requiredKills} are {@code null}/0.</li>
+ * </ul>
+ *
+ * @param id                unique quest identifier
+ * @param name              display name shown to players
+ * @param description       short flavour description of the quest goal
+ * @param targetMobId       mob template id that must be killed to progress (kill quests only)
+ * @param requiredKills     number of kills needed to complete the quest (kill quests only)
+ * @param goldReward        bonus gold awarded on completion
+ * @param xpReward          bonus XP awarded on completion
+ * @param dropItemId        item id that must be collected and turned in (delivery quests only)
+ * @param requiredDropCount number of drop items needed to complete the quest (delivery quests only)
  */
 public record QuestTemplate(
     QuestId id,
@@ -20,15 +30,20 @@ public record QuestTemplate(
     String targetMobId,
     int requiredKills,
     int goldReward,
-    int xpReward
+    int xpReward,
+    String dropItemId,
+    int requiredDropCount
 ) {
     public QuestTemplate {
         Objects.requireNonNull(id, "Quest id is required");
         Objects.requireNonNull(name, "Quest name is required");
         Objects.requireNonNull(description, "Quest description is required");
-        Objects.requireNonNull(targetMobId, "Quest targetMobId is required");
-        if (requiredKills <= 0) {
-            throw new IllegalArgumentException("requiredKills must be positive");
+        boolean isKillQuest = targetMobId != null && requiredKills > 0;
+        boolean isDeliveryQuest = dropItemId != null && requiredDropCount > 0;
+        if (!isKillQuest && !isDeliveryQuest) {
+            throw new IllegalArgumentException(
+                "Quest must define either kill targets (targetMobId + requiredKills) "
+                + "or drop targets (dropItemId + requiredDropCount)");
         }
         if (goldReward < 0) {
             throw new IllegalArgumentException("goldReward must be non-negative");
@@ -36,5 +51,36 @@ public record QuestTemplate(
         if (xpReward < 0) {
             throw new IllegalArgumentException("xpReward must be non-negative");
         }
+    }
+
+    /**
+     * Convenience constructor for kill-count quests (no delivery fields).
+     *
+     * @param id            unique quest identifier
+     * @param name          display name shown to players
+     * @param description   short flavour description of the quest goal
+     * @param targetMobId   mob template id that must be killed to progress
+     * @param requiredKills number of kills needed to complete the quest
+     * @param goldReward    bonus gold awarded on completion
+     * @param xpReward      bonus XP awarded on completion
+     */
+    public QuestTemplate(
+        QuestId id,
+        String name,
+        String description,
+        String targetMobId,
+        int requiredKills,
+        int goldReward,
+        int xpReward
+    ) {
+        this(id, name, description, targetMobId, requiredKills, goldReward, xpReward, null, 0);
+    }
+
+    /**
+     * Returns {@code true} when this is a delivery quest where the player must
+     * collect a specific drop item and turn it in to the Guild Clerk.
+     */
+    public boolean isDeliveryQuest() {
+        return dropItemId != null && requiredDropCount > 0;
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/quest/repository/json/JsonQuestRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/quest/repository/json/JsonQuestRepository.java
@@ -26,7 +26,8 @@ import io.taanielo.jmud.core.quest.QuestTemplate;
 @Slf4j
 public class JsonQuestRepository implements QuestRepository {
 
-    private static final int SCHEMA_VERSION = 1;
+    private static final int SCHEMA_VERSION_KILL = 1;
+    private static final int SCHEMA_VERSION_DELIVERY = 2;
     private static final String QUESTS_DIR = "quests";
 
     private final ObjectMapper objectMapper;
@@ -66,7 +67,8 @@ public class JsonQuestRepository implements QuestRepository {
         try (var stream = Files.list(questsDirPath)) {
             for (Path path : stream.filter(p -> p.toString().endsWith(".json")).toList()) {
                 QuestDto dto = readDto(path);
-                if (dto.schemaVersion() != SCHEMA_VERSION) {
+                if (dto.schemaVersion() != SCHEMA_VERSION_KILL
+                        && dto.schemaVersion() != SCHEMA_VERSION_DELIVERY) {
                     throw new QuestRepositoryException(
                         "Unsupported quest schema version " + dto.schemaVersion() + " in " + path);
                 }
@@ -88,7 +90,9 @@ public class JsonQuestRepository implements QuestRepository {
                 dto.targetMobId(),
                 dto.requiredKills(),
                 dto.goldReward(),
-                dto.xpReward()
+                dto.xpReward(),
+                dto.dropItemId(),
+                dto.requiredDropCount()
             );
         } catch (IllegalArgumentException e) {
             throw new QuestRepositoryException("Invalid quest data in " + source + ": " + e.getMessage(), e);

--- a/src/main/java/io/taanielo/jmud/core/quest/repository/json/QuestDto.java
+++ b/src/main/java/io/taanielo/jmud/core/quest/repository/json/QuestDto.java
@@ -2,6 +2,10 @@ package io.taanielo.jmud.core.quest.repository.json;
 
 /**
  * JSON transfer object for a quest definition file ({@code quest.*.json}).
+ *
+ * <p>Fields {@code dropItemId} and {@code requiredDropCount} are optional and
+ * used only for delivery quests (schema version 2). Kill quests (schema version 1)
+ * use {@code targetMobId} and {@code requiredKills} instead.
  */
 record QuestDto(
     int schemaVersion,
@@ -11,6 +15,8 @@ record QuestDto(
     String targetMobId,
     int requiredKills,
     int goldReward,
-    int xpReward
+    int xpReward,
+    String dropItemId,
+    int requiredDropCount
 ) {
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/QuestCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/QuestCommand.java
@@ -11,7 +11,8 @@ import java.util.Optional;
  *   <li>{@code QUEST LIST}           — shows available contracts</li>
  *   <li>{@code QUEST ACCEPT <name>}  — accepts the named contract</li>
  *   <li>{@code QUEST STATUS}         — prints current quest progress</li>
- *   <li>{@code QUEST COMPLETE}       — claims reward (must be in Courtyard)</li>
+ *   <li>{@code QUEST COMPLETE}       — claims kill-quest reward (must be in Courtyard)</li>
+ *   <li>{@code QUEST DELIVER}        — turns in collected items for delivery-quest reward (must be in Courtyard)</li>
  *   <li>{@code QUEST ABANDON}        — drops the active quest with no penalty</li>
  * </ul>
  */
@@ -37,7 +38,8 @@ public class QuestCommand extends RegistrableCommand {
              + "  QUEST LIST             — show available contracts\n"
              + "  QUEST ACCEPT <id>      — accept a contract (e.g. QUEST ACCEPT rat-catcher)\n"
              + "  QUEST STATUS           — show current quest progress\n"
-             + "  QUEST COMPLETE         — claim your reward (must be in the Courtyard)\n"
+             + "  QUEST COMPLETE         — claim kill-quest reward (must be in the Courtyard)\n"
+             + "  QUEST DELIVER          — turn in collected items for delivery-quest reward (must be in the Courtyard)\n"
              + "  QUEST ABANDON          — drop the active quest with no penalty";
     }
 

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -57,6 +57,7 @@ import io.taanielo.jmud.core.server.ClientPool;
 import io.taanielo.jmud.core.server.connection.ClientConnection;
 import io.taanielo.jmud.core.server.connection.TransportSecurity;
 import io.taanielo.jmud.core.quest.ActiveQuest;
+import io.taanielo.jmud.core.quest.QuestDeliveryService;
 import io.taanielo.jmud.core.quest.QuestKillService;
 import io.taanielo.jmud.core.quest.QuestRepository;
 import io.taanielo.jmud.core.quest.QuestRepositoryException;
@@ -1017,8 +1018,28 @@ public class SocketClient implements Client {
                 return;
             }
             cancelRestIfActive();
-            GameActionResult result = gameActionService.getItem(session.getPlayer(), args);
+            Player playerBeforeGet = session.getPlayer();
+            GameActionResult result = gameActionService.getItem(playerBeforeGet, args);
             deliverResult(result);
+            // After a successful pickup, check if this triggers delivery quest progress
+            if (result.updatedSource() != null && context.questRepository() != null) {
+                Player updatedPlayer = session.getPlayer();
+                // Find the newly added item by comparing item-id counts before and after
+                java.util.Map<io.taanielo.jmud.core.world.ItemId, Long> oldCounts =
+                    playerBeforeGet.getInventory().stream()
+                        .collect(java.util.stream.Collectors.groupingBy(Item::getId, java.util.stream.Collectors.counting()));
+                QuestDeliveryService deliverySvc = new QuestDeliveryService(context.questRepository());
+                for (Item item : updatedPlayer.getInventory()) {
+                    long before = oldCounts.getOrDefault(item.getId(), 0L);
+                    long after = updatedPlayer.getInventory().stream()
+                        .filter(i -> i.getId().equals(item.getId())).count();
+                    if (after > before) {
+                        deliverySvc.checkPickupProgress(updatedPlayer, item.getId())
+                            .ifPresent(connection::writeLine);
+                        break;
+                    }
+                }
+            }
             sendPrompt();
         }
 
@@ -1465,9 +1486,10 @@ public class SocketClient implements Client {
                 case "ACCEPT" -> handleQuestAccept(questRepo, subArgs);
                 case "STATUS" -> handleQuestStatus(questRepo);
                 case "COMPLETE" -> handleQuestComplete(questRepo);
+                case "DELIVER" -> handleQuestDeliver(questRepo);
                 case "ABANDON" -> handleQuestAbandon();
                 default -> writeLineWithPrompt(
-                    "Usage: QUEST [LIST|ACCEPT <id>|STATUS|COMPLETE|ABANDON]");
+                    "Usage: QUEST [LIST|ACCEPT <id>|STATUS|COMPLETE|DELIVER|ABANDON]");
             }
         }
 
@@ -1649,10 +1671,17 @@ public class SocketClient implements Client {
             ActiveQuest active = new ActiveQuest(template.id(), template.requiredKills());
             Player updated = player.withActiveQuest(active);
             session.replacePlayer(updated);
-            writeLineWithPrompt(
-                "Contract accepted: " + template.name() + ". "
-                    + "Kill " + template.requiredKills() + " "
-                    + template.targetMobId() + "(s). Good luck.");
+            if (template.isDeliveryQuest()) {
+                writeLineWithPrompt(
+                    "Contract accepted: " + template.name() + ". "
+                        + "Collect " + template.requiredDropCount() + " "
+                        + template.dropItemId() + "(s) and QUEST DELIVER them here. Good luck.");
+            } else {
+                writeLineWithPrompt(
+                    "Contract accepted: " + template.name() + ". "
+                        + "Kill " + template.requiredKills() + " "
+                        + template.targetMobId() + "(s). Good luck.");
+            }
         }
 
         private void handleQuestStatus(QuestRepository questRepo) {
@@ -1674,7 +1703,20 @@ public class SocketClient implements Client {
                 writeLineWithPrompt("Unknown quest. Use QUEST ABANDON to clear it.");
                 return;
             }
-            if (active.isComplete()) {
+            if (template.isDeliveryQuest()) {
+                int held = 0;
+                for (Item it : player.getInventory()) {
+                    if (it.getId().getValue().equalsIgnoreCase(template.dropItemId())) {
+                        held++;
+                    }
+                }
+                if (held >= template.requiredDropCount()) {
+                    writeLineWithPrompt(template.name() + ": " + held + "/" + template.requiredDropCount()
+                        + " collected — return to the Guild Clerk and use QUEST DELIVER to claim your reward.");
+                } else {
+                    writeLineWithPrompt(template.name() + ": " + held + "/" + template.requiredDropCount() + " collected.");
+                }
+            } else if (active.isComplete()) {
                 writeLineWithPrompt(template.name() + ": complete — return to the Guild Clerk to claim your reward.");
             } else {
                 int done = template.requiredKills() - active.killsRemaining();
@@ -1696,6 +1738,18 @@ public class SocketClient implements Client {
             ActiveQuest active = player.getActiveQuest();
             if (active == null) {
                 writeLineWithPrompt("You have no active contract to complete.");
+                return;
+            }
+            // Delivery quests use QUEST DELIVER, not QUEST COMPLETE
+            QuestTemplate templateCheck;
+            try {
+                templateCheck = questRepo.findById(active.templateId()).orElse(null);
+            } catch (QuestRepositoryException e) {
+                writeLineWithPrompt("Quest lookup failed.");
+                return;
+            }
+            if (templateCheck != null && templateCheck.isDeliveryQuest()) {
+                writeLineWithPrompt("This contract requires item delivery. Use QUEST DELIVER instead.");
                 return;
             }
             if (!active.isComplete()) {
@@ -1737,6 +1791,28 @@ public class SocketClient implements Client {
                 "You receive " + template.goldReward() + " gold and " + template.xpReward() + " experience.");
             if (lvResult.leveledUp()) {
                 connection.writeLine("You have advanced to level " + rewarded.getLevel() + "!");
+            }
+            sendPrompt();
+        }
+
+        private void handleQuestDeliver(QuestRepository questRepo) {
+            Player player = session.getPlayer();
+            var roomIdOpt = roomService.findPlayerLocation(player.getUsername());
+            if (roomIdOpt.isEmpty()) {
+                writeLineWithPrompt("You are nowhere.");
+                return;
+            }
+            if (!"courtyard".equals(roomIdOpt.get().getValue())) {
+                writeLineWithPrompt("The Guild Clerk is not here. Find them in the Courtyard.");
+                return;
+            }
+            QuestDeliveryService deliverySvc = new QuestDeliveryService(questRepo);
+            QuestDeliveryService.DeliverResult result = deliverySvc.deliver(player);
+            if (result.success()) {
+                session.replacePlayer(result.player());
+            }
+            for (String msg : result.messages()) {
+                connection.writeLine(msg);
             }
             sendPrompt();
         }

--- a/src/test/java/io/taanielo/jmud/core/quest/QuestDeliveryServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/quest/QuestDeliveryServiceTest.java
@@ -1,0 +1,237 @@
+package io.taanielo.jmud.core.quest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.prompt.PromptSettings;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemAttributes;
+import io.taanielo.jmud.core.world.ItemId;
+
+/**
+ * Unit tests for {@link QuestDeliveryService}.
+ */
+class QuestDeliveryServiceTest {
+
+    private static final QuestId COLLECTOR_ID = QuestId.of("rat-tail-collector");
+    private static final QuestTemplate COLLECTOR_QUEST = new QuestTemplate(
+        COLLECTOR_ID,
+        "Rat Tail Collector",
+        "Bring 5 rat tails to the Guild Clerk.",
+        null, 0,                  // no kill targets
+        40, 100,                  // rewards
+        "rat-tail", 5             // delivery fields
+    );
+
+    private QuestDeliveryService service;
+    private Player basePlayer;
+
+    @BeforeEach
+    void setUp() {
+        QuestRepository repo = new StubQuestRepository(List.of(COLLECTOR_QUEST));
+        service = new QuestDeliveryService(repo);
+        User user = new User(Username.of("tester"), Password.of("pass"));
+        basePlayer = Player.of(user, PromptSettings.defaultFormat());
+    }
+
+    // ── checkPickupProgress ────────────────────────────────────────────
+
+    @Test
+    void returnsEmptyWhenNoActiveQuest() {
+        Player withTail = basePlayer.addItem(ratTail());
+        Optional<String> msg = service.checkPickupProgress(withTail, ItemId.of("rat-tail"));
+        assertTrue(msg.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyWhenActiveQuestIsKillType() {
+        QuestTemplate killQuest = new QuestTemplate(
+            QuestId.of("rat-catcher"), "Rat Catcher", "Kill rats.", "rat", 5, 30, 75);
+        QuestRepository repo = new StubQuestRepository(List.of(killQuest));
+        QuestDeliveryService svc = new QuestDeliveryService(repo);
+
+        Player withQuest = basePlayer
+            .withActiveQuest(new ActiveQuest(QuestId.of("rat-catcher"), 5))
+            .addItem(ratTail());
+        Optional<String> msg = svc.checkPickupProgress(withQuest, ItemId.of("rat-tail"));
+        assertTrue(msg.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyWhenPickedUpItemDoesNotMatchDropId() {
+        Player withQuest = basePlayer.withActiveQuest(new ActiveQuest(COLLECTOR_ID, 0));
+        Item wolfPelt = makeItem("wolf-pelt", "Wolf Pelt");
+        Player withPelt = withQuest.addItem(wolfPelt);
+        Optional<String> msg = service.checkPickupProgress(withPelt, ItemId.of("wolf-pelt"));
+        assertTrue(msg.isEmpty());
+    }
+
+    @Test
+    void returnsProgressMessageOnFirstPickup() {
+        Player withQuest = basePlayer
+            .withActiveQuest(new ActiveQuest(COLLECTOR_ID, 0))
+            .addItem(ratTail());
+        Optional<String> msg = service.checkPickupProgress(withQuest, ItemId.of("rat-tail"));
+        assertTrue(msg.isPresent(), "Expected progress message");
+        assertTrue(msg.get().contains("1/5"), "Expected '1/5' in: " + msg.get());
+        assertTrue(msg.get().contains("collected"), "Expected 'collected' in: " + msg.get());
+    }
+
+    @Test
+    void returnsProgressMessageReflectsCurrentInventoryCount() {
+        Player withQuest = basePlayer.withActiveQuest(new ActiveQuest(COLLECTOR_ID, 0));
+        // Add 3 rat tails
+        Player with3 = withQuest.addItem(ratTail()).addItem(ratTail()).addItem(ratTail());
+        Optional<String> msg = service.checkPickupProgress(with3, ItemId.of("rat-tail"));
+        assertTrue(msg.isPresent());
+        assertTrue(msg.get().contains("3/5"), "Expected '3/5' in: " + msg.get());
+    }
+
+    // ── deliver ────────────────────────────────────────────────────────
+
+    @Test
+    void deliverFailsWhenNoActiveQuest() {
+        QuestDeliveryService.DeliverResult result = service.deliver(basePlayer);
+        assertFalse(result.success());
+        assertFalse(result.messages().isEmpty());
+        assertTrue(result.messages().getFirst().toLowerCase().contains("no active"),
+            "Expected 'no active' in: " + result.messages());
+    }
+
+    @Test
+    void deliverFailsWhenActiveQuestIsKillType() {
+        QuestTemplate killQuest = new QuestTemplate(
+            QuestId.of("rat-catcher"), "Rat Catcher", "Kill rats.", "rat", 5, 30, 75);
+        QuestRepository repo = new StubQuestRepository(List.of(killQuest));
+        QuestDeliveryService svc = new QuestDeliveryService(repo);
+
+        Player withQuest = basePlayer.withActiveQuest(new ActiveQuest(QuestId.of("rat-catcher"), 5));
+        QuestDeliveryService.DeliverResult result = svc.deliver(withQuest);
+        assertFalse(result.success());
+        assertTrue(result.messages().getFirst().contains("QUEST COMPLETE"),
+            "Expected 'QUEST COMPLETE' hint in: " + result.messages());
+    }
+
+    @Test
+    void deliverRejectsIncompleteWithFeedback() {
+        // Player has 3/5 rat tails
+        Player withQuest = basePlayer.withActiveQuest(new ActiveQuest(COLLECTOR_ID, 0));
+        Player with3 = withQuest.addItem(ratTail()).addItem(ratTail()).addItem(ratTail());
+        QuestDeliveryService.DeliverResult result = service.deliver(with3);
+        assertFalse(result.success(), "Should fail when fewer than 5 tails held");
+        assertNull(result.player(), "No updated player on failure");
+        String msg = result.messages().getFirst();
+        assertTrue(msg.contains("3/5") || msg.contains("3"), "Expected count in: " + msg);
+        assertTrue(msg.contains("2") || msg.contains("still need"), "Expected missing count info in: " + msg);
+    }
+
+    @Test
+    void deliverSuccessRemovesItemsAndGrantsReward() {
+        // Player has exactly 5 rat tails
+        Player withQuest = basePlayer.withActiveQuest(new ActiveQuest(COLLECTOR_ID, 0));
+        Player with5 = withQuest;
+        for (int i = 0; i < 5; i++) {
+            with5 = with5.addItem(ratTail());
+        }
+        assertEquals(5, countRatTails(with5), "Precondition: 5 tails in inventory");
+
+        QuestDeliveryService.DeliverResult result = service.deliver(with5);
+
+        assertTrue(result.success(), "Delivery should succeed with 5 tails");
+        assertNotNull(result.player(), "Updated player required on success");
+        Player rewarded = result.player();
+
+        assertEquals(0, countRatTails(rewarded), "All rat tails should be removed after delivery");
+        assertNull(rewarded.getActiveQuest(), "Active quest should be cleared after delivery");
+        assertEquals(40, rewarded.getGold(), "Gold reward should be granted");
+        assertTrue(rewarded.getExperience() >= 100, "XP reward should be granted");
+    }
+
+    @Test
+    void deliverSuccessWithMoreThanRequiredRemovesExactCount() {
+        // Player has 7 rat tails but only 5 are needed
+        Player withQuest = basePlayer.withActiveQuest(new ActiveQuest(COLLECTOR_ID, 0));
+        Player with7 = withQuest;
+        for (int i = 0; i < 7; i++) {
+            with7 = with7.addItem(ratTail());
+        }
+
+        QuestDeliveryService.DeliverResult result = service.deliver(with7);
+
+        assertTrue(result.success());
+        Player rewarded = result.player();
+        assertEquals(2, countRatTails(rewarded),
+            "Only 5 tails should be removed; 2 should remain");
+    }
+
+    @Test
+    void deliverMessagesContainGuildClerkAcknowledgement() {
+        Player withQuest = basePlayer.withActiveQuest(new ActiveQuest(COLLECTOR_ID, 0));
+        Player with5 = withQuest;
+        for (int i = 0; i < 5; i++) {
+            with5 = with5.addItem(ratTail());
+        }
+
+        QuestDeliveryService.DeliverResult result = service.deliver(with5);
+
+        assertTrue(result.success());
+        boolean hasClerkMsg = result.messages().stream()
+            .anyMatch(m -> m.contains("Guild Clerk"));
+        assertTrue(hasClerkMsg, "Expected Guild Clerk message in: " + result.messages());
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private static Item ratTail() {
+        return makeItem("rat-tail", "Rat Tail");
+    }
+
+    private static Item makeItem(String id, String name) {
+        return new Item(
+            ItemId.of(id),
+            name,
+            "A " + name + ".",
+            ItemAttributes.empty(),
+            List.of(),
+            List.of(),
+            null,
+            0,
+            0,
+            null
+        );
+    }
+
+    private static int countRatTails(Player player) {
+        int count = 0;
+        for (Item item : player.getInventory()) {
+            if ("rat-tail".equals(item.getId().getValue())) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    // ── stub repository ────────────────────────────────────────────────
+
+    static class StubQuestRepository implements QuestRepository {
+        private final List<QuestTemplate> templates;
+        StubQuestRepository(List<QuestTemplate> templates) { this.templates = templates; }
+        @Override public List<QuestTemplate> findAll() { return templates; }
+        @Override public Optional<QuestTemplate> findById(QuestId id) {
+            return templates.stream().filter(t -> t.id().equals(id)).findFirst();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new delivery quest type where players collect rat tail drops from rats (40% drop rate) and turn them in at the Guild Clerk for XP/gold rewards
- New `QuestDeliveryService` handles drop pickup progress messages and the QUEST DELIVER command flow
- Extended `QuestTemplate` and `QuestDto` with `dropItemId`/`requiredDropCount` fields; QUEST STATUS shows collected/required count for delivery quests

## Test plan

- [ ] Start a delivery quest and kill rats to collect rat tails; verify progress messages appear
- [ ] Attempt QUEST DELIVER outside the Guild Clerk room; verify rejection message
- [ ] Go to Guild Clerk room and run QUEST DELIVER with enough tails; verify XP/gold reward and quest completion
- [ ] Run QUEST STATUS mid-collection; verify it shows collected/required count
- [ ] Unit tests in `QuestDeliveryServiceTest` pass (`./gradlew test`)

Closes #147

Generated with [Claude Code](https://claude.com/claude-code)