### PR TITLE
feat(party): add PARTY system with XP sharing and prompt HP display

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -55,7 +55,7 @@
 - [x] Add SCORE command enhancements: show current level, XP to next level, and total kills
 - [x] Add TRAIN command and trainer NPC so players can spend practice points on skills
 - [x] Add multi-kill quest: deliver a fixed number of drops (e.g. rat tails) to an NPC for a reward
-- [ ] Add PARTY system: players can form a group to share XP and see party HP in prompt
+- [x] Add PARTY system: players can form a group to share XP and see party HP in prompt
 - [ ] Add mob respawn with wander: mobs randomly move between linked rooms on tick
 - [ ] Add LOCK and UNLOCK commands with key items for gated doors between zones
 - [ ] Add CAST command as an explicit spell-use alias alongside the existing ability system

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -25,6 +25,7 @@ import io.taanielo.jmud.core.player.LevelUpService;
 import io.taanielo.jmud.core.player.LevelUpService.LevelUpResult;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.party.PartyService;
 import io.taanielo.jmud.core.quest.QuestKillService;
 import io.taanielo.jmud.core.tick.Tickable;
 import io.taanielo.jmud.core.world.EquipmentSlot;
@@ -53,6 +54,8 @@ public class MobRegistry implements Tickable {
     private final LevelUpService levelUpService = new LevelUpService();
     /** Optional quest kill hook; may be null when quests are disabled. */
     private QuestKillService questKillService;
+    /** Optional party service for XP splitting; may be null when parties are disabled. */
+    private PartyService partyService;
 
     private final ConcurrentHashMap<UUID, MobInstance> instances = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Username, UUID> playerCombatTargets = new ConcurrentHashMap<>();
@@ -80,6 +83,15 @@ public class MobRegistry implements Tickable {
      */
     public void setQuestKillService(QuestKillService questKillService) {
         this.questKillService = questKillService;
+    }
+
+    /**
+     * Registers the party service used to split XP among party members on mob kills.
+     *
+     * @param partyService the party service; may be null to disable party XP splitting
+     */
+    public void setPartyService(PartyService partyService) {
+        this.partyService = partyService;
     }
 
     /**
@@ -176,8 +188,17 @@ public class MobRegistry implements Tickable {
             }
             mob.scheduleRespawn();
             endCombatForMob(mob);
+
+            // Determine XP share: split equally among party members in the same room.
+            List<Username> xpRecipients = partyService != null
+                ? partyService.getPartyMembersInRoom(
+                    attacker.getUsername(), roomId, roomService::findPlayerLocation)
+                : List.of(attacker.getUsername());
+            int xpPerMember = (int) Math.floor(
+                (double) mob.template().xpReward() / Math.max(1, xpRecipients.size()));
+
             Player reloaded = playerRepository.loadPlayer(attacker.getUsername()).orElse(attacker);
-            LevelUpResult levelUpResult = levelUpService.awardXp(reloaded, mob.template().xpReward());
+            LevelUpResult levelUpResult = levelUpService.awardXp(reloaded, xpPerMember);
             Player afterXp = levelUpResult.player();
             if (mob.template().goldDrop() != null) {
                 int gold = mob.template().goldDrop().roll();
@@ -200,10 +221,34 @@ public class MobRegistry implements Tickable {
             afterXp = afterXp.withTotalKills(afterXp.getTotalKills() + 1);
             playerRepository.savePlayer(afterXp);
             messages.add(GameMessage.toSource(
-                "You gain " + mob.template().xpReward() + " experience points."));
+                "You gain " + xpPerMember + " experience points."));
             if (levelUpResult.leveledUp()) {
                 messages.add(GameMessage.toSource(
                     "You have advanced to level " + afterXp.getLevel() + "!"));
+            }
+
+            // Award XP to other party members in the same room.
+            for (Username member : xpRecipients) {
+                if (member.equals(attacker.getUsername())) {
+                    continue;
+                }
+                Player memberPlayer = playerRepository.loadPlayer(member).orElse(null);
+                if (memberPlayer == null || memberPlayer.isDead()) {
+                    continue;
+                }
+                LevelUpResult memberLvl = levelUpService.awardXp(memberPlayer, xpPerMember);
+                Player memberAfterXp = memberLvl.player()
+                    .withTotalKills(memberLvl.player().getTotalKills() + 1);
+                playerRepository.savePlayer(memberAfterXp);
+                List<GameMessage> memberMsgs = new ArrayList<>();
+                memberMsgs.add(GameMessage.toSource(
+                    "Your party slay the " + mob.template().name()
+                        + "! You gain " + xpPerMember + " experience points."));
+                if (memberLvl.leveledUp()) {
+                    memberMsgs.add(GameMessage.toSource(
+                        "You have advanced to level " + memberAfterXp.getLevel() + "!"));
+                }
+                playerEventBus.publish(member, new GameActionResult(memberAfterXp, null, memberMsgs));
             }
         }
         return new GameActionResult(null, null, messages);
@@ -330,8 +375,18 @@ public class MobRegistry implements Tickable {
                 }
                 mob.scheduleRespawn();
                 endCombatForMob(mob);
+
+                // Determine XP share: split equally among party members in the same room.
+                RoomId killRoom = playerRoom;
+                List<Username> xpRecipients = partyService != null
+                    ? partyService.getPartyMembersInRoom(
+                        username, killRoom, roomService::findPlayerLocation)
+                    : List.of(username);
+                int xpPerMember = (int) Math.floor(
+                    (double) mob.template().xpReward() / Math.max(1, xpRecipients.size()));
+
                 Player reloaded = playerRepository.loadPlayer(username).orElse(player);
-                LevelUpResult levelUpResult = levelUpService.awardXp(reloaded, mob.template().xpReward());
+                LevelUpResult levelUpResult = levelUpService.awardXp(reloaded, xpPerMember);
                 Player afterXp = levelUpResult.player();
                 if (mob.template().goldDrop() != null) {
                     int gold = mob.template().goldDrop().roll();
@@ -354,10 +409,34 @@ public class MobRegistry implements Tickable {
                 afterXp = afterXp.withTotalKills(afterXp.getTotalKills() + 1);
                 playerRepository.savePlayer(afterXp);
                 messages.add(GameMessage.toSource(
-                    "You gain " + mob.template().xpReward() + " experience points."));
+                    "You gain " + xpPerMember + " experience points."));
                 if (levelUpResult.leveledUp()) {
                     messages.add(GameMessage.toSource(
                         "You have advanced to level " + afterXp.getLevel() + "!"));
+                }
+
+                // Award XP to other party members in the same room.
+                for (Username member : xpRecipients) {
+                    if (member.equals(username)) {
+                        continue;
+                    }
+                    Player memberPlayer = playerRepository.loadPlayer(member).orElse(null);
+                    if (memberPlayer == null || memberPlayer.isDead()) {
+                        continue;
+                    }
+                    LevelUpResult memberLvl = levelUpService.awardXp(memberPlayer, xpPerMember);
+                    Player memberAfterXp = memberLvl.player()
+                        .withTotalKills(memberLvl.player().getTotalKills() + 1);
+                    playerRepository.savePlayer(memberAfterXp);
+                    List<GameMessage> memberMsgs = new ArrayList<>();
+                    memberMsgs.add(GameMessage.toSource(
+                        "Your party slay the " + mob.template().name()
+                            + "! You gain " + xpPerMember + " experience points."));
+                    if (memberLvl.leveledUp()) {
+                        memberMsgs.add(GameMessage.toSource(
+                            "You have advanced to level " + memberAfterXp.getLevel() + "!"));
+                    }
+                    playerEventBus.publish(member, new GameActionResult(memberAfterXp, null, memberMsgs));
                 }
             }
             playerEventBus.publish(username, new GameActionResult(null, null, messages));

--- a/src/main/java/io/taanielo/jmud/core/party/Party.java
+++ b/src/main/java/io/taanielo/jmud/core/party/Party.java
@@ -1,0 +1,47 @@
+package io.taanielo.jmud.core.party;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.taanielo.jmud.core.authentication.Username;
+
+/**
+ * Represents an active player party as an immutable snapshot.
+ *
+ * <p>A party always has at least one member (the leader). When membership
+ * drops to one player the party is typically disbanded by {@link PartyService}.
+ */
+public record Party(Username leaderId, List<Username> memberIds) {
+
+    /**
+     * Constructs a party with the given leader and member list.
+     *
+     * @param leaderId  the username of the party leader
+     * @param memberIds all current member usernames (must include the leader)
+     */
+    public Party {
+        Objects.requireNonNull(leaderId, "leaderId is required");
+        Objects.requireNonNull(memberIds, "memberIds is required");
+        memberIds = List.copyOf(memberIds);
+    }
+
+    /**
+     * Returns {@code true} when the given username is the party leader.
+     *
+     * @param username the username to check
+     * @return whether the player is the leader
+     */
+    public boolean isLeader(Username username) {
+        return leaderId.equals(username);
+    }
+
+    /**
+     * Returns {@code true} when the given username is a member of the party.
+     *
+     * @param username the username to check
+     * @return whether the player is a member
+     */
+    public boolean contains(Username username) {
+        return memberIds.contains(username);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/party/PartyService.java
+++ b/src/main/java/io/taanielo/jmud/core/party/PartyService.java
@@ -1,0 +1,279 @@
+package io.taanielo.jmud.core.party;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * In-memory party management service.
+ *
+ * <p>Manages party formation, membership, invitations, and disbanding.
+ * All mutating operations are {@code synchronized} to guarantee consistent
+ * state across concurrent virtual-thread player sessions.
+ *
+ * <p>No persistence is used; parties vanish on server restart.
+ */
+public class PartyService {
+
+    /**
+     * Result of a party operation, carrying a success flag and a player-facing message.
+     */
+    public record PartyResult(boolean success, String message) {}
+
+    /** partyId → Party snapshot. */
+    private final Map<UUID, Party> parties = new ConcurrentHashMap<>();
+    /** member username → partyId. */
+    private final Map<Username, UUID> memberToParty = new ConcurrentHashMap<>();
+    /** invitee username → inviter username (pending invitations). */
+    private final Map<Username, Username> pendingInvites = new ConcurrentHashMap<>();
+
+    // ── Party lifecycle ───────────────────────────────────────────────
+
+    /**
+     * Creates a new party with {@code leader} as its sole member.
+     *
+     * @param leader the player forming the party
+     * @return result describing success or failure
+     */
+    public synchronized PartyResult form(Username leader) {
+        Objects.requireNonNull(leader, "leader is required");
+        if (memberToParty.containsKey(leader)) {
+            return new PartyResult(false, "You are already in a party. Use PARTY LEAVE first.");
+        }
+        UUID partyId = UUID.randomUUID();
+        Party party = new Party(leader, List.of(leader));
+        parties.put(partyId, party);
+        memberToParty.put(leader, partyId);
+        return new PartyResult(true, "You have formed a new party.");
+    }
+
+    /**
+     * Records a pending invitation from {@code inviter} to {@code invitee}.
+     *
+     * <p>The inviter must be the party leader. The invitee must be online and
+     * not already in a party.
+     *
+     * @param inviter        the player sending the invitation (must be party leader)
+     * @param invitee        the player to invite
+     * @param inviteeOnline  whether the invitee is currently connected
+     * @return result describing success or failure
+     */
+    public synchronized PartyResult invite(Username inviter, Username invitee, boolean inviteeOnline) {
+        Objects.requireNonNull(inviter, "inviter is required");
+        Objects.requireNonNull(invitee, "invitee is required");
+        if (invitee.equals(inviter)) {
+            return new PartyResult(false, "You cannot invite yourself.");
+        }
+        if (!inviteeOnline) {
+            return new PartyResult(false, invitee.getValue() + " is not online.");
+        }
+        UUID partyId = memberToParty.get(inviter);
+        if (partyId == null) {
+            return new PartyResult(false, "You are not in a party. Use PARTY FORM first.");
+        }
+        Party party = parties.get(partyId);
+        if (party == null || !party.isLeader(inviter)) {
+            return new PartyResult(false, "Only the party leader can invite players.");
+        }
+        if (memberToParty.containsKey(invitee)) {
+            return new PartyResult(false, invitee.getValue() + " is already in a party.");
+        }
+        pendingInvites.put(invitee, inviter);
+        return new PartyResult(true, "Party invitation sent to " + invitee.getValue() + ".");
+    }
+
+    /**
+     * Accepts the pending invitation for {@code invitee}, adding them to the party.
+     *
+     * @param invitee the player accepting an invitation
+     * @return result describing success or failure
+     */
+    public synchronized PartyResult accept(Username invitee) {
+        Objects.requireNonNull(invitee, "invitee is required");
+        Username inviter = pendingInvites.remove(invitee);
+        if (inviter == null) {
+            return new PartyResult(false, "You have no pending party invitation.");
+        }
+        if (memberToParty.containsKey(invitee)) {
+            return new PartyResult(false, "You are already in a party.");
+        }
+        UUID partyId = memberToParty.get(inviter);
+        if (partyId == null) {
+            return new PartyResult(false, "The party you were invited to no longer exists.");
+        }
+        Party old = parties.get(partyId);
+        if (old == null) {
+            return new PartyResult(false, "The party you were invited to no longer exists.");
+        }
+        List<Username> newMembers = new ArrayList<>(old.memberIds());
+        newMembers.add(invitee);
+        parties.put(partyId, new Party(old.leaderId(), newMembers));
+        memberToParty.put(invitee, partyId);
+        return new PartyResult(true, "You have joined " + inviter.getValue() + "'s party.");
+    }
+
+    /**
+     * Declines the pending invitation for {@code invitee}.
+     *
+     * @param invitee the player declining an invitation
+     * @return result describing success or failure
+     */
+    public synchronized PartyResult decline(Username invitee) {
+        Objects.requireNonNull(invitee, "invitee is required");
+        Username inviter = pendingInvites.remove(invitee);
+        if (inviter == null) {
+            return new PartyResult(false, "You have no pending party invitation.");
+        }
+        return new PartyResult(true, "You declined the party invitation from " + inviter.getValue() + ".");
+    }
+
+    /**
+     * Removes {@code member} from their current party.
+     *
+     * <p>If only one member remains after the leave, the party is automatically disbanded.
+     * If the leaving member was the leader, leadership is transferred to the next member.
+     *
+     * @param member the player leaving the party
+     * @return result describing success or failure
+     */
+    public synchronized PartyResult leave(Username member) {
+        Objects.requireNonNull(member, "member is required");
+        UUID partyId = memberToParty.remove(member);
+        if (partyId == null) {
+            return new PartyResult(false, "You are not in a party.");
+        }
+        Party old = parties.get(partyId);
+        if (old == null) {
+            return new PartyResult(true, "You have left the party.");
+        }
+        List<Username> remaining = old.memberIds().stream()
+            .filter(m -> !m.equals(member))
+            .toList();
+        if (remaining.size() <= 1) {
+            // Disband: remove party and remaining member mapping
+            parties.remove(partyId);
+            for (Username m : remaining) {
+                memberToParty.remove(m);
+            }
+            return new PartyResult(true, "You have left the party. The party has been disbanded.");
+        }
+        Username newLeader = old.isLeader(member) ? remaining.get(0) : old.leaderId();
+        parties.put(partyId, new Party(newLeader, remaining));
+        String suffix = old.isLeader(member)
+            ? " " + newLeader.getValue() + " is now the party leader."
+            : "";
+        return new PartyResult(true, "You have left the party." + suffix);
+    }
+
+    /**
+     * Disbands the party entirely. Only the party leader may invoke this.
+     *
+     * @param leader the player disbanding the party
+     * @return result describing success or failure
+     */
+    public synchronized PartyResult disband(Username leader) {
+        Objects.requireNonNull(leader, "leader is required");
+        UUID partyId = memberToParty.get(leader);
+        if (partyId == null) {
+            return new PartyResult(false, "You are not in a party.");
+        }
+        Party party = parties.get(partyId);
+        if (party == null || !party.isLeader(leader)) {
+            return new PartyResult(false, "Only the party leader can disband the party.");
+        }
+        parties.remove(partyId);
+        for (Username m : party.memberIds()) {
+            memberToParty.remove(m);
+        }
+        return new PartyResult(true, "Party disbanded.");
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────
+
+    /**
+     * Returns the party that {@code username} belongs to, if any.
+     *
+     * @param username the player to look up
+     * @return an {@code Optional} containing the party, or empty
+     */
+    public Optional<Party> findParty(Username username) {
+        Objects.requireNonNull(username, "username is required");
+        UUID partyId = memberToParty.get(username);
+        if (partyId == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(parties.get(partyId));
+    }
+
+    /**
+     * Returns the party members of {@code username}'s party who are currently
+     * in {@code roomId}. Includes the player themselves.
+     *
+     * <p>If the player is not in a party, the returned list contains only
+     * {@code username} (so callers can always iterate recipients).
+     *
+     * @param username   the reference player (killer/actor)
+     * @param roomId     the room to filter by
+     * @param locationFn function that resolves a username to their current room
+     * @return usernames of party members in the room
+     */
+    public List<Username> getPartyMembersInRoom(
+        Username username,
+        RoomId roomId,
+        Function<Username, Optional<RoomId>> locationFn
+    ) {
+        Objects.requireNonNull(username, "username is required");
+        Objects.requireNonNull(roomId, "roomId is required");
+        Objects.requireNonNull(locationFn, "locationFn is required");
+        Optional<Party> partyOpt = findParty(username);
+        if (partyOpt.isEmpty()) {
+            return List.of(username);
+        }
+        return partyOpt.get().memberIds().stream()
+            .filter(m -> locationFn.apply(m)
+                .map(r -> r.equals(roomId))
+                .orElse(false))
+            .toList();
+    }
+
+    /**
+     * Returns the usernames of all party members of {@code username} except
+     * {@code username} themselves. Useful for broadcasting party notifications.
+     *
+     * @param username the reference player
+     * @return other members in the same party, or an empty list
+     */
+    public List<Username> getOtherMembers(Username username) {
+        Objects.requireNonNull(username, "username is required");
+        UUID partyId = memberToParty.get(username);
+        if (partyId == null) {
+            return List.of();
+        }
+        Party party = parties.get(partyId);
+        if (party == null) {
+            return List.of();
+        }
+        return party.memberIds().stream()
+            .filter(m -> !m.equals(username))
+            .toList();
+    }
+
+    /**
+     * Returns the pending inviter for the given invitee, if an invitation exists.
+     *
+     * @param invitee the player who received an invite
+     * @return the inviter username, or empty
+     */
+    public Optional<Username> getPendingInviter(Username invitee) {
+        Objects.requireNonNull(invitee, "invitee is required");
+        return Optional.ofNullable(pendingInvites.get(invitee));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/prompt/PromptRenderer.java
+++ b/src/main/java/io/taanielo/jmud/core/prompt/PromptRenderer.java
@@ -3,9 +3,44 @@ package io.taanielo.jmud.core.prompt;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerVitals;
 
+/**
+ * Renders the player prompt string by substituting named tokens.
+ *
+ * <p>Supported tokens:
+ * <ul>
+ *   <li>{@code {hp}} / {@code {maxHp}} — current and maximum hit points</li>
+ *   <li>{@code {mana}} / {@code {maxMana}} — current and maximum mana</li>
+ *   <li>{@code {move}} / {@code {maxMove}} — current and maximum movement points</li>
+ *   <li>{@code {exp}} — accumulated experience points</li>
+ *   <li>{@code {partyHp}} — space-separated {@code Name:hp/maxHp} entries for party members
+ *       (empty string when not in a party)</li>
+ * </ul>
+ */
 public class PromptRenderer {
 
+    /**
+     * Renders the prompt format for the given player.
+     *
+     * <p>The {@code {partyHp}} token is replaced with an empty string.
+     *
+     * @param format the prompt format string
+     * @param player the current player
+     * @return the rendered prompt
+     */
     public String render(String format, Player player) {
+        return render(format, player, "");
+    }
+
+    /**
+     * Renders the prompt format for the given player, substituting the {@code {partyHp}} token
+     * with the provided pre-computed party HP string.
+     *
+     * @param format    the prompt format string
+     * @param player    the current player
+     * @param partyHp   pre-computed party HP string (empty string when not in a party)
+     * @return the rendered prompt
+     */
+    public String render(String format, Player player, String partyHp) {
         PlayerVitals vitals = player.getVitals();
         String rendered = format;
         rendered = rendered.replace("{hp}", String.valueOf(vitals.hp()));
@@ -15,6 +50,7 @@ public class PromptRenderer {
         rendered = rendered.replace("{move}", String.valueOf(vitals.move()));
         rendered = rendered.replace("{maxMove}", String.valueOf(vitals.maxMove()));
         rendered = rendered.replace("{exp}", String.valueOf(player.getExperience()));
+        rendered = rendered.replace("{partyHp}", partyHp != null ? partyHp : "");
         if (player.isResting()) {
             rendered = "[REST] " + rendered;
         }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
@@ -37,6 +37,7 @@ import io.taanielo.jmud.core.healing.HealingEngine;
 import io.taanielo.jmud.core.mob.MobRegistry;
 import io.taanielo.jmud.core.mob.MobRepositoryException;
 import io.taanielo.jmud.core.mob.repository.json.JsonMobTemplateRepository;
+import io.taanielo.jmud.core.party.PartyService;
 import io.taanielo.jmud.core.quest.QuestKillService;
 import io.taanielo.jmud.core.quest.QuestRepository;
 import io.taanielo.jmud.core.quest.QuestRepositoryException;
@@ -89,7 +90,8 @@ public record GameContext(
     MobRegistry mobRegistry,
     CharacterCreationService characterCreationService,
     ShopService shopService,
-    QuestRepository questRepository
+    QuestRepository questRepository,
+    PartyService partyService
 ) {
 
     /**
@@ -145,6 +147,11 @@ public record GameContext(
             mobRegistry.setQuestKillService(new QuestKillService(questRepository));
         }
 
+        PartyService partyService = new PartyService();
+        if (mobRegistry != null) {
+            mobRegistry.setPartyService(partyService);
+        }
+
         return new GameContext(
             userRegistry,
             authenticationPolicy,
@@ -170,7 +177,8 @@ public record GameContext(
             mobRegistry,
             characterCreationService,
             shopService,
-            questRepository
+            questRepository,
+            partyService
         );
     }
 

--- a/src/main/java/io/taanielo/jmud/core/server/socket/PartyCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/PartyCommand.java
@@ -1,0 +1,64 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the {@code PARTY} command, letting players form and manage groups.
+ *
+ * <p>Sub-commands:
+ * <ul>
+ *   <li>{@code PARTY}                — list current party members and their HP</li>
+ *   <li>{@code PARTY FORM}           — create a new party with the issuing player as leader</li>
+ *   <li>{@code PARTY INVITE <name>}  — send an invitation to another online player</li>
+ *   <li>{@code PARTY ACCEPT}         — accept a pending invitation</li>
+ *   <li>{@code PARTY DECLINE}        — decline a pending invitation</li>
+ *   <li>{@code PARTY LEAVE}          — leave the current party (disbands if last member)</li>
+ *   <li>{@code PARTY DISBAND}        — disband the party (leader only)</li>
+ * </ul>
+ */
+public class PartyCommand extends RegistrableCommand {
+
+    /**
+     * Creates a {@code PartyCommand} and registers it with the given registry.
+     *
+     * @param registry the registry this command is part of
+     */
+    public PartyCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "party";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Form and manage a player party for shared XP. Use PARTY FORM to begin.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: PARTY [sub-command] [args]\n"
+             + "  PARTY                  — show current party members and their HP\n"
+             + "  PARTY FORM             — create a new party (you become the leader)\n"
+             + "  PARTY INVITE <player>  — invite an online player to your party\n"
+             + "  PARTY ACCEPT           — accept a pending party invitation\n"
+             + "  PARTY DECLINE          — decline a pending party invitation\n"
+             + "  PARTY LEAVE            — leave your current party\n"
+             + "  PARTY DISBAND          — disband the party (leader only)\n"
+             + "\n"
+             + "XP earned from mob kills is split equally among party members in the same room.\n"
+             + "Add {partyHp} to your prompt format to display party member HP at a glance.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"PARTY".equals(parts[0])) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> context.executeParty(args)));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -56,6 +56,8 @@ import io.taanielo.jmud.core.server.Client;
 import io.taanielo.jmud.core.server.ClientPool;
 import io.taanielo.jmud.core.server.connection.ClientConnection;
 import io.taanielo.jmud.core.server.connection.TransportSecurity;
+import io.taanielo.jmud.core.party.Party;
+import io.taanielo.jmud.core.party.PartyService;
 import io.taanielo.jmud.core.quest.ActiveQuest;
 import io.taanielo.jmud.core.quest.QuestDeliveryService;
 import io.taanielo.jmud.core.quest.QuestKillService;
@@ -604,8 +606,63 @@ public class SocketClient implements Client {
         if (format == null || format.isBlank()) {
             format = PromptSettings.defaultFormat();
         }
-        String promptLine = promptRenderer.render(format, player);
+        String partyHp = format.contains("{partyHp}") ? buildPartyHpString(player) : "";
+        String promptLine = promptRenderer.render(format, player, partyHp);
         connection.write(promptLine + "> ");
+    }
+
+    /**
+     * Builds the {@code {partyHp}} token value for the given player.
+     *
+     * <p>Iterates the party members, looks up current HP from connected sessions
+     * (falling back to the repository), and returns a space-separated
+     * {@code Name:hp/maxHp} string. Returns an empty string when the player
+     * is not in a party.
+     *
+     * @param player the current player
+     * @return formatted party HP string, or {@code ""} when not in a party
+     */
+    private String buildPartyHpString(Player player) {
+        PartyService partyService = context.partyService();
+        if (partyService == null) {
+            return "";
+        }
+        return partyService.findParty(player.getUsername())
+            .map(party -> {
+                StringBuilder sb = new StringBuilder();
+                for (Username memberId : party.memberIds()) {
+                    if (memberId.equals(player.getUsername())) {
+                        continue;
+                    }
+                    if (sb.length() > 0) {
+                        sb.append(' ');
+                    }
+                    sb.append(memberId.getValue()).append(':').append(findMemberCurrentHp(memberId));
+                }
+                return sb.toString();
+            })
+            .orElse("");
+    }
+
+    /**
+     * Returns the current HP string for a party member by consulting connected sessions
+     * first, then falling back to the player repository.
+     *
+     * @param username the member to look up
+     * @return {@code "hp/maxHp"} string
+     */
+    private String findMemberCurrentHp(Username username) {
+        for (Client client : clientPool.clients()) {
+            if (client instanceof SocketClient sc && sc.isAuthenticatedUser(username)) {
+                Player p = sc.session.getPlayer();
+                if (p != null) {
+                    return p.getVitals().hp() + "/" + p.getVitals().maxHp();
+                }
+            }
+        }
+        return playerRepository.loadPlayer(username)
+            .map(p -> p.getVitals().hp() + "/" + p.getVitals().maxHp())
+            .orElse("?/?");
     }
 
     private void sendToUsername(Username username, String message) {
@@ -1523,6 +1580,121 @@ public class SocketClient implements Client {
                 case "" -> writeLineWithPrompt("Usage: TRAIN LIST  or  TRAIN <ability-id>");
                 default -> handleTrainAbility(player, sub + (subArgs.isBlank() ? "" : " " + subArgs));
             }
+        }
+
+        @Override
+        public void executeParty(String args) {
+            if (!session.isAuthenticated() || session.getPlayer() == null) {
+                writeLineWithPrompt("You must be logged in to use party commands.");
+                return;
+            }
+            PartyService partyService = context.partyService();
+            if (partyService == null) {
+                writeLineWithPrompt("The party system is not available.");
+                return;
+            }
+            Player player = session.getPlayer();
+            String[] parts = args == null ? new String[]{"", ""} : SocketCommandParsing.splitInput(args);
+            String sub = parts[0];
+            String subArgs = parts[1];
+
+            switch (sub) {
+                case "FORM" -> handlePartyForm(player, partyService);
+                case "INVITE" -> handlePartyInvite(player, partyService, subArgs);
+                case "ACCEPT" -> handlePartyAccept(player, partyService);
+                case "DECLINE" -> handlePartyDecline(player, partyService);
+                case "LEAVE" -> handlePartyLeave(player, partyService);
+                case "DISBAND" -> handlePartyDisband(player, partyService);
+                case "" -> handlePartyStatus(player, partyService);
+                default -> writeLineWithPrompt(
+                    "Usage: PARTY [FORM|INVITE <player>|ACCEPT|DECLINE|LEAVE|DISBAND]");
+            }
+        }
+
+        private void handlePartyForm(Player player, PartyService partyService) {
+            PartyService.PartyResult result = partyService.form(player.getUsername());
+            writeLineWithPrompt(result.message());
+        }
+
+        private void handlePartyInvite(Player player, PartyService partyService, String targetName) {
+            if (targetName == null || targetName.isBlank()) {
+                writeLineWithPrompt("Invite whom? Usage: PARTY INVITE <player>");
+                return;
+            }
+            Username invitee = Username.of(targetName.trim());
+            List<Username> online = onlinePlayerNames();
+            boolean inviteeOnline = online.contains(invitee);
+            PartyService.PartyResult result = partyService.invite(
+                player.getUsername(), invitee, inviteeOnline);
+            writeLineWithPrompt(result.message());
+            if (result.success()) {
+                // Notify the invitee
+                sendToUsername(invitee,
+                    player.getUsername().getValue()
+                        + " invites you to join their party. Type PARTY ACCEPT or PARTY DECLINE.");
+            }
+        }
+
+        private void handlePartyAccept(Player player, PartyService partyService) {
+            // Notify the inviter before accepting (so we can look up party members)
+            java.util.Optional<Username> inviterOpt = partyService.getPendingInviter(player.getUsername());
+            PartyService.PartyResult result = partyService.accept(player.getUsername());
+            writeLineWithPrompt(result.message());
+            if (result.success()) {
+                inviterOpt.ifPresent(inviter ->
+                    sendToUsername(inviter,
+                        player.getUsername().getValue() + " has joined the party."));
+            }
+        }
+
+        private void handlePartyDecline(Player player, PartyService partyService) {
+            java.util.Optional<Username> inviterOpt = partyService.getPendingInviter(player.getUsername());
+            PartyService.PartyResult result = partyService.decline(player.getUsername());
+            writeLineWithPrompt(result.message());
+            if (result.success()) {
+                inviterOpt.ifPresent(inviter ->
+                    sendToUsername(inviter,
+                        player.getUsername().getValue() + " declined the party invitation."));
+            }
+        }
+
+        private void handlePartyLeave(Player player, PartyService partyService) {
+            List<Username> others = partyService.getOtherMembers(player.getUsername());
+            PartyService.PartyResult result = partyService.leave(player.getUsername());
+            writeLineWithPrompt(result.message());
+            if (result.success()) {
+                for (Username other : others) {
+                    sendToUsername(other,
+                        player.getUsername().getValue() + " has left the party.");
+                }
+            }
+        }
+
+        private void handlePartyDisband(Player player, PartyService partyService) {
+            List<Username> others = partyService.getOtherMembers(player.getUsername());
+            PartyService.PartyResult result = partyService.disband(player.getUsername());
+            writeLineWithPrompt(result.message());
+            if (result.success()) {
+                for (Username other : others) {
+                    sendToUsername(other, "The party has been disbanded by the leader.");
+                }
+            }
+        }
+
+        private void handlePartyStatus(Player player, PartyService partyService) {
+            java.util.Optional<Party> partyOpt = partyService.findParty(player.getUsername());
+            if (partyOpt.isEmpty()) {
+                writeLineWithPrompt("You are not in a party. Use PARTY FORM to create one.");
+                return;
+            }
+            Party party = partyOpt.get();
+            connection.writeLine("Party members:");
+            for (Username memberId : party.memberIds()) {
+                String hp = findMemberCurrentHp(memberId);
+                String leaderTag = party.isLeader(memberId) ? " (leader)" : "";
+                connection.writeLine("  " + memberId.getValue() + leaderTag + "  HP: " + hp);
+            }
+            sendPrompt();
         }
 
         private void handleTrainList(Player player) {

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -269,4 +269,17 @@ public interface SocketCommandContext extends Client {
      */
     default void executeTrain(String args) {}
 
+    /**
+     * Executes a PARTY sub-command (FORM, INVITE, ACCEPT, DECLINE, LEAVE, DISBAND, or empty).
+     *
+     * <p>Manages in-memory party groups that share XP on mob kills and display
+     * member HP in the prompt via the {@code {partyHp}} token.
+     *
+     * <p>The default implementation is a no-op so that existing test stubs
+     * do not need to be updated.
+     *
+     * @param args the sub-command and optional arguments (e.g. {@code "INVITE Alice"})
+     */
+    default void executeParty(String args) {}
+
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -46,6 +46,7 @@ public class SocketCommandRegistry {
         new SellCommand(registry);
         new QuestCommand(registry);
         new TrainCommand(registry);
+        new PartyCommand(registry);
         new QuitCommand(registry);
         new HelpCommand(registry);
         return registry;

--- a/src/test/java/io/taanielo/jmud/core/party/PartyServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/party/PartyServiceTest.java
@@ -1,0 +1,329 @@
+package io.taanielo.jmud.core.party;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.party.PartyService.PartyResult;
+import io.taanielo.jmud.core.world.RoomId;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PartyServiceTest {
+
+    private PartyService partyService;
+
+    private static final Username ALICE = Username.of("Alice");
+    private static final Username BOB   = Username.of("Bob");
+    private static final Username CAROL = Username.of("Carol");
+    private static final RoomId   ROOM1 = RoomId.of("room-1");
+    private static final RoomId   ROOM2 = RoomId.of("room-2");
+
+    @BeforeEach
+    void setUp() {
+        partyService = new PartyService();
+    }
+
+    // ── FORM ──────────────────────────────────────────────────────────
+
+    @Test
+    void form_createsPartyWithLeader() {
+        PartyResult result = partyService.form(ALICE);
+
+        assertTrue(result.success());
+        Optional<Party> party = partyService.findParty(ALICE);
+        assertTrue(party.isPresent());
+        assertEquals(ALICE, party.get().leaderId());
+        assertEquals(List.of(ALICE), party.get().memberIds());
+    }
+
+    @Test
+    void form_failsWhenAlreadyInParty() {
+        partyService.form(ALICE);
+
+        PartyResult result = partyService.form(ALICE);
+
+        assertFalse(result.success());
+        assertTrue(result.message().contains("already in a party"));
+    }
+
+    // ── INVITE / ACCEPT ───────────────────────────────────────────────
+
+    @Test
+    void inviteAndAccept_addsInviteeToParty() {
+        partyService.form(ALICE);
+
+        PartyResult inviteResult = partyService.invite(ALICE, BOB, true);
+        assertTrue(inviteResult.success());
+
+        PartyResult acceptResult = partyService.accept(BOB);
+        assertTrue(acceptResult.success());
+
+        Optional<Party> party = partyService.findParty(BOB);
+        assertTrue(party.isPresent());
+        assertEquals(List.of(ALICE, BOB), party.get().memberIds());
+        assertEquals(ALICE, party.get().leaderId());
+    }
+
+    @Test
+    void invite_failsWhenInviteeIsOffline() {
+        partyService.form(ALICE);
+
+        PartyResult result = partyService.invite(ALICE, BOB, false);
+
+        assertFalse(result.success());
+        assertTrue(result.message().contains("not online"));
+    }
+
+    @Test
+    void invite_failsWhenInviterIsNotLeader() {
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+        partyService.accept(BOB);
+
+        // BOB is a member but not the leader
+        PartyResult result = partyService.invite(BOB, CAROL, true);
+
+        assertFalse(result.success());
+        assertTrue(result.message().contains("leader"));
+    }
+
+    @Test
+    void invite_failsWhenInviterHasNoParty() {
+        PartyResult result = partyService.invite(ALICE, BOB, true);
+
+        assertFalse(result.success());
+        assertTrue(result.message().contains("not in a party"));
+    }
+
+    @Test
+    void accept_failsWhenNoPendingInvite() {
+        PartyResult result = partyService.accept(BOB);
+
+        assertFalse(result.success());
+        assertTrue(result.message().contains("no pending"));
+    }
+
+    // ── DECLINE ───────────────────────────────────────────────────────
+
+    @Test
+    void decline_removesPendingInvite() {
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+
+        PartyResult result = partyService.decline(BOB);
+
+        assertTrue(result.success());
+        assertFalse(partyService.findParty(BOB).isPresent());
+        assertFalse(partyService.getPendingInviter(BOB).isPresent());
+    }
+
+    @Test
+    void decline_failsWhenNoPendingInvite() {
+        PartyResult result = partyService.decline(BOB);
+
+        assertFalse(result.success());
+    }
+
+    // ── LEAVE ─────────────────────────────────────────────────────────
+
+    @Test
+    void leave_removesPlayerFromParty() {
+        // With 3 members: BOB leaving leaves ALICE + CAROL, so party survives.
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+        partyService.accept(BOB);
+        partyService.invite(ALICE, CAROL, true);
+        partyService.accept(CAROL);
+
+        PartyResult result = partyService.leave(BOB);
+
+        assertTrue(result.success());
+        assertFalse(partyService.findParty(BOB).isPresent());
+        Optional<Party> aliceParty = partyService.findParty(ALICE);
+        assertTrue(aliceParty.isPresent());
+        assertTrue(aliceParty.get().memberIds().contains(ALICE));
+        assertTrue(aliceParty.get().memberIds().contains(CAROL));
+        assertFalse(aliceParty.get().memberIds().contains(BOB));
+    }
+
+    @Test
+    void leave_disbandWhenOnlyOneRemainingAfterLeave() {
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+        partyService.accept(BOB);
+
+        // Alice leaves; only Bob remains → disband
+        PartyResult result = partyService.leave(ALICE);
+
+        assertTrue(result.success());
+        assertTrue(result.message().contains("disbanded"));
+        assertFalse(partyService.findParty(ALICE).isPresent());
+        assertFalse(partyService.findParty(BOB).isPresent());
+    }
+
+    @Test
+    void leave_leadershipTransferredWhenLeaderLeaves() {
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+        partyService.accept(BOB);
+        partyService.invite(ALICE, CAROL, true);
+        partyService.accept(CAROL);
+
+        // Alice (leader) leaves; Bob should become leader
+        partyService.leave(ALICE);
+
+        Optional<Party> party = partyService.findParty(BOB);
+        assertTrue(party.isPresent());
+        assertEquals(BOB, party.get().leaderId());
+        assertTrue(party.get().memberIds().contains(BOB));
+        assertTrue(party.get().memberIds().contains(CAROL));
+        assertFalse(party.get().memberIds().contains(ALICE));
+    }
+
+    @Test
+    void leave_failsWhenNotInParty() {
+        PartyResult result = partyService.leave(ALICE);
+
+        assertFalse(result.success());
+        assertTrue(result.message().contains("not in a party"));
+    }
+
+    // ── DISBAND ───────────────────────────────────────────────────────
+
+    @Test
+    void disband_removesAllMembersAndDestroyParty() {
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+        partyService.accept(BOB);
+
+        PartyResult result = partyService.disband(ALICE);
+
+        assertTrue(result.success());
+        assertFalse(partyService.findParty(ALICE).isPresent());
+        assertFalse(partyService.findParty(BOB).isPresent());
+    }
+
+    @Test
+    void disband_failsWhenCallerIsNotLeader() {
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+        partyService.accept(BOB);
+
+        PartyResult result = partyService.disband(BOB);
+
+        assertFalse(result.success());
+        assertTrue(result.message().contains("leader"));
+    }
+
+    @Test
+    void disband_failsWhenNotInParty() {
+        PartyResult result = partyService.disband(ALICE);
+
+        assertFalse(result.success());
+    }
+
+    // ── XP SPLIT (getPartyMembersInRoom) ──────────────────────────────
+
+    @Test
+    void getPartyMembersInRoom_soloPlayer_returnsSelf() {
+        List<Username> recipients = partyService.getPartyMembersInRoom(
+            ALICE, ROOM1, u -> Optional.of(ROOM1));
+
+        assertEquals(List.of(ALICE), recipients);
+    }
+
+    @Test
+    void getPartyMembersInRoom_allMembersInRoom_returnsAll() {
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+        partyService.accept(BOB);
+        partyService.invite(ALICE, CAROL, true);
+        partyService.accept(CAROL);
+
+        List<Username> recipients = partyService.getPartyMembersInRoom(
+            ALICE, ROOM1, u -> Optional.of(ROOM1));
+
+        assertEquals(3, recipients.size());
+        assertTrue(recipients.contains(ALICE));
+        assertTrue(recipients.contains(BOB));
+        assertTrue(recipients.contains(CAROL));
+    }
+
+    @Test
+    void getPartyMembersInRoom_onlyMembersInSameRoom() {
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+        partyService.accept(BOB);
+        partyService.invite(ALICE, CAROL, true);
+        partyService.accept(CAROL);
+
+        // CAROL is in a different room
+        List<Username> recipients = partyService.getPartyMembersInRoom(
+            ALICE, ROOM1, u -> u.equals(CAROL) ? Optional.of(ROOM2) : Optional.of(ROOM1));
+
+        assertEquals(2, recipients.size());
+        assertTrue(recipients.contains(ALICE));
+        assertTrue(recipients.contains(BOB));
+        assertFalse(recipients.contains(CAROL));
+    }
+
+    @Test
+    void xpSplit_twoMembersInRoom_halvesXp() {
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+        partyService.accept(BOB);
+
+        List<Username> recipients = partyService.getPartyMembersInRoom(
+            ALICE, ROOM1, u -> Optional.of(ROOM1));
+
+        int mobXp = 100;
+        int xpPerMember = (int) Math.floor((double) mobXp / Math.max(1, recipients.size()));
+
+        assertEquals(2, recipients.size());
+        assertEquals(50, xpPerMember);
+    }
+
+    @Test
+    void xpSplit_threeMembersInRoom_dividesXp() {
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+        partyService.accept(BOB);
+        partyService.invite(ALICE, CAROL, true);
+        partyService.accept(CAROL);
+
+        List<Username> recipients = partyService.getPartyMembersInRoom(
+            ALICE, ROOM1, u -> Optional.of(ROOM1));
+
+        int mobXp = 100;
+        int xpPerMember = (int) Math.floor((double) mobXp / Math.max(1, recipients.size()));
+
+        assertEquals(3, recipients.size());
+        assertEquals(33, xpPerMember); // floor(100/3)
+    }
+
+    // ── getOtherMembers ───────────────────────────────────────────────
+
+    @Test
+    void getOtherMembers_returnsAllExceptSelf() {
+        partyService.form(ALICE);
+        partyService.invite(ALICE, BOB, true);
+        partyService.accept(BOB);
+
+        List<Username> others = partyService.getOtherMembers(ALICE);
+
+        assertEquals(List.of(BOB), others);
+    }
+
+    @Test
+    void getOtherMembers_noParty_returnsEmpty() {
+        List<Username> others = partyService.getOtherMembers(ALICE);
+
+        assertTrue(others.isEmpty());
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/prompt/PromptRendererTest.java
+++ b/src/test/java/io/taanielo/jmud/core/prompt/PromptRendererTest.java
@@ -1,0 +1,63 @@
+package io.taanielo.jmud.core.prompt;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PromptRendererTest {
+
+    private final PromptRenderer renderer = new PromptRenderer();
+
+    private Player testPlayer() {
+        User user = new User(Username.of("Alice"), Password.of("secret"));
+        return Player.of(user, "{hp}/{maxHp} HP");
+    }
+
+    @Test
+    void render_substitutesHpTokens() {
+        Player player = testPlayer();
+        String result = renderer.render("{hp}/{maxHp}", player);
+
+        String expected = player.getVitals().hp() + "/" + player.getVitals().maxHp();
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void render_partyHpToken_emptyWhenNoPartyHpProvided() {
+        Player player = testPlayer();
+        String result = renderer.render("{partyHp}", player);
+
+        assertEquals("", result);
+    }
+
+    @Test
+    void render_partyHpToken_substitutesProvidedValue() {
+        Player player = testPlayer();
+        String result = renderer.render("{hp} [{partyHp}]", player, "Bob:80/100 Carol:50/100");
+
+        assertTrue(result.contains("Bob:80/100 Carol:50/100"));
+        assertTrue(result.contains(String.valueOf(player.getVitals().hp())));
+    }
+
+    @Test
+    void render_partyHpToken_nullTreatedAsEmpty() {
+        Player player = testPlayer();
+        String result = renderer.render("[{partyHp}]", player, null);
+
+        assertEquals("[]", result);
+    }
+
+    @Test
+    void render_withoutPartyHp_backwardsCompatible() {
+        Player player = testPlayer();
+        String result = renderer.render("{hp}/{maxHp}", player);
+
+        assertEquals(player.getVitals().hp() + "/" + player.getVitals().maxHp(), result);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Party` model and `PartyService` with FORM/INVITE/ACCEPT/DECLINE/LEAVE/DISBAND operations (in-memory)
- Adds `PartyCommand` socket handler routing all `PARTY <sub-command>` variants
- XP splitting on mob kill among party members present in the same room
- `{partyHp}` prompt token showing each party member's current/max HP
- 27 unit tests across `PartyServiceTest` and `PromptRendererTest`

## Test plan

- [ ] Run `./gradlew test` — all 27 new tests pass alongside existing suite
- [ ] Connect two clients, `PARTY FORM`, invite second player with `PARTY INVITE <name>`, second player `PARTY ACCEPT`
- [ ] Kill a mob with both players in the room — verify XP is split evenly
- [ ] Set prompt to include `{partyHp}` — verify party member HP is shown after each action
- [ ] `PARTY LEAVE` / `PARTY DISBAND` — verify party is cleaned up and players receive confirmation messages

Closes #149

Generated with [Claude Code](https://claude.com/claude-code)