### PR TITLE
feat(mob): add mob respawn with wander behavior

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,7 @@
 - [x] Add TRAIN command and trainer NPC so players can spend practice points on skills
 - [x] Add multi-kill quest: deliver a fixed number of drops (e.g. rat tails) to an NPC for a reward
 - [x] Add PARTY system: players can form a group to share XP and see party HP in prompt
-- [ ] Add mob respawn with wander: mobs randomly move between linked rooms on tick
+- [x] Add mob respawn with wander: mobs randomly move between linked rooms on tick
 - [ ] Add LOCK and UNLOCK commands with key items for gated doors between zones
 - [ ] Add CAST command as an explicit spell-use alias alongside the existing ability system
 - [ ] Add mana potions with QUAFF restoring mana and add them to shops and mob loot tables

--- a/data/mobs/rat.json
+++ b/data/mobs/rat.json
@@ -5,6 +5,7 @@
   "max_hp": 8,
   "attack_id": "attack.rat",
   "aggressive": false,
+  "wanders": true,
   "spawn_room_id": "muddy-hollow",
   "max_count": 3,
   "respawn_ticks": 15,

--- a/src/main/java/io/taanielo/jmud/core/mob/MobInstance.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobInstance.java
@@ -1,6 +1,7 @@
 package io.taanielo.jmud.core.mob;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -15,6 +16,10 @@ import io.taanielo.jmud.core.world.RoomId;
  * <p>HP is tracked via {@link AtomicInteger} so that player-thread attacks
  * (command queue) and tick-thread AI reads are both safe. All other state
  * mutations are confined to the tick thread.
+ *
+ * <p>{@code currentRoomId} tracks the mob's live position (it starts at
+ * {@code template.spawnRoomId()} and is updated when the mob wanders or
+ * reset to the spawn room on respawn).
  */
 public class MobInstance {
 
@@ -23,10 +28,13 @@ public class MobInstance {
     private final AtomicInteger hp;
     private final AtomicInteger respawnTicksRemaining = new AtomicInteger(0);
     private final Set<Username> engagedPlayers = ConcurrentHashMap.newKeySet();
+    /** Mutable live location; confined to tick thread for writes, safe to read from any thread. */
+    private volatile RoomId currentRoomId;
 
     public MobInstance(MobTemplate template) {
         this.template = template;
         this.hp = new AtomicInteger(template.maxHp());
+        this.currentRoomId = template.spawnRoomId();
     }
 
     public UUID instanceId() {
@@ -37,8 +45,19 @@ public class MobInstance {
         return template;
     }
 
+    /** Returns the mob's current live room (may differ from the template spawn room after wandering). */
     public RoomId roomId() {
-        return template.spawnRoomId();
+        return currentRoomId;
+    }
+
+    /**
+     * Moves the mob to the given room.
+     * Must only be called from the tick thread.
+     *
+     * @param roomId the destination room
+     */
+    public void moveTo(RoomId roomId) {
+        this.currentRoomId = Objects.requireNonNull(roomId, "Room id is required");
     }
 
     public boolean isAlive() {
@@ -80,10 +99,11 @@ public class MobInstance {
         return Collections.unmodifiableSet(engagedPlayers);
     }
 
-    /** Resets the mob to full HP, ready to act again. */
+    /** Resets the mob to full HP and returns it to its spawn room, ready to act again. */
     public void respawn() {
         hp.set(template.maxHp());
         respawnTicksRemaining.set(0);
         engagedPlayers.clear();
+        currentRoomId = template.spawnRoomId();
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -28,6 +29,7 @@ import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.party.PartyService;
 import io.taanielo.jmud.core.quest.QuestKillService;
 import io.taanielo.jmud.core.tick.Tickable;
+import io.taanielo.jmud.core.world.Direction;
 import io.taanielo.jmud.core.world.EquipmentSlot;
 import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.ItemId;
@@ -117,6 +119,7 @@ public class MobRegistry implements Tickable {
     @Override
     public void tick() {
         runPlayerCombat();
+        runWanderPhase();
         for (MobInstance mob : instances.values()) {
             if (!mob.isAlive()) {
                 if (mob.tickRespawn()) {
@@ -132,6 +135,61 @@ public class MobRegistry implements Tickable {
                 continue;
             }
             runMobAi(mob);
+        }
+    }
+
+    /**
+     * Wander phase: for each alive, non-NPC, non-combat, wandering mob, with 30% probability
+     * move it through a randomly chosen exit and notify nearby players.
+     */
+    private void runWanderPhase() {
+        for (MobInstance mob : instances.values()) {
+            if (!mob.isAlive()) {
+                continue;
+            }
+            if (!mob.template().wanders()) {
+                continue;
+            }
+            if (mob.template().hasTag("npc")) {
+                continue;
+            }
+            if (!mob.engagedPlayers().isEmpty()) {
+                continue;
+            }
+            // ~30 % chance to wander this tick
+            if (ThreadLocalRandom.current().nextDouble() >= 0.30) {
+                continue;
+            }
+            RoomId fromRoomId = mob.roomId();
+            Map<Direction, RoomId> exits = roomService.getExits(fromRoomId);
+            if (exits.isEmpty()) {
+                continue;
+            }
+            List<Map.Entry<Direction, RoomId>> exitList = List.copyOf(exits.entrySet());
+            Map.Entry<Direction, RoomId> chosen =
+                exitList.get(ThreadLocalRandom.current().nextInt(exitList.size()));
+            Direction dir = chosen.getKey();
+            RoomId toRoomId = chosen.getValue();
+
+            // Notify players in departure room
+            String departMsg = "A " + mob.template().name() + " wanders off to the " + dir.label() + ".";
+            for (Username occupant : roomService.getPlayersInRoom(fromRoomId)) {
+                playerEventBus.publish(occupant,
+                    new GameActionResult(null, null, List.of(GameMessage.toSource(departMsg))));
+            }
+
+            mob.moveTo(toRoomId);
+
+            // Notify players in arrival room
+            String arriveMsg = "A " + mob.template().name()
+                + " wanders in from the " + dir.opposite().label() + ".";
+            for (Username occupant : roomService.getPlayersInRoom(toRoomId)) {
+                playerEventBus.publish(occupant,
+                    new GameActionResult(null, null, List.of(GameMessage.toSource(arriveMsg))));
+            }
+
+            log.debug("Mob {} wandered from {} to {} ({})",
+                mob.template().name(), fromRoomId, toRoomId, dir.label());
         }
     }
 

--- a/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
@@ -26,7 +26,13 @@ public record MobTemplate(
      * Optional classification tags (e.g. {@code "undead"}).
      * Always non-null; defaults to an empty list when not specified in data.
      */
-    List<String> tags
+    List<String> tags,
+    /**
+     * When {@code true} the mob may randomly wander between linked rooms on each tick.
+     * NPCs (tag {@code "npc"}) never wander regardless of this flag.
+     * Defaults to {@code false}.
+     */
+    boolean wanders
 ) {
     public MobTemplate {
         if (maxHp <= 0) {

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
@@ -15,6 +15,7 @@ public record MobTemplateDto(
     int maxCount,
     int respawnTicks,
     Integer xpReward,
-    GoldDropDto goldDrop
+    GoldDropDto goldDrop,
+    Boolean wanders
 ) {
 }

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
@@ -25,6 +25,7 @@ public class MobTemplateDtoMapper {
             ? new GoldDrop(dto.goldDrop().min(), dto.goldDrop().max())
             : null;
         List<String> tags = dto.tags() == null ? List.of() : List.copyOf(dto.tags());
+        boolean wanders = dto.wanders() != null && dto.wanders();
         return new MobTemplate(
             MobId.of(dto.id()),
             dto.name(),
@@ -37,7 +38,8 @@ public class MobTemplateDtoMapper {
             dto.respawnTicks(),
             xpReward,
             goldDrop,
-            tags
+            tags,
+            wanders
         );
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/Direction.java
+++ b/src/main/java/io/taanielo/jmud/core/world/Direction.java
@@ -43,6 +43,21 @@ public enum Direction {
         return shortLabel;
     }
 
+    /**
+     * Returns the cardinal opposite of this direction
+     * (e.g. {@code NORTH.opposite()} returns {@code SOUTH}).
+     */
+    public Direction opposite() {
+        return switch (this) {
+            case NORTH -> SOUTH;
+            case SOUTH -> NORTH;
+            case EAST  -> WEST;
+            case WEST  -> EAST;
+            case UP    -> DOWN;
+            case DOWN  -> UP;
+        };
+    }
+
     public static Optional<Direction> fromInput(String input) {
         if (input == null) {
             return Optional.empty();

--- a/src/main/java/io/taanielo/jmud/core/world/RoomService.java
+++ b/src/main/java/io/taanielo/jmud/core/world/RoomService.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
@@ -91,6 +92,19 @@ public class RoomService {
         Objects.requireNonNull(username, "Username is required");
         playerLocations.put(username, startingRoomId);
         return startingRoomId;
+    }
+
+    /**
+     * Returns the exit map for the given room, or an empty map if the room cannot be found.
+     *
+     * <p>Used by mob AI to enumerate candidate wander destinations.
+     *
+     * @param roomId the room to query
+     * @return an unmodifiable map of direction to neighbouring room id (never null)
+     */
+    public Map<Direction, RoomId> getExits(RoomId roomId) {
+        Objects.requireNonNull(roomId, "Room id is required");
+        return findRoom(roomId).map(Room::getExits).orElse(Map.of());
     }
 
     /**

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryAggressiveMobTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryAggressiveMobTest.java
@@ -66,7 +66,8 @@ class MobRegistryAggressiveMobTest {
             10,
             5,
             null,
-            null
+            null,
+            false
         );
         MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
         AttackRepository attackRepo = new StubAttackRepository(Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryFleeCombatTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryFleeCombatTest.java
@@ -62,7 +62,8 @@ class MobRegistryFleeCombatTest {
             10,
             5,
             null,
-            null
+            null,
+            false
         );
         MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
         AttackRepository attackRepo = new StubAttackRepository(Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryGoldDropTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryGoldDropTest.java
@@ -69,7 +69,8 @@ class MobRegistryGoldDropTest {
             10,
             5,
             drop,
-            null
+            null,
+            false
         );
     }
 
@@ -87,7 +88,8 @@ class MobRegistryGoldDropTest {
             10,
             5,
             null,
-            null
+            null,
+            false
         );
     }
 

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryKillTrackingTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryKillTrackingTest.java
@@ -64,7 +64,8 @@ class MobRegistryKillTrackingTest {
             10,
             5,
             null,
-            null
+            null,
+            false
         );
     }
 

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryLootAnnouncementTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryLootAnnouncementTest.java
@@ -84,7 +84,8 @@ class MobRegistryLootAnnouncementTest {
             10,
             5,
             null,
-            null
+            null,
+            false
         );
     }
 
@@ -198,7 +199,8 @@ class MobRegistryLootAnnouncementTest {
             10,
             5,
             null,
-            null
+            null,
+            false
         );
         AttackRepository attackRepo = new StubAttackRepository(
             Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryWanderTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryWanderTest.java
@@ -1,0 +1,270 @@
+package io.taanielo.jmud.core.mob;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.action.PlayerEventBus;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.combat.AttackId;
+import io.taanielo.jmud.core.combat.CombatSettings;
+import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.combat.repository.AttackRepositoryException;
+import io.taanielo.jmud.core.combat.AttackDefinition;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.world.Direction;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.ItemRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Unit tests covering the mob wander phase in {@link MobRegistry}.
+ *
+ * <p>Tests verify that wandering mobs move between rooms, that engaged mobs
+ * and NPCs do not wander, and that respawning resets a mob to its spawn room.
+ */
+class MobRegistryWanderTest {
+
+    private static final RoomId SPAWN_ROOM = RoomId.of("room.spawn");
+    private static final RoomId NORTH_ROOM = RoomId.of("room.north");
+    private static final AttackId DEFAULT_ATTACK =
+        AttackId.of(CombatSettings.DEFAULT_ATTACK_ID);
+
+    // ── helpers ───────────────────────────────────────────────────────
+
+    private Player player(String name) {
+        User user = User.of(Username.of(name), Password.hash("pw", 1));
+        return Player.of(user, "%hp> ");
+    }
+
+    private MobTemplate wanderingTemplate(boolean wanders, List<String> tags) {
+        return new MobTemplate(
+            MobId.of("mob.rat"),
+            "Giant Rat",
+            20,
+            null,
+            false,
+            List.of(),
+            SPAWN_ROOM,
+            1,
+            10,
+            5,
+            null,
+            tags,
+            wanders
+        );
+    }
+
+    /**
+     * Builds a room repository with two rooms: SPAWN_ROOM with a north exit to
+     * NORTH_ROOM, and NORTH_ROOM with no exits.
+     */
+    private StubRoomRepository twoRoomRepository() {
+        Room spawnRoom = new Room(
+            SPAWN_ROOM, "Spawn Room", "A test room.",
+            Map.of(Direction.NORTH, NORTH_ROOM),
+            List.of(), List.of());
+        Room northRoom = new Room(
+            NORTH_ROOM, "North Room", "Another test room.",
+            Map.of(Direction.SOUTH, SPAWN_ROOM),
+            List.of(), List.of());
+        return new StubRoomRepository(Map.of(
+            SPAWN_ROOM, spawnRoom,
+            NORTH_ROOM, northRoom
+        ));
+    }
+
+    private MobRegistry buildRegistry(MobTemplate template, RoomRepository roomRepo) {
+        MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
+        AttackRepository attackRepo = new StubAttackRepository(Map.of());
+        ItemRepository itemRepo = new StubItemRepository(Map.of());
+        RoomService roomService = new RoomService(roomRepo, SPAWN_ROOM);
+        PlayerRepository playerRepo = new StubPlayerRepository();
+        PlayerEventBus bus = new PlayerEventBus();
+        MobRegistry registry = new MobRegistry(
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo, bus);
+        registry.init();
+        return registry;
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────
+
+    /**
+     * A wandering mob should eventually move to an adjacent room after enough ticks.
+     * We run 50 ticks — with 30% probability per tick this should succeed with
+     * overwhelming likelihood (P(never moves) = 0.7^50 ≈ 1e-8).
+     */
+    @Test
+    void wanderingMob_movesToAdjacentRoom_afterTicks() {
+        MobTemplate template = wanderingTemplate(true, List.of());
+        MobRegistry registry = buildRegistry(template, twoRoomRepository());
+
+        MobInstance mob = registry.allInstances().iterator().next();
+        assertEquals(SPAWN_ROOM, mob.roomId(),
+            "Mob should start in spawn room");
+
+        // Run ticks until the mob moves or we exhaust attempts
+        boolean moved = false;
+        for (int i = 0; i < 50; i++) {
+            registry.tick();
+            if (!mob.roomId().equals(SPAWN_ROOM)) {
+                moved = true;
+                break;
+            }
+        }
+        assert moved : "Wandering mob should have moved within 50 ticks";
+        assertEquals(NORTH_ROOM, mob.roomId(),
+            "Mob should have moved to the north room");
+    }
+
+    /**
+     * A mob flagged with wanders=false should never move regardless of ticks.
+     */
+    @Test
+    void nonWanderingMob_staysInSpawnRoom() {
+        MobTemplate template = wanderingTemplate(false, List.of());
+        MobRegistry registry = buildRegistry(template, twoRoomRepository());
+
+        MobInstance mob = registry.allInstances().iterator().next();
+        for (int i = 0; i < 20; i++) {
+            registry.tick();
+        }
+        assertEquals(SPAWN_ROOM, mob.roomId(),
+            "Non-wandering mob should remain in spawn room");
+    }
+
+    /**
+     * A mob that is engaged in combat must not wander.
+     */
+    @Test
+    void engagedMob_doesNotWander() {
+        MobTemplate template = wanderingTemplate(true, List.of());
+        MobRegistry registry = buildRegistry(template, twoRoomRepository());
+
+        MobInstance mob = registry.allInstances().iterator().next();
+        // Engage the mob manually
+        mob.engage(Username.of("fighter"));
+
+        for (int i = 0; i < 50; i++) {
+            registry.tick();
+        }
+        assertEquals(SPAWN_ROOM, mob.roomId(),
+            "Engaged mob should not wander");
+    }
+
+    /**
+     * An NPC (tag "npc") with wanders=true must still not wander.
+     */
+    @Test
+    void npcMob_doesNotWander() {
+        MobTemplate template = wanderingTemplate(true, List.of("npc"));
+        MobRegistry registry = buildRegistry(template, twoRoomRepository());
+
+        MobInstance mob = registry.allInstances().iterator().next();
+        for (int i = 0; i < 50; i++) {
+            registry.tick();
+        }
+        assertEquals(SPAWN_ROOM, mob.roomId(),
+            "NPC mob should not wander even if wanders=true");
+    }
+
+    /**
+     * When a wandering mob dies and respawns, its room should be reset to the spawn room.
+     */
+    @Test
+    void respawn_resetsMobToSpawnRoom() {
+        MobTemplate template = wanderingTemplate(true, List.of());
+        MobRegistry registry = buildRegistry(template, twoRoomRepository());
+
+        MobInstance mob = registry.allInstances().iterator().next();
+
+        // Force mob to move to north room
+        mob.moveTo(NORTH_ROOM);
+        assertEquals(NORTH_ROOM, mob.roomId(),
+            "Precondition: mob should be in north room");
+
+        // Kill it and run the respawn countdown
+        mob.takeDamage(Integer.MAX_VALUE);
+        mob.scheduleRespawn();
+
+        // Tick through respawn countdown (10 ticks configured)
+        for (int i = 0; i < 10; i++) {
+            registry.tick();
+        }
+
+        assertEquals(SPAWN_ROOM, mob.roomId(),
+            "Respawned mob should be back in spawn room");
+    }
+
+    // ── stubs ─────────────────────────────────────────────────────────
+
+    private record StubMobTemplateRepository(List<MobTemplate> templates)
+        implements MobTemplateRepository {
+        @Override
+        public List<MobTemplate> findAll() { return templates; }
+    }
+
+    private record StubAttackRepository(Map<AttackId, AttackDefinition> attacks)
+        implements AttackRepository {
+        @Override
+        public Optional<AttackDefinition> findById(AttackId id) throws AttackRepositoryException {
+            return Optional.ofNullable(attacks.get(id));
+        }
+    }
+
+    private static class StubItemRepository implements ItemRepository {
+        private final Map<ItemId, Item> items;
+
+        StubItemRepository(Map<ItemId, Item> items) { this.items = Map.copyOf(items); }
+
+        @Override
+        public void save(Item item) throws RepositoryException {}
+
+        @Override
+        public Optional<Item> findById(ItemId id) throws RepositoryException {
+            return Optional.ofNullable(items.get(id));
+        }
+    }
+
+    private static class StubPlayerRepository implements PlayerRepository {
+        private final ConcurrentHashMap<Username, Player> store = new ConcurrentHashMap<>();
+
+        @Override
+        public void savePlayer(Player player) { store.put(player.getUsername(), player); }
+
+        @Override
+        public Optional<Player> loadPlayer(Username username) {
+            return Optional.ofNullable(store.get(username));
+        }
+    }
+
+    private static class StubRoomRepository implements RoomRepository {
+        private final Map<RoomId, Room> rooms;
+
+        StubRoomRepository(Map<RoomId, Room> rooms) {
+            this.rooms = Map.copyOf(rooms);
+        }
+
+        @Override
+        public void save(Room room) throws RepositoryException {}
+
+        @Override
+        public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return Optional.ofNullable(rooms.get(id));
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/MonstersLineFormatterTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/MonstersLineFormatterTest.java
@@ -28,7 +28,8 @@ class MonstersLineFormatterTest {
             0,
             0,
             null,
-            null
+            null,
+            false
         );
         return new MobInstance(template);
     }


### PR DESCRIPTION
## Summary

- MobInstance now tracks mutable `currentRoomId`, reset on respawn
- MobTemplate gains optional `wanders` boolean flag (default false)
- MobRegistry.tick() runs a wander phase: 30% chance per tick for idle non-NPC wandering mobs to move to a random adjacent room
- Players see departure/arrival messages via PlayerEventBus
- Direction.opposite() added for arrival direction messages
- RoomService.getExits() added to expose exit map
- rat.json updated with "wanders": true
- Unit tests in MobRegistryWanderTest covering all acceptance criteria
- Existing MobTemplate constructor callsites updated for new wanders field

Closes #151

## Test plan

- [ ] Run `./gradlew test` and verify MobRegistryWanderTest passes
- [ ] Start the server, log in, and observe rats wandering between rooms
- [ ] Verify departure message appears when a mob leaves your room
- [ ] Verify arrival message appears when a mob enters your room
- [ ] Verify non-wandering mobs stay put

🤖 Generated with [Claude Code](https://claude.com/claude-code)