### PR TITLE
feat(world): add LOCK and UNLOCK commands with key items for gated doors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,7 +57,7 @@
 - [x] Add multi-kill quest: deliver a fixed number of drops (e.g. rat tails) to an NPC for a reward
 - [x] Add PARTY system: players can form a group to share XP and see party HP in prompt
 - [x] Add mob respawn with wander: mobs randomly move between linked rooms on tick
-- [ ] Add LOCK and UNLOCK commands with key items for gated doors between zones
+- [x] Add LOCK and UNLOCK commands with key items for gated doors between zones
 - [ ] Add CAST command as an explicit spell-use alias alongside the existing ability system
 - [ ] Add mana potions with QUAFF restoring mana and add them to shops and mob loot tables
 - [ ] Add BANK NPC with DEPOSIT and WITHDRAW commands for safe gold storage

--- a/data/rooms/catacombs-entrance.json
+++ b/data/rooms/catacombs-entrance.json
@@ -1,11 +1,14 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "catacombs-entrance",
   "name": "Catacombs Entrance",
-  "description": "Crumbling stone steps descend into a cold, musty passage. Ancient runes are carved into the archway above, their meaning long forgotten. The smell of dry bone and stale air drifts upward from below.",
+  "description": "Crumbling stone steps descend into a cold, musty passage. Ancient runes are carved into the archway above, their meaning long forgotten. The smell of dry bone and stale air drifts upward from below. A heavy iron gate bars the way south.",
   "item_ids": [],
   "exits": {
     "north": "dark-burrow",
     "south": "ossuary-hall"
+  },
+  "locked_exits": {
+    "south": "crypt-key"
   }
 }

--- a/data/rooms/ossuary-hall.json
+++ b/data/rooms/ossuary-hall.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "ossuary-hall",
   "name": "Ossuary Hall",
   "description": "A wide underground hall lined with rows of skulls and bones stacked in alcoves along every wall. The bones rattle softly as you move through the chamber. The dead do not rest easy here.",
@@ -8,5 +8,8 @@
     "north": "catacombs-entrance",
     "east": "burial-alcove",
     "south": "crypt-corridor"
+  },
+  "locked_exits": {
+    "north": "crypt-key"
   }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/LockCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/LockCommand.java
@@ -1,0 +1,46 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Handles the {@code LOCK <direction>} command.
+ *
+ * <p>The player must carry the required key item. Locking is only possible on exits
+ * that are declared lockable in the room data and are currently unlocked.
+ */
+public class LockCommand extends RegistrableCommand {
+
+    public LockCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "lock";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Lock a door in the given direction.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: LOCK <direction>\n"
+             + "  Locks the door in the given direction. You must carry the correct key.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"LOCK".equals(parts[0])) {
+            return Optional.empty();
+        }
+        Optional<Direction> dir = Direction.fromInput(parts[1]);
+        return dir.map(direction ->
+            new SocketCommandMatch(this, context -> context.lockExit(direction))
+        );
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -1611,6 +1611,36 @@ public class SocketClient implements Client {
             }
         }
 
+        @Override
+        public void lockExit(Direction direction) {
+            if (!session.isAuthenticated() || session.getPlayer() == null) {
+                writeLineWithPrompt("You must be logged in to lock doors.");
+                return;
+            }
+            Player player = session.getPlayer();
+            RoomService.DoorActionResult result = roomService.lock(
+                player.getUsername(), direction, player.getInventory());
+            if (result.roomMessage() != null) {
+                deliverRoomMessage(player.getUsername(), null, result.roomMessage());
+            }
+            writeLineWithPrompt(result.playerMessage());
+        }
+
+        @Override
+        public void unlockExit(Direction direction) {
+            if (!session.isAuthenticated() || session.getPlayer() == null) {
+                writeLineWithPrompt("You must be logged in to unlock doors.");
+                return;
+            }
+            Player player = session.getPlayer();
+            RoomService.DoorActionResult result = roomService.unlock(
+                player.getUsername(), direction, player.getInventory());
+            if (result.roomMessage() != null) {
+                deliverRoomMessage(player.getUsername(), null, result.roomMessage());
+            }
+            writeLineWithPrompt(result.playerMessage());
+        }
+
         private void handlePartyForm(Player player, PartyService partyService) {
             PartyService.PartyResult result = partyService.form(player.getUsername());
             writeLineWithPrompt(result.message());

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -282,4 +282,30 @@ public interface SocketCommandContext extends Client {
      */
     default void executeParty(String args) {}
 
+    /**
+     * Locks the door in the given direction from the player's current room.
+     *
+     * <p>Requires the player to carry the correct key item. Prints a failure message
+     * when the exit is not lockable or the player lacks the key.
+     *
+     * <p>The default implementation is a no-op so that existing test stubs
+     * do not need to be updated.
+     *
+     * @param direction the direction of the exit to lock
+     */
+    default void lockExit(Direction direction) {}
+
+    /**
+     * Unlocks the door in the given direction from the player's current room.
+     *
+     * <p>Requires the player to carry the correct key item. Prints a failure message
+     * when the exit is not lockable, already unlocked, or the player lacks the key.
+     *
+     * <p>The default implementation is a no-op so that existing test stubs
+     * do not need to be updated.
+     *
+     * @param direction the direction of the exit to unlock
+     */
+    default void unlockExit(Direction direction) {}
+
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -47,6 +47,8 @@ public class SocketCommandRegistry {
         new QuestCommand(registry);
         new TrainCommand(registry);
         new PartyCommand(registry);
+        new LockCommand(registry);
+        new UnlockCommand(registry);
         new QuitCommand(registry);
         new HelpCommand(registry);
         return registry;

--- a/src/main/java/io/taanielo/jmud/core/server/socket/UnlockCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/UnlockCommand.java
@@ -1,0 +1,46 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Handles the {@code UNLOCK <direction>} command.
+ *
+ * <p>The player must carry the required key item. Unlocking is only possible on exits
+ * that are declared lockable in the room data and are currently locked.
+ */
+public class UnlockCommand extends RegistrableCommand {
+
+    public UnlockCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "unlock";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Unlock a door in the given direction.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: UNLOCK <direction>\n"
+             + "  Unlocks the door in the given direction. You must carry the correct key.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"UNLOCK".equals(parts[0])) {
+            return Optional.empty();
+        }
+        Optional<Direction> dir = Direction.fromInput(parts[1]);
+        return dir.map(direction ->
+            new SocketCommandMatch(this, context -> context.unlockExit(direction))
+        );
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/Room.java
+++ b/src/main/java/io/taanielo/jmud/core/world/Room.java
@@ -16,7 +16,12 @@ public class Room {
     Map<Direction, RoomId> exits;
     List<Item> items;
     List<Username> occupants;
+    /** Exits that start locked and the key item id required to unlock each one. */
+    Map<Direction, ItemId> lockedExits;
 
+    /**
+     * Constructs a room with no locked exits. Existing callsites use this overload.
+     */
     public Room(
         RoomId id,
         String name,
@@ -24,6 +29,23 @@ public class Room {
         Map<Direction, RoomId> exits,
         List<Item> items,
         List<Username> occupants
+    ) {
+        this(id, name, description, exits, items, occupants, Map.of());
+    }
+
+    /**
+     * Constructs a room with the specified locked exits configuration.
+     *
+     * @param lockedExits map of direction to required key item id for exits that start locked
+     */
+    public Room(
+        RoomId id,
+        String name,
+        String description,
+        Map<Direction, RoomId> exits,
+        List<Item> items,
+        List<Username> occupants,
+        Map<Direction, ItemId> lockedExits
     ) {
         this.id = Objects.requireNonNull(id, "Room id is required");
         if (name == null || name.isBlank()) {
@@ -34,5 +56,6 @@ public class Room {
         this.exits = Map.copyOf(Objects.requireNonNull(exits, "Room exits are required"));
         this.items = List.copyOf(Objects.requireNonNull(items, "Room items are required"));
         this.occupants = List.copyOf(Objects.requireNonNull(occupants, "Room occupants are required"));
+        this.lockedExits = Map.copyOf(Objects.requireNonNull(lockedExits, "Locked exits map is required"));
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/RoomService.java
+++ b/src/main/java/io/taanielo/jmud/core/world/RoomService.java
@@ -3,12 +3,14 @@ package io.taanielo.jmud.core.world;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
@@ -35,12 +37,27 @@ public class RoomService {
     public record MoveResult(boolean moved, List<String> lines, Room room) {
     }
 
+    /**
+     * Result of a lock or unlock door action.
+     *
+     * @param success       whether the action was performed
+     * @param playerMessage message shown to the acting player
+     * @param roomMessage   message broadcast to other room occupants, or {@code null} on failure
+     */
+    public record DoorActionResult(boolean success, String playerMessage, String roomMessage) {
+    }
+
     private final RoomRepository roomRepository;
     private final RoomId startingRoomId;
     private final ConcurrentHashMap<Username, RoomId> playerLocations = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<RoomId, List<Item>> transientItems = new ConcurrentHashMap<>();
     private final ConcurrentLinkedQueue<Corpse> trackedCorpses = new ConcurrentLinkedQueue<>();
     private final AtomicLong corpseCounter = new AtomicLong();
+    /**
+     * Runtime locked-exit state: maps each room id to the set of directions that are currently locked.
+     * Seeded lazily from each room's {@link Room#getLockedExits()} on first access.
+     */
+    private final ConcurrentHashMap<RoomId, Set<Direction>> runtimeLockedExits = new ConcurrentHashMap<>();
 
     /**
      * Creates a room service with the provided repository and starting room id.
@@ -230,6 +247,9 @@ public class RoomService {
         if (destinationId == null) {
             return new MoveResult(false, List.of("You cannot go " + direction.label() + "."), room);
         }
+        if (isExitLocked(room.getId(), direction)) {
+            return new MoveResult(false, List.of("The door to the " + direction.label() + " is locked."), room);
+        }
         Room destination = findRoom(destinationId).orElse(null);
         if (destination == null) {
             return new MoveResult(false, List.of("The way " + direction.label() + " is blocked."), room);
@@ -267,7 +287,8 @@ public class RoomService {
             room.getDescription(),
             room.getExits(),
             items,
-            occupants
+            occupants,
+            room.getLockedExits()
         );
     }
 
@@ -275,19 +296,20 @@ public class RoomService {
         List<String> lines = new ArrayList<>();
         lines.add(room.getName());
         lines.add(room.getDescription());
-        lines.add("Exits: " + formatExits(room.getExits()));
+        lines.add("Exits: " + formatExits(room.getId(), room.getExits()));
         lines.add("Items: " + formatItems(room.getItems()));
         lines.add("Occupants: " + formatOccupants(room.getOccupants(), viewer));
         return lines;
     }
 
-    private String formatExits(java.util.Map<Direction, RoomId> exits) {
+    private String formatExits(RoomId roomId, Map<Direction, RoomId> exits) {
         if (exits.isEmpty()) {
             return "none";
         }
+        Set<Direction> locked = ensureLockedState(roomId);
         return exits.keySet().stream()
-            .map(Direction::label)
-            .sorted()
+            .sorted(Comparator.comparing(Direction::label))
+            .map(dir -> locked.contains(dir) ? dir.label() + " [locked]" : dir.label())
             .collect(Collectors.joining(", "));
     }
 
@@ -345,7 +367,8 @@ public class RoomService {
             room.getDescription(),
             room.getExits(),
             nextItems,
-            room.getOccupants()
+            room.getOccupants(),
+            room.getLockedExits()
         );
         try {
             roomRepository.save(updated);
@@ -371,6 +394,132 @@ public class RoomService {
             next.removeIf(item -> item.getId().equals(itemId));
             return next.isEmpty() ? null : List.copyOf(next);
         });
+    }
+
+    /**
+     * Attempts to unlock the exit in the given direction from the player's current room.
+     *
+     * <p>Succeeds when the exit is declared lockable in the room data, is currently locked,
+     * and the player's inventory contains the required key item.
+     *
+     * @param username  the acting player
+     * @param direction the direction of the exit to unlock
+     * @param inventory the player's current inventory (used to check for the required key)
+     * @return the result of the action
+     */
+    public DoorActionResult unlock(Username username, Direction direction, List<Item> inventory) {
+        Objects.requireNonNull(username, "Username is required");
+        Objects.requireNonNull(direction, "Direction is required");
+        Objects.requireNonNull(inventory, "Inventory is required");
+        Room room = loadRoomForPlayer(username);
+        if (room == null) {
+            return new DoorActionResult(false, "You are nowhere.", null);
+        }
+        ItemId requiredKey = room.getLockedExits().get(direction);
+        if (requiredKey == null) {
+            return new DoorActionResult(false, "There is no lockable door to the " + direction.label() + ".", null);
+        }
+        Set<Direction> locked = ensureLockedState(room.getId());
+        if (!locked.contains(direction)) {
+            return new DoorActionResult(false, "The door to the " + direction.label() + " is already unlocked.", null);
+        }
+        if (!hasItem(inventory, requiredKey)) {
+            return new DoorActionResult(false, "You need the right key to unlock this door.", null);
+        }
+        locked.remove(direction);
+        propagateLockState(room, direction, false);
+        String playerMsg = "You unlock the door to the " + direction.label() + ".";
+        String roomMsg = username.getValue() + " unlocks the door to the " + direction.label() + ".";
+        return new DoorActionResult(true, playerMsg, roomMsg);
+    }
+
+    /**
+     * Attempts to lock the exit in the given direction from the player's current room.
+     *
+     * <p>Succeeds when the exit is declared lockable, is currently unlocked, and the player's
+     * inventory contains the required key item.
+     *
+     * @param username  the acting player
+     * @param direction the direction of the exit to lock
+     * @param inventory the player's current inventory
+     * @return the result of the action
+     */
+    public DoorActionResult lock(Username username, Direction direction, List<Item> inventory) {
+        Objects.requireNonNull(username, "Username is required");
+        Objects.requireNonNull(direction, "Direction is required");
+        Objects.requireNonNull(inventory, "Inventory is required");
+        Room room = loadRoomForPlayer(username);
+        if (room == null) {
+            return new DoorActionResult(false, "You are nowhere.", null);
+        }
+        ItemId requiredKey = room.getLockedExits().get(direction);
+        if (requiredKey == null) {
+            return new DoorActionResult(false, "There is no lockable door to the " + direction.label() + ".", null);
+        }
+        Set<Direction> locked = ensureLockedState(room.getId());
+        if (locked.contains(direction)) {
+            return new DoorActionResult(false, "The door to the " + direction.label() + " is already locked.", null);
+        }
+        if (!hasItem(inventory, requiredKey)) {
+            return new DoorActionResult(false, "You need the right key to lock this door.", null);
+        }
+        locked.add(direction);
+        propagateLockState(room, direction, true);
+        String playerMsg = "You lock the door to the " + direction.label() + ".";
+        String roomMsg = username.getValue() + " locks the door to the " + direction.label() + ".";
+        return new DoorActionResult(true, playerMsg, roomMsg);
+    }
+
+    private boolean isExitLocked(RoomId roomId, Direction direction) {
+        return ensureLockedState(roomId).contains(direction);
+    }
+
+    /**
+     * Returns (and lazily seeds) the runtime locked-exit set for a room.
+     *
+     * <p>The first call for a given room id loads the room from the repository and
+     * initialises the set from the room's {@link Room#getLockedExits()} configuration.
+     */
+    private Set<Direction> ensureLockedState(RoomId roomId) {
+        return runtimeLockedExits.computeIfAbsent(roomId, id -> {
+            Set<Direction> set = ConcurrentHashMap.newKeySet();
+            findRoom(id).ifPresent(r -> set.addAll(r.getLockedExits().keySet()));
+            return set;
+        });
+    }
+
+    /**
+     * Propagates a lock state change to the opposite side of the door (if the destination
+     * room also declares the reverse direction as a lockable exit).
+     */
+    private void propagateLockState(Room room, Direction direction, boolean nowLocked) {
+        RoomId destId = room.getExits().get(direction);
+        if (destId == null) {
+            return;
+        }
+        Room dest = findRoom(destId).orElse(null);
+        if (dest == null) {
+            return;
+        }
+        Direction reverse = direction.opposite();
+        if (!dest.getLockedExits().containsKey(reverse)) {
+            return;
+        }
+        Set<Direction> destLocked = ensureLockedState(destId);
+        if (nowLocked) {
+            destLocked.add(reverse);
+        } else {
+            destLocked.remove(reverse);
+        }
+    }
+
+    private boolean hasItem(List<Item> inventory, ItemId itemId) {
+        for (Item item : inventory) {
+            if (item.getId().equals(itemId)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Item createCorpse(Username username, int gold) {

--- a/src/main/java/io/taanielo/jmud/core/world/dto/RoomDto.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/RoomDto.java
@@ -5,7 +5,8 @@ import java.util.Map;
 
 /**
  * Data transfer object for room persistence. Schema version 2 adds the {@code exits} field;
- * version 1 files are still accepted and will produce rooms with no exits.
+ * version 3 adds the optional {@code lockedExits} map.
+ * Version 1 and 2 files are still accepted.
  */
-public record RoomDto(int schemaVersion, String id, String name, String description, List<String> itemIds, Map<String, String> exits) {
+public record RoomDto(int schemaVersion, String id, String name, String description, List<String> itemIds, Map<String, String> exits, Map<String, String> lockedExits) {
 }

--- a/src/main/java/io/taanielo/jmud/core/world/dto/RoomMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/RoomMapper.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 
 import io.taanielo.jmud.core.world.Direction;
 import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.Room;
 import io.taanielo.jmud.core.world.RoomId;
 
@@ -25,7 +26,11 @@ public class RoomMapper {
             .toList();
         Map<String, String> exits = new HashMap<>();
         room.getExits().forEach((dir, roomId) -> exits.put(dir.name().toLowerCase(), roomId.getValue()));
-        return new RoomDto(SchemaVersions.V2, room.getId().getValue(), room.getName(), room.getDescription(), itemIds, exits);
+        Map<String, String> lockedExits = new HashMap<>();
+        room.getLockedExits().forEach((dir, keyId) -> lockedExits.put(dir.name().toLowerCase(), keyId.getValue()));
+        int version = lockedExits.isEmpty() ? SchemaVersions.V2 : SchemaVersions.V3;
+        return new RoomDto(version, room.getId().getValue(), room.getName(), room.getDescription(), itemIds, exits,
+            lockedExits.isEmpty() ? null : lockedExits);
     }
 
     /**
@@ -42,13 +47,22 @@ public class RoomMapper {
                 );
             }
         }
+        Map<Direction, ItemId> lockedExits = new HashMap<>();
+        if (dto.lockedExits() != null) {
+            for (Map.Entry<String, String> entry : dto.lockedExits().entrySet()) {
+                Direction.fromInput(entry.getKey()).ifPresent(
+                    dir -> lockedExits.put(dir, ItemId.of(entry.getValue()))
+                );
+            }
+        }
         return new Room(
             RoomId.of(dto.id()),
             dto.name(),
             dto.description(),
             exits,
             items,
-            List.of()
+            List.of(),
+            lockedExits
         );
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepository.java
@@ -119,7 +119,9 @@ public class JsonRoomRepository implements RoomRepository {
     }
 
     private void validateSchema(RoomDto dto, Path path) throws RepositoryException {
-        if (dto.schemaVersion() != SchemaVersions.V1 && dto.schemaVersion() != SchemaVersions.V2) {
+        if (dto.schemaVersion() != SchemaVersions.V1
+                && dto.schemaVersion() != SchemaVersions.V2
+                && dto.schemaVersion() != SchemaVersions.V3) {
             throw new RepositoryException("Unsupported room schema version " + dto.schemaVersion() + " in " + path);
         }
     }

--- a/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
@@ -1,5 +1,6 @@
 package io.taanielo.jmud.core.world;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -196,6 +197,197 @@ class RoomServiceTest {
         String output = String.join("\n", lookResult.lines());
 
         assertTrue(output.contains("Apple"));
+    }
+
+    // ── Lock / Unlock tests ─────────────────────────────────────────────
+
+    @Test
+    void moveBlockedThroughLockedExit() {
+        RoomId roomAId = RoomId.of("a");
+        RoomId roomBId = RoomId.of("b");
+        ItemId keyId = ItemId.of("iron-key");
+        Room roomA = new Room(
+            roomAId,
+            "Room A",
+            "A quiet room.",
+            Map.of(Direction.NORTH, roomBId),
+            List.of(),
+            List.of(),
+            Map.of(Direction.NORTH, keyId)
+        );
+        Room roomB = new Room(
+            roomBId,
+            "Room B",
+            "A bright room.",
+            Map.of(Direction.SOUTH, roomAId),
+            List.of(),
+            List.of(),
+            Map.of(Direction.SOUTH, keyId)
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA, roomBId, roomB)), roomAId);
+        Username player = Username.of("Bob");
+        service.ensurePlayerLocation(player);
+
+        RoomService.MoveResult result = service.move(player, Direction.NORTH);
+
+        assertFalse(result.moved());
+        assertTrue(result.lines().getFirst().contains("locked"));
+    }
+
+    @Test
+    void unlockWithCorrectKeyAllowsMovement() {
+        RoomId roomAId = RoomId.of("a");
+        RoomId roomBId = RoomId.of("b");
+        ItemId keyId = ItemId.of("iron-key");
+        Item key = new Item(
+            keyId, "Iron Key", "A key.", ItemAttributes.empty(),
+            List.of(), List.of(), null, 1, 0, null
+        );
+        Room roomA = new Room(
+            roomAId, "Room A", "A quiet room.",
+            Map.of(Direction.NORTH, roomBId), List.of(), List.of(),
+            Map.of(Direction.NORTH, keyId)
+        );
+        Room roomB = new Room(
+            roomBId, "Room B", "A bright room.",
+            Map.of(Direction.SOUTH, roomAId), List.of(), List.of(),
+            Map.of(Direction.SOUTH, keyId)
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA, roomBId, roomB)), roomAId);
+        Username player = Username.of("Bob");
+        service.ensurePlayerLocation(player);
+
+        RoomService.DoorActionResult unlockResult = service.unlock(player, Direction.NORTH, List.of(key));
+        assertTrue(unlockResult.success());
+        assertTrue(unlockResult.playerMessage().contains("unlock"));
+
+        RoomService.MoveResult moveResult = service.move(player, Direction.NORTH);
+        assertTrue(moveResult.moved());
+    }
+
+    @Test
+    void unlockWithoutKeyFails() {
+        RoomId roomAId = RoomId.of("a");
+        RoomId roomBId = RoomId.of("b");
+        ItemId keyId = ItemId.of("iron-key");
+        Room roomA = new Room(
+            roomAId, "Room A", "A quiet room.",
+            Map.of(Direction.NORTH, roomBId), List.of(), List.of(),
+            Map.of(Direction.NORTH, keyId)
+        );
+        Room roomB = new Room(
+            roomBId, "Room B", "A bright room.",
+            Map.of(Direction.SOUTH, roomAId), List.of(), List.of()
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA, roomBId, roomB)), roomAId);
+        Username player = Username.of("Bob");
+        service.ensurePlayerLocation(player);
+
+        RoomService.DoorActionResult result = service.unlock(player, Direction.NORTH, List.of());
+
+        assertFalse(result.success());
+        assertTrue(result.playerMessage().contains("key"));
+    }
+
+    @Test
+    void lockAfterUnlockRestoresBlockedMovement() {
+        RoomId roomAId = RoomId.of("a");
+        RoomId roomBId = RoomId.of("b");
+        ItemId keyId = ItemId.of("iron-key");
+        Item key = new Item(
+            keyId, "Iron Key", "A key.", ItemAttributes.empty(),
+            List.of(), List.of(), null, 1, 0, null
+        );
+        Room roomA = new Room(
+            roomAId, "Room A", "A quiet room.",
+            Map.of(Direction.NORTH, roomBId), List.of(), List.of(),
+            Map.of(Direction.NORTH, keyId)
+        );
+        Room roomB = new Room(
+            roomBId, "Room B", "A bright room.",
+            Map.of(Direction.SOUTH, roomAId), List.of(), List.of(),
+            Map.of(Direction.SOUTH, keyId)
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA, roomBId, roomB)), roomAId);
+        Username player = Username.of("Bob");
+        service.ensurePlayerLocation(player);
+
+        // Unlock then lock again
+        assertTrue(service.unlock(player, Direction.NORTH, List.of(key)).success());
+        assertTrue(service.lock(player, Direction.NORTH, List.of(key)).success());
+
+        // Should be blocked again
+        assertFalse(service.move(player, Direction.NORTH).moved());
+    }
+
+    @Test
+    void lookShowsLockedSuffix() {
+        RoomId roomAId = RoomId.of("a");
+        RoomId roomBId = RoomId.of("b");
+        ItemId keyId = ItemId.of("iron-key");
+        Room roomA = new Room(
+            roomAId, "Room A", "A quiet room.",
+            Map.of(Direction.NORTH, roomBId), List.of(), List.of(),
+            Map.of(Direction.NORTH, keyId)
+        );
+        Room roomB = new Room(
+            roomBId, "Room B", "A bright room.",
+            Map.of(Direction.SOUTH, roomAId), List.of(), List.of()
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA, roomBId, roomB)), roomAId);
+        Username player = Username.of("Bob");
+        service.ensurePlayerLocation(player);
+
+        RoomService.LookResult look = service.look(player);
+        String output = String.join("\n", look.lines());
+
+        assertTrue(output.contains("[locked]"), "Expected '[locked]' in exits line, got: " + output);
+    }
+
+    @Test
+    void unlockFromOneSideUnlocksBothSides() {
+        RoomId roomAId = RoomId.of("a");
+        RoomId roomBId = RoomId.of("b");
+        ItemId keyId = ItemId.of("iron-key");
+        Item key = new Item(
+            keyId, "Iron Key", "A key.", ItemAttributes.empty(),
+            List.of(), List.of(), null, 1, 0, null
+        );
+        Room roomA = new Room(
+            roomAId, "Room A", "A quiet room.",
+            Map.of(Direction.NORTH, roomBId), List.of(), List.of(),
+            Map.of(Direction.NORTH, keyId)
+        );
+        Room roomB = new Room(
+            roomBId, "Room B", "A bright room.",
+            Map.of(Direction.SOUTH, roomAId), List.of(), List.of(),
+            Map.of(Direction.SOUTH, keyId)
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA, roomBId, roomB)), roomAId);
+        Username playerA = Username.of("Alice");
+        Username playerB = Username.of("Bob");
+        service.ensurePlayerLocation(playerA); // Alice in room A
+        // Move Bob to room B first using direct location assignment
+        service.ensurePlayerLocation(playerB);
+        // Manually place Bob in room B by unlocking and moving
+        service.unlock(playerA, Direction.NORTH, List.of(key));
+        // Alice unlocked from room A; now Bob (also in room A) tries to move north
+        // First re-lock so we can verify Bob in B after Alice unlocks
+        service.lock(playerA, Direction.NORTH, List.of(key));
+
+        // Alice unlocks from room A side
+        assertTrue(service.unlock(playerA, Direction.NORTH, List.of(key)).success());
+
+        // Move Bob to room B
+        service.move(playerA, Direction.NORTH);
+        // Now Alice is in room B; simulate Bob being in room A at the start
+        // Let's simplify: verify that the south exit from room B is also unlocked
+        // Re-place Alice back in room A for clarity
+        service.respawnPlayer(playerA); // puts Alice in starting room = roomA
+        service.move(playerA, Direction.NORTH); // Alice goes north (unlocked)
+        // Alice is now in room B - the reverse (south) should also be unlocked
+        RoomService.MoveResult backResult = service.move(playerA, Direction.SOUTH);
+        assertTrue(backResult.moved(), "Reverse direction should be unlocked after unlocking from other side");
     }
 
     private record TestRoomRepository(Map<RoomId, Room> rooms) implements RoomRepository {


### PR DESCRIPTION
## Summary

- Room domain extended with `lockedExits` map (schema bumped to v3)
- `RoomService` holds in-memory locked state, blocks movement through locked exits, and exposes `lock()`/`unlock()` methods keyed on item possession
- `LockCommand` and `UnlockCommand` socket handlers registered in `SocketCommandRegistry`
- LOOK output shows `[locked]` suffix on locked exits
- Catacombs entrance and ossuary hall rooms wired with a crypt-key locked door between them
- 5 new unit tests in `RoomServiceTest` covering all acceptance criteria

## Test plan

- [ ] Player without key cannot move through a locked exit (receives error message)
- [ ] Player with correct key can UNLOCK the exit and then move through
- [ ] Player with correct key can LOCK an exit that was previously unlocked
- [ ] LOOK shows `[locked]` suffix on locked exits
- [ ] Run `./gradlew test` — all tests pass including the 5 new `RoomServiceTest` cases

Closes #153

Generated with [Claude Code](https://claude.com/claude-code)