### PR TITLE
feat(items): add mana potions with QUAFF command restoring mana

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -59,7 +59,7 @@
 - [x] Add mob respawn with wander: mobs randomly move between linked rooms on tick
 - [x] Add LOCK and UNLOCK commands with key items for gated doors between zones
 - [x] Add CAST command as an explicit spell-use alias alongside the existing ability system
-- [ ] Add mana potions with QUAFF restoring mana and add them to shops and mob loot tables
+- [x] Add mana potions with QUAFF restoring mana and add them to shops and mob loot tables
 - [ ] Add BANK NPC with DEPOSIT and WITHDRAW commands for safe gold storage
 - [ ] Add item sell-value and item description visible in LIST so players can compare gear
 - [ ] Add weapon type variety: blunt, piercing, slashing with different damage dice and attack messages

--- a/data/items/mana-potion.json
+++ b/data/items/mana-potion.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 3,
+  "id": "mana-potion",
+  "name": "Mana Potion",
+  "description": "A small blue vial that restores a bit of magical energy.",
+  "attributes": {
+    "stats": {
+      "mana": 20
+    }
+  },
+  "effects": [],
+  "messages": [
+    {
+      "phase": "quaff",
+      "channel": "self",
+      "text": "You quaff {item}."
+    },
+    {
+      "phase": "quaff",
+      "channel": "room",
+      "text": "{source} quaffs {item}."
+    }
+  ],
+  "weight": 1,
+  "value": 15
+}

--- a/data/mobs/goblin.json
+++ b/data/mobs/goblin.json
@@ -12,6 +12,10 @@
     {
       "item_id": "health-potion",
       "drop_chance": 0.5
+    },
+    {
+      "item_id": "mana-potion",
+      "drop_chance": 0.2
     }
   ],
   "gold_drop": {

--- a/data/mobs/kobold.json
+++ b/data/mobs/kobold.json
@@ -12,6 +12,10 @@
     {
       "item_id": "health-potion",
       "drop_chance": 0.3
+    },
+    {
+      "item_id": "mana-potion",
+      "drop_chance": 0.15
     }
   ],
   "gold_drop": {

--- a/data/shops/shop.armory.json
+++ b/data/shops/shop.armory.json
@@ -6,7 +6,8 @@
   "stock": [
     {"item_id": "iron-sword"},
     {"item_id": "training-shield"},
-    {"item_id": "health-potion"}
+    {"item_id": "health-potion"},
+    {"item_id": "mana-potion"}
   ],
   "sell_ratio": 0.5
 }

--- a/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
+++ b/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
@@ -318,8 +318,10 @@ public class GameActionService {
             return GameActionResult.error("You aren't carrying that.");
         }
         int hpDelta = item.getAttributes().getStats().getOrDefault("hp", 0);
+        int manaDelta = item.getAttributes().getStats().getOrDefault("mana", 0);
         boolean hasHpStat = hpDelta != 0;
-        if (!hasHpStat && item.getEffects().isEmpty()) {
+        boolean hasManaStat = manaDelta != 0;
+        if (!hasHpStat && !hasManaStat && item.getEffects().isEmpty()) {
             return GameActionResult.error("Nothing happens.");
         }
         // Apply hp stat: positive heals, negative damages
@@ -328,6 +330,10 @@ public class GameActionService {
             vitals = vitals.heal(hpDelta);
         } else if (hpDelta < 0) {
             vitals = vitals.damage(-hpDelta);
+        }
+        // Apply mana stat: positive restores mana
+        if (manaDelta > 0) {
+            vitals = vitals.restoreMana(manaDelta);
         }
         Player working = source.withVitals(vitals);
         CollectingEffectMessageSink effectSink = new CollectingEffectMessageSink(

--- a/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
@@ -440,6 +440,84 @@ class GameActionServiceTest {
     }
 
     @Test
+    void quaffManaPotionRestoresManaFromPartialToMax() {
+        PlayerVitals lowMana = new PlayerVitals(20, 20, 5, 20, 20, 20);
+        Player withLowMana = new Player(
+            User.of(Username.of("attacker"), Password.hash("pw", 1000)),
+            1, 0, lowMana, List.of(), "prompt", false,
+            List.of(), null, null
+        );
+        Item manaPotion = new Item(
+            ItemId.of("mana-potion"),
+            "Mana Potion",
+            "A small blue vial.",
+            new ItemAttributes(Map.of("mana", 20)),
+            List.of(),
+            List.of(
+                new io.taanielo.jmud.core.messaging.MessageSpec(
+                    io.taanielo.jmud.core.messaging.MessagePhase.QUAFF,
+                    io.taanielo.jmud.core.messaging.MessageChannel.SELF,
+                    "You quaff {item}."
+                )
+            ),
+            null,
+            1,
+            15,
+            null
+        );
+        Player withPotion = withLowMana.addItem(manaPotion);
+
+        GameActionResult result = service.quaffItem(withPotion, "mana-potion");
+
+        assertEquals(20, result.updatedSource().getVitals().mana());
+        assertTrue(result.updatedSource().getInventory().isEmpty());
+    }
+
+    @Test
+    void quaffManaPotionIsCappedAtMaxMana() {
+        // Player is already at full mana (20/20); restoreMana(20) should stay at 20
+        Item manaPotion = new Item(
+            ItemId.of("mana-potion"),
+            "Mana Potion",
+            "A small blue vial.",
+            new ItemAttributes(Map.of("mana", 20)),
+            List.of(),
+            List.of(),
+            null,
+            1,
+            15,
+            null
+        );
+        Player withPotion = attacker.addItem(manaPotion);
+
+        GameActionResult result = service.quaffItem(withPotion, "mana-potion");
+
+        assertEquals(20, result.updatedSource().getVitals().mana());
+        assertTrue(result.updatedSource().getInventory().isEmpty());
+    }
+
+    @Test
+    void quaffItemNothingHappensGuardRequiresBothHpAndManaToBeZero() {
+        // Item with neither hp nor mana stat and no effects should still return "Nothing happens."
+        Item rock = new Item(
+            ItemId.of("rock"),
+            "Rock",
+            "A plain rock.",
+            ItemAttributes.empty(),
+            List.of(),
+            List.of(),
+            null,
+            1,
+            1,
+            null
+        );
+        Player withItem = attacker.addItem(rock);
+
+        GameActionResult result = service.quaffItem(withItem, "rock");
+        assertEquals("Nothing happens.", result.messages().getFirst().text());
+    }
+
+    @Test
     void resolveDeathIfNeededDoesNothingWhenAlive() {
         GameActionResult result = service.resolveDeathIfNeeded(target, attacker);
 


### PR DESCRIPTION
## Summary

- Adds `data/items/mana-potion.json` (schema v3, restores 20 mana, value 15)
- Extends `GameActionService.quaffItem` to read `stats.mana` and call `vitals.restoreMana()`; updates the "nothing happens" guard to cover both hp and mana
- Mana potion added to `shop.armory.json` stock, `goblin.json` loot at 20%, and `kobold.json` loot at 15%
- 3 new unit tests in `GameActionServiceTest` covering the quaff-mana logic

## Test plan

- [ ] Build passes (`./gradlew build`)
- [ ] New unit tests all green (`./gradlew test`)
- [ ] In-game: buy mana potion from armory shop; use QUAFF and confirm mana increases
- [ ] Kill goblins and kobolds; verify mana potion drops at expected rates
- [ ] QUAFF a mana potion at full mana; confirm "nothing happens" message

Closes #157

Generated with [Claude Code](https://claude.com/claude-code)