### PR TITLE
feat(bank): add BANK NPC with DEPOSIT and WITHDRAW commands for safe gold storage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -60,7 +60,7 @@
 - [x] Add LOCK and UNLOCK commands with key items for gated doors between zones
 - [x] Add CAST command as an explicit spell-use alias alongside the existing ability system
 - [x] Add mana potions with QUAFF restoring mana and add them to shops and mob loot tables
-- [ ] Add BANK NPC with DEPOSIT and WITHDRAW commands for safe gold storage
+- [x] Add BANK NPC with DEPOSIT and WITHDRAW commands for safe gold storage
 - [ ] Add item sell-value and item description visible in LIST so players can compare gear
 - [ ] Add weapon type variety: blunt, piercing, slashing with different damage dice and attack messages
 - [ ] Add armour items (chest, legs, head slots) with AC value reducing incoming damage in combat engine

--- a/data/banks/bank.town.json
+++ b/data/banks/bank.town.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "id": "town-bank",
+  "name": "Aldric the Banker",
+  "room_id": "courtyard"
+}

--- a/src/main/java/io/taanielo/jmud/core/bank/Bank.java
+++ b/src/main/java/io/taanielo/jmud/core/bank/Bank.java
@@ -1,0 +1,23 @@
+package io.taanielo.jmud.core.bank;
+
+import java.util.Objects;
+
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * Immutable definition of a bank NPC loaded from data files.
+ *
+ * <p>A bank is associated with a single room via {@link #roomId()}.
+ * Players interact with the bank to safely store and retrieve gold.
+ */
+public record Bank(
+    BankId id,
+    String name,
+    RoomId roomId
+) {
+    public Bank {
+        Objects.requireNonNull(id, "Bank id is required");
+        Objects.requireNonNull(name, "Bank name is required");
+        Objects.requireNonNull(roomId, "Bank roomId is required");
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/bank/BankId.java
+++ b/src/main/java/io/taanielo/jmud/core/bank/BankId.java
@@ -1,0 +1,21 @@
+package io.taanielo.jmud.core.bank;
+
+import java.util.Objects;
+
+/**
+ * Value object identifying a bank NPC by its string id.
+ */
+public record BankId(String value) {
+
+    public BankId {
+        Objects.requireNonNull(value, "BankId value is required");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("BankId value must not be blank");
+        }
+    }
+
+    /** Creates a {@link BankId} from a raw string. */
+    public static BankId of(String value) {
+        return new BankId(value);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/bank/BankRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/bank/BankRepository.java
@@ -1,0 +1,27 @@
+package io.taanielo.jmud.core.bank;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * Data-access contract for {@link Bank} definitions.
+ */
+public interface BankRepository {
+
+    /**
+     * Returns all bank definitions.
+     *
+     * @throws BankRepositoryException when data cannot be read
+     */
+    List<Bank> findAll() throws BankRepositoryException;
+
+    /**
+     * Returns the bank whose {@code roomId} matches the given room, or empty
+     * when there is no bank in that room.
+     *
+     * @throws BankRepositoryException when data cannot be read
+     */
+    Optional<Bank> findByRoomId(RoomId roomId) throws BankRepositoryException;
+}

--- a/src/main/java/io/taanielo/jmud/core/bank/BankRepositoryException.java
+++ b/src/main/java/io/taanielo/jmud/core/bank/BankRepositoryException.java
@@ -1,0 +1,15 @@
+package io.taanielo.jmud.core.bank;
+
+/**
+ * Thrown when bank data cannot be read from the underlying storage.
+ */
+public class BankRepositoryException extends Exception {
+
+    public BankRepositoryException(String message) {
+        super(message);
+    }
+
+    public BankRepositoryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/bank/BankService.java
+++ b/src/main/java/io/taanielo/jmud/core/bank/BankService.java
@@ -1,0 +1,104 @@
+package io.taanielo.jmud.core.bank;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * Application service for bank interactions: depositing and withdrawing gold.
+ *
+ * <p>All operations are stateless with respect to the bank; the {@link Player}
+ * passed in is never mutated. Callers receive an updated {@link Player} in the
+ * returned {@link BankTransactionResult} on success.
+ *
+ * <p>Banked gold survives death and is never lost to mob drops or corpse decay.
+ * Gold can only be moved between carried and banked balances — no gold is ever
+ * created or destroyed.
+ */
+@Slf4j
+public class BankService {
+
+    private final BankRepository bankRepository;
+
+    public BankService(BankRepository bankRepository) {
+        this.bankRepository = Objects.requireNonNull(bankRepository, "bankRepository is required");
+    }
+
+    /**
+     * Returns the bank located in the given room, if any.
+     *
+     * @param roomId the room to search
+     * @return the bank in the room, or empty
+     */
+    public Optional<Bank> findBankInRoom(RoomId roomId) {
+        Objects.requireNonNull(roomId, "roomId is required");
+        try {
+            return bankRepository.findByRoomId(roomId);
+        } catch (BankRepositoryException e) {
+            log.warn("Failed to look up bank in room {}: {}", roomId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Deposits the given amount from the player's carried gold into the bank.
+     *
+     * <p>Fails if {@code amount} is zero or negative, or if the player does not
+     * carry enough gold.
+     *
+     * @param player the depositing player
+     * @param amount the amount to deposit; must be positive
+     * @return a result describing success or failure
+     */
+    public BankTransactionResult deposit(Player player, int amount) {
+        Objects.requireNonNull(player, "player is required");
+        if (amount <= 0) {
+            return BankTransactionResult.failure("You must deposit a positive amount of gold.");
+        }
+        if (player.getGold() < amount) {
+            return BankTransactionResult.failure(
+                "You do not have enough gold. You are only carrying "
+                    + player.getGold() + " gold.");
+        }
+        Player updated = player.addGold(-amount).addBankedGold(amount);
+        return BankTransactionResult.success(
+            "You deposit " + amount + " gold. "
+                + "Carried: " + updated.getGold() + " gold. "
+                + "Banked: " + updated.getBankedGold() + " gold.",
+            updated
+        );
+    }
+
+    /**
+     * Withdraws the given amount from the player's banked gold into carried gold.
+     *
+     * <p>Fails if {@code amount} is zero or negative, or if the bank does not
+     * hold enough gold for this player.
+     *
+     * @param player the withdrawing player
+     * @param amount the amount to withdraw; must be positive
+     * @return a result describing success or failure
+     */
+    public BankTransactionResult withdraw(Player player, int amount) {
+        Objects.requireNonNull(player, "player is required");
+        if (amount <= 0) {
+            return BankTransactionResult.failure("You must withdraw a positive amount of gold.");
+        }
+        if (player.getBankedGold() < amount) {
+            return BankTransactionResult.failure(
+                "You do not have that much gold in the bank. Your balance is "
+                    + player.getBankedGold() + " gold.");
+        }
+        Player updated = player.addBankedGold(-amount).addGold(amount);
+        return BankTransactionResult.success(
+            "You withdraw " + amount + " gold. "
+                + "Carried: " + updated.getGold() + " gold. "
+                + "Banked: " + updated.getBankedGold() + " gold.",
+            updated
+        );
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/bank/BankTransactionResult.java
+++ b/src/main/java/io/taanielo/jmud/core/bank/BankTransactionResult.java
@@ -1,0 +1,22 @@
+package io.taanielo.jmud.core.bank;
+
+import io.taanielo.jmud.core.player.Player;
+
+/**
+ * Outcome of a {@link BankService} deposit or withdraw operation.
+ *
+ * <p>On success {@link #updatedPlayer()} holds the player with updated carried and banked
+ * gold balances. On failure {@link #updatedPlayer()} is {@code null}.
+ */
+public record BankTransactionResult(boolean success, String message, Player updatedPlayer) {
+
+    /** Constructs a successful result with an updated player state. */
+    public static BankTransactionResult success(String message, Player updatedPlayer) {
+        return new BankTransactionResult(true, message, updatedPlayer);
+    }
+
+    /** Constructs a failure result with no player change. */
+    public static BankTransactionResult failure(String message) {
+        return new BankTransactionResult(false, message, null);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/bank/repository/json/BankDto.java
+++ b/src/main/java/io/taanielo/jmud/core/bank/repository/json/BankDto.java
@@ -1,0 +1,12 @@
+package io.taanielo.jmud.core.bank.repository.json;
+
+/**
+ * JSON transfer object for a bank definition file ({@code bank.*.json}).
+ */
+record BankDto(
+    int schemaVersion,
+    String id,
+    String name,
+    String roomId
+) {
+}

--- a/src/main/java/io/taanielo/jmud/core/bank/repository/json/JsonBankDataMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/bank/repository/json/JsonBankDataMapper.java
@@ -1,0 +1,20 @@
+package io.taanielo.jmud.core.bank.repository.json;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+final class JsonBankDataMapper {
+    private JsonBankDataMapper() {
+    }
+
+    static ObjectMapper create() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        return mapper;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/bank/repository/json/JsonBankRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/bank/repository/json/JsonBankRepository.java
@@ -1,0 +1,110 @@
+package io.taanielo.jmud.core.bank.repository.json;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.taanielo.jmud.core.bank.Bank;
+import io.taanielo.jmud.core.bank.BankId;
+import io.taanielo.jmud.core.bank.BankRepository;
+import io.taanielo.jmud.core.bank.BankRepositoryException;
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * Loads {@link Bank} definitions from {@code data/banks/bank.*.json} files.
+ *
+ * <p>All banks are eagerly loaded and cached at construction time.
+ */
+@Slf4j
+public class JsonBankRepository implements BankRepository {
+
+    private static final int SCHEMA_VERSION = 1;
+    private static final String BANKS_DIR = "banks";
+
+    private final ObjectMapper objectMapper;
+    private final Path banksDirPath;
+    private List<Bank> cache;
+
+    public JsonBankRepository() throws BankRepositoryException {
+        this(Path.of("data"));
+    }
+
+    public JsonBankRepository(Path dataRoot) throws BankRepositoryException {
+        this.objectMapper = JsonBankDataMapper.create();
+        this.banksDirPath = Objects.requireNonNull(dataRoot, "Data root is required").resolve(BANKS_DIR);
+        ensureDirectory(banksDirPath);
+    }
+
+    @Override
+    public List<Bank> findAll() throws BankRepositoryException {
+        if (cache == null) {
+            cache = load();
+        }
+        return cache;
+    }
+
+    @Override
+    public Optional<Bank> findByRoomId(RoomId roomId) throws BankRepositoryException {
+        Objects.requireNonNull(roomId, "roomId is required");
+        return findAll().stream()
+            .filter(b -> b.roomId().equals(roomId))
+            .findFirst();
+    }
+
+    // ── private helpers ───────────────────────────────────────────────
+
+    private List<Bank> load() throws BankRepositoryException {
+        List<Bank> banks = new ArrayList<>();
+        try (var stream = Files.list(banksDirPath)) {
+            for (Path path : stream.filter(p -> p.toString().endsWith(".json")).toList()) {
+                BankDto dto = readDto(path);
+                if (dto.schemaVersion() != SCHEMA_VERSION) {
+                    throw new BankRepositoryException(
+                        "Unsupported bank schema version " + dto.schemaVersion() + " in " + path);
+                }
+                banks.add(toDomain(dto, path));
+            }
+        } catch (IOException e) {
+            throw new BankRepositoryException("Failed to list bank data files: " + e.getMessage(), e);
+        }
+        log.info("Loaded {} bank(s) from {}", banks.size(), banksDirPath);
+        return List.copyOf(banks);
+    }
+
+    private Bank toDomain(BankDto dto, Path source) throws BankRepositoryException {
+        try {
+            return new Bank(
+                BankId.of(dto.id()),
+                dto.name(),
+                RoomId.of(dto.roomId())
+            );
+        } catch (IllegalArgumentException e) {
+            throw new BankRepositoryException("Invalid bank data in " + source + ": " + e.getMessage(), e);
+        }
+    }
+
+    private BankDto readDto(Path path) throws BankRepositoryException {
+        try {
+            return objectMapper.readValue(path.toFile(), BankDto.class);
+        } catch (IOException e) {
+            throw new BankRepositoryException(
+                "Failed to read bank data from " + path + ": " + e.getMessage(), e);
+        }
+    }
+
+    private void ensureDirectory(Path path) throws BankRepositoryException {
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new BankRepositoryException("Failed to create banks directory " + path, e);
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/player/Player.java
+++ b/src/main/java/io/taanielo/jmud/core/player/Player.java
@@ -36,6 +36,8 @@ public class Player implements EffectTarget, Combatant {
     private final long totalKills;
     /** Unspent practice points earned by levelling up; defaults to {@code 0} for existing players. */
     private final int practicePoints;
+    /** Persisted gold balance held in the bank; never negative. */
+    private final int bankedGold;
 
     public static Player of(User user, String promptFormat) {
         return new Player(user, 1, 0, PlayerVitals.defaults(), List.of(), promptFormat, false, List.of(), null, null);
@@ -79,6 +81,7 @@ public class Player implements EffectTarget, Combatant {
             null,
             null,
             null,
+            null,
             null
         );
     }
@@ -101,7 +104,8 @@ public class Player implements EffectTarget, Combatant {
         @JsonProperty("gold") Integer gold,
         @JsonProperty("activeQuest") ActiveQuest activeQuest,
         @JsonProperty("totalKills") Long totalKills,
-        @JsonProperty("practicePoints") Integer practicePoints
+        @JsonProperty("practicePoints") Integer practicePoints,
+        @JsonProperty("bankedGold") Integer bankedGold
     ) {
         this(
             new PlayerIdentity(user, level, experience, race, classId),
@@ -114,7 +118,8 @@ public class Player implements EffectTarget, Combatant {
             gold == null ? 0 : Math.max(0, gold),
             activeQuest,
             totalKills == null ? 0L : totalKills,
-            practicePoints == null ? 0 : Math.max(0, practicePoints)
+            practicePoints == null ? 0 : Math.max(0, practicePoints),
+            bankedGold == null ? 0 : Math.max(0, bankedGold)
         );
     }
 
@@ -126,7 +131,7 @@ public class Player implements EffectTarget, Combatant {
         PlayerInventory inventory,
         PlayerEquipment equipment
     ) {
-        this(identity, combatState, preferences, abilities, inventory, equipment, false, 0, null, 0L, 0);
+        this(identity, combatState, preferences, abilities, inventory, equipment, false, 0, null, 0L, 0, 0);
     }
 
     private Player(
@@ -139,7 +144,7 @@ public class Player implements EffectTarget, Combatant {
         boolean resting,
         int gold
     ) {
-        this(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, null, 0L, 0);
+        this(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, null, 0L, 0, 0);
     }
 
     private Player(
@@ -153,7 +158,7 @@ public class Player implements EffectTarget, Combatant {
         int gold,
         ActiveQuest activeQuest
     ) {
-        this(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, 0L, 0);
+        this(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, 0L, 0, 0);
     }
 
     private Player(
@@ -168,7 +173,7 @@ public class Player implements EffectTarget, Combatant {
         ActiveQuest activeQuest,
         long totalKills
     ) {
-        this(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, 0);
+        this(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, 0, 0);
     }
 
     private Player(
@@ -182,7 +187,8 @@ public class Player implements EffectTarget, Combatant {
         int gold,
         ActiveQuest activeQuest,
         long totalKills,
-        int practicePoints
+        int practicePoints,
+        int bankedGold
     ) {
         this.identity = Objects.requireNonNull(identity, "Identity is required");
         this.combatState = Objects.requireNonNull(combatState, "Combat state is required");
@@ -195,6 +201,7 @@ public class Player implements EffectTarget, Combatant {
         this.activeQuest = activeQuest;
         this.totalKills = Math.max(0L, totalKills);
         this.practicePoints = Math.max(0, practicePoints);
+        this.bankedGold = Math.max(0, bankedGold);
     }
 
     @JsonProperty("user")
@@ -282,6 +289,11 @@ public class Player implements EffectTarget, Combatant {
         return practicePoints;
     }
 
+    @JsonProperty("bankedGold")
+    public int getBankedGold() {
+        return bankedGold;
+    }
+
     public PlayerIdentity identity() {
         return identity;
     }
@@ -342,54 +354,54 @@ public class Player implements EffectTarget, Combatant {
             return this;
         }
         // Dying always clears the resting flag.
-        return new Player(identity, combatState.die(), preferences, abilities, inventory, equipment, false, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState.die(), preferences, abilities, inventory, equipment, false, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     public Player respawn() {
-        return new Player(identity, combatState.respawn(), preferences, abilities, inventory, equipment, false, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState.respawn(), preferences, abilities, inventory, equipment, false, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     public Player withoutEffects() {
-        return new Player(identity, combatState.withoutEffects(), preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState.withoutEffects(), preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     public Player withAnsiEnabled(boolean enabled) {
-        return new Player(identity, combatState, preferences.withAnsiEnabled(enabled), abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState, preferences.withAnsiEnabled(enabled), abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     public Player withVitals(PlayerVitals updatedVitals) {
-        return new Player(identity, combatState.withVitals(updatedVitals), preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState.withVitals(updatedVitals), preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     public Player withDead(boolean dead) {
-        return new Player(identity, combatState.withDead(dead), preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState.withDead(dead), preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     public Player withLearnedAbilities(List<AbilityId> learnedAbilities) {
-        return new Player(identity, combatState, preferences, abilities.withLearned(learnedAbilities), inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState, preferences, abilities.withLearned(learnedAbilities), inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     public Player withInventory(List<Item> items) {
-        return new Player(identity, combatState, preferences, abilities, inventory.withItems(items), equipment, resting, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState, preferences, abilities, inventory.withItems(items), equipment, resting, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     public Player addItem(Item item) {
-        return new Player(identity, combatState, preferences, abilities, inventory.addItem(item), equipment, resting, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState, preferences, abilities, inventory.addItem(item), equipment, resting, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     public Player removeItem(Item item) {
-        return new Player(identity, combatState, preferences, abilities, inventory.removeItem(item), equipment, resting, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState, preferences, abilities, inventory.removeItem(item), equipment, resting, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     public Player withEquipment(PlayerEquipment nextEquipment) {
-        return new Player(identity, combatState, preferences, abilities, inventory, nextEquipment, resting, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState, preferences, abilities, inventory, nextEquipment, resting, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     /**
      * Returns a copy of this player with the given identity (level and experience).
      */
     public Player withIdentity(PlayerIdentity nextIdentity) {
-        return new Player(nextIdentity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills);
+        return new Player(nextIdentity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     /**
@@ -400,7 +412,7 @@ public class Player implements EffectTarget, Combatant {
      * @param resting {@code true} to enter a resting state, {@code false} to wake up
      */
     public Player withResting(boolean resting) {
-        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     /**
@@ -409,7 +421,7 @@ public class Player implements EffectTarget, Combatant {
      * @param newGold the new gold amount; negative values are clamped to 0
      */
     public Player withGold(int newGold) {
-        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, newGold, activeQuest, totalKills, practicePoints);
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, newGold, activeQuest, totalKills, practicePoints, bankedGold);
     }
 
     /**
@@ -422,12 +434,30 @@ public class Player implements EffectTarget, Combatant {
     }
 
     /**
+     * Returns a copy of this player with the given banked gold balance.
+     *
+     * @param newBankedGold the new banked gold amount; negative values are clamped to 0
+     */
+    public Player withBankedGold(int newBankedGold) {
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, practicePoints, newBankedGold);
+    }
+
+    /**
+     * Returns a copy of this player with the given amount added to the banked gold balance.
+     *
+     * @param amount amount to add; may be negative (clamped so balance never goes below 0)
+     */
+    public Player addBankedGold(int amount) {
+        return withBankedGold(bankedGold + amount);
+    }
+
+    /**
      * Returns a copy of this player with the given active quest set.
      *
      * @param quest the quest to set, or {@code null} to clear the active quest
      */
     public Player withActiveQuest(ActiveQuest quest) {
-        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, quest, totalKills, practicePoints);
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, quest, totalKills, practicePoints, bankedGold);
     }
 
     /**
@@ -436,7 +466,7 @@ public class Player implements EffectTarget, Combatant {
      * @param newTotalKills the new kill count; negative values are clamped to 0
      */
     public Player withTotalKills(long newTotalKills) {
-        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, newTotalKills, practicePoints);
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, newTotalKills, practicePoints, bankedGold);
     }
 
     /**
@@ -445,6 +475,6 @@ public class Player implements EffectTarget, Combatant {
      * @param newPracticePoints the new practice point count; negative values are clamped to 0
      */
     public Player withPracticePoints(int newPracticePoints) {
-        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, newPracticePoints);
+        return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, newPracticePoints, bankedGold);
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/DepositCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/DepositCommand.java
@@ -1,0 +1,40 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the {@code DEPOSIT <amount>} command, moving gold from carried balance to the bank.
+ */
+public class DepositCommand extends RegistrableCommand {
+
+    public DepositCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "deposit";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Deposit gold into the bank for safe keeping.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: DEPOSIT <amount>\n"
+             + "  Moves the specified amount of gold from your carried balance to the bank.\n"
+             + "  Banked gold is safe from death and never lost. Requires a bank NPC in the room.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"DEPOSIT".equals(parts[0])) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> context.depositToBank(args)));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
@@ -42,6 +42,10 @@ import io.taanielo.jmud.core.quest.QuestKillService;
 import io.taanielo.jmud.core.quest.QuestRepository;
 import io.taanielo.jmud.core.quest.QuestRepositoryException;
 import io.taanielo.jmud.core.quest.repository.json.JsonQuestRepository;
+import io.taanielo.jmud.core.bank.BankRepository;
+import io.taanielo.jmud.core.bank.BankRepositoryException;
+import io.taanielo.jmud.core.bank.BankService;
+import io.taanielo.jmud.core.bank.repository.json.JsonBankRepository;
 import io.taanielo.jmud.core.shop.ShopRepository;
 import io.taanielo.jmud.core.shop.ShopRepositoryException;
 import io.taanielo.jmud.core.shop.ShopService;
@@ -91,7 +95,8 @@ public record GameContext(
     CharacterCreationService characterCreationService,
     ShopService shopService,
     QuestRepository questRepository,
-    PartyService partyService
+    PartyService partyService,
+    BankService bankService
 ) {
 
     /**
@@ -142,6 +147,7 @@ public record GameContext(
 
         CharacterCreationService characterCreationService = createCharacterCreationService();
         ShopService shopService = createShopService();
+        BankService bankService = createBankService();
         QuestRepository questRepository = createQuestRepository();
         if (mobRegistry != null && questRepository != null) {
             mobRegistry.setQuestKillService(new QuestKillService(questRepository));
@@ -178,7 +184,8 @@ public record GameContext(
             characterCreationService,
             shopService,
             questRepository,
-            partyService
+            partyService,
+            bankService
         );
     }
 
@@ -273,6 +280,15 @@ public record GameContext(
             return new ShopService(shopRepository, itemRepository);
         } catch (ShopRepositoryException | RepositoryException e) {
             throw new IllegalStateException("Failed to initialize shop service: " + e.getMessage(), e);
+        }
+    }
+
+    private static BankService createBankService() {
+        try {
+            BankRepository bankRepository = new JsonBankRepository();
+            return new BankService(bankRepository);
+        } catch (BankRepositoryException e) {
+            throw new IllegalStateException("Failed to initialize bank service: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GoldCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GoldCommand.java
@@ -26,7 +26,7 @@ public class GoldCommand extends RegistrableCommand {
     @Override
     public String longDescription() {
         return "Usage: GOLD\n"
-             + "  Shows how many gold coins you are currently carrying.";
+             + "  Shows how many gold coins you are currently carrying and how much is banked.";
     }
 
     @Override
@@ -44,7 +44,11 @@ public class GoldCommand extends RegistrableCommand {
             return;
         }
         Player player = context.getPlayer();
-        context.writeLineWithPrompt("You are carrying " + player.getGold() + " gold coin"
-            + (player.getGold() == 1 ? "" : "s") + ".");
+        context.writeLineWithPrompt(
+            "Carried: " + player.getGold() + " gold coin"
+                + (player.getGold() == 1 ? "" : "s") + ".  "
+                + "Banked: " + player.getBankedGold() + " gold coin"
+                + (player.getBankedGold() == 1 ? "" : "s") + "."
+        );
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -64,6 +64,8 @@ import io.taanielo.jmud.core.quest.QuestKillService;
 import io.taanielo.jmud.core.quest.QuestRepository;
 import io.taanielo.jmud.core.quest.QuestRepositoryException;
 import io.taanielo.jmud.core.quest.QuestTemplate;
+import io.taanielo.jmud.core.bank.Bank;
+import io.taanielo.jmud.core.bank.BankTransactionResult;
 import io.taanielo.jmud.core.shop.Shop;
 import io.taanielo.jmud.core.shop.ShopTransactionResult;
 import io.taanielo.jmud.core.world.Direction;
@@ -541,6 +543,10 @@ public class SocketClient implements Client {
             if (!shopLine.isEmpty()) {
                 connection.writeLine(shopLine);
             }
+            String bankLine = formatBankNpcLine(result.room().getId());
+            if (!bankLine.isEmpty()) {
+                connection.writeLine(bankLine);
+            }
         }
         sendPrompt();
     }
@@ -820,6 +826,24 @@ public class SocketClient implements Client {
             .orElse("");
     }
 
+    /**
+     * Builds a bank NPC line for the given room, using the context's bank service.
+     *
+     * <p>Returns an empty string when there is no bank in the room or the service is unavailable.
+     *
+     * @param roomId the room to check for a bank
+     * @return a formatted line such as {@code "Banker: Aldric the Banker"}, or {@code ""}
+     */
+    private String formatBankNpcLine(RoomId roomId) {
+        if (context.bankService() == null || roomId == null) {
+            return "";
+        }
+        return context.bankService()
+            .findBankInRoom(roomId)
+            .map(bank -> "Banker: " + bank.name())
+            .orElse("");
+    }
+
     private boolean isAuthenticatedUser(Username username) {
         return session.isAuthenticated()
             && session.getPlayer() != null
@@ -913,6 +937,10 @@ public class SocketClient implements Client {
                 if (!shopLine.isEmpty()) {
                     connection.writeLine(shopLine);
                 }
+                String bankLine = formatBankNpcLine(result.room().getId());
+                if (!bankLine.isEmpty()) {
+                    connection.writeLine(bankLine);
+                }
             }
             sendPrompt();
         }
@@ -991,6 +1019,10 @@ public class SocketClient implements Client {
                 String shopLine = formatShopNpcLine(result.room().getId());
                 if (!shopLine.isEmpty()) {
                     connection.writeLine(shopLine);
+                }
+                String bankLine = formatBankNpcLine(result.room().getId());
+                if (!bankLine.isEmpty()) {
+                    connection.writeLine(bankLine);
                 }
             }
             sendPrompt();
@@ -1659,6 +1691,82 @@ public class SocketClient implements Client {
                 deliverRoomMessage(player.getUsername(), null, result.roomMessage());
             }
             writeLineWithPrompt(result.playerMessage());
+        }
+
+        @Override
+        public void depositToBank(String args) {
+            if (!session.isAuthenticated() || session.getPlayer() == null) {
+                writeLineWithPrompt("You must be logged in to use the bank.");
+                return;
+            }
+            if (context.bankService() == null) {
+                writeLineWithPrompt("There is no bank here.");
+                return;
+            }
+            Player player = session.getPlayer();
+            var roomIdOpt = roomService.findPlayerLocation(player.getUsername());
+            if (roomIdOpt.isEmpty()) {
+                writeLineWithPrompt("You are nowhere.");
+                return;
+            }
+            if (context.bankService().findBankInRoom(roomIdOpt.get()).isEmpty()) {
+                writeLineWithPrompt("There is no bank here.");
+                return;
+            }
+            if (args == null || args.isBlank()) {
+                writeLineWithPrompt("Deposit how much gold? Usage: DEPOSIT <amount>");
+                return;
+            }
+            int amount;
+            try {
+                amount = Integer.parseInt(args.trim());
+            } catch (NumberFormatException e) {
+                writeLineWithPrompt("'" + args.trim() + "' is not a valid amount.");
+                return;
+            }
+            BankTransactionResult result = context.bankService().deposit(player, amount);
+            if (result.success()) {
+                session.replacePlayer(result.updatedPlayer());
+            }
+            writeLineWithPrompt(result.message());
+        }
+
+        @Override
+        public void withdrawFromBank(String args) {
+            if (!session.isAuthenticated() || session.getPlayer() == null) {
+                writeLineWithPrompt("You must be logged in to use the bank.");
+                return;
+            }
+            if (context.bankService() == null) {
+                writeLineWithPrompt("There is no bank here.");
+                return;
+            }
+            Player player = session.getPlayer();
+            var roomIdOpt = roomService.findPlayerLocation(player.getUsername());
+            if (roomIdOpt.isEmpty()) {
+                writeLineWithPrompt("You are nowhere.");
+                return;
+            }
+            if (context.bankService().findBankInRoom(roomIdOpt.get()).isEmpty()) {
+                writeLineWithPrompt("There is no bank here.");
+                return;
+            }
+            if (args == null || args.isBlank()) {
+                writeLineWithPrompt("Withdraw how much gold? Usage: WITHDRAW <amount>");
+                return;
+            }
+            int amount;
+            try {
+                amount = Integer.parseInt(args.trim());
+            } catch (NumberFormatException e) {
+                writeLineWithPrompt("'" + args.trim() + "' is not a valid amount.");
+                return;
+            }
+            BankTransactionResult result = context.bankService().withdraw(player, amount);
+            if (result.success()) {
+                session.replacePlayer(result.updatedPlayer());
+            }
+            writeLineWithPrompt(result.message());
         }
 
         private void handlePartyForm(Player player, PartyService partyService) {

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -322,4 +322,32 @@ public interface SocketCommandContext extends Client {
      */
     default void unlockExit(Direction direction) {}
 
+    /**
+     * Deposits the specified amount of gold from the player's carried balance into the bank.
+     *
+     * <p>Requires the player to be in the same room as a bank NPC.
+     * Fails with a clear message if no bank is present, the amount is invalid,
+     * or the player does not carry enough gold.
+     *
+     * <p>The default implementation is a no-op so that existing test stubs
+     * do not need to be updated.
+     *
+     * @param args the raw amount string (e.g. {@code "100"})
+     */
+    default void depositToBank(String args) {}
+
+    /**
+     * Withdraws the specified amount of gold from the bank into the player's carried balance.
+     *
+     * <p>Requires the player to be in the same room as a bank NPC.
+     * Fails with a clear message if no bank is present, the amount is invalid,
+     * or the bank does not hold enough gold for this player.
+     *
+     * <p>The default implementation is a no-op so that existing test stubs
+     * do not need to be updated.
+     *
+     * @param args the raw amount string (e.g. {@code "50"})
+     */
+    default void withdrawFromBank(String args) {}
+
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -48,6 +48,8 @@ public class SocketCommandRegistry {
         new QuestCommand(registry);
         new TrainCommand(registry);
         new PartyCommand(registry);
+        new DepositCommand(registry);
+        new WithdrawCommand(registry);
         new LockCommand(registry);
         new UnlockCommand(registry);
         new QuitCommand(registry);

--- a/src/main/java/io/taanielo/jmud/core/server/socket/WithdrawCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/WithdrawCommand.java
@@ -1,0 +1,40 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the {@code WITHDRAW <amount>} command, moving gold from the bank to carried balance.
+ */
+public class WithdrawCommand extends RegistrableCommand {
+
+    public WithdrawCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "withdraw";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Withdraw gold from the bank into your pocket.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: WITHDRAW <amount>\n"
+             + "  Moves the specified amount of gold from the bank to your carried balance.\n"
+             + "  Requires a bank NPC in the room.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"WITHDRAW".equals(parts[0])) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> context.withdrawFromBank(args)));
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/bank/BankServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/bank/BankServiceTest.java
@@ -1,0 +1,207 @@
+package io.taanielo.jmud.core.bank;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * Unit tests for {@link BankService}.
+ *
+ * <p>All tests run without networking or file I/O — the repository is stubbed in-memory.
+ */
+class BankServiceTest {
+
+    private static final RoomId BANK_ROOM = RoomId.of("courtyard");
+    private static final RoomId OTHER_ROOM = RoomId.of("training-yard");
+
+    private static final Bank BANK = new Bank(
+        BankId.of("town-bank"), "Aldric the Banker", BANK_ROOM);
+
+    private BankService bankService;
+
+    @BeforeEach
+    void setUp() {
+        bankService = new BankService(new StubBankRepository(BANK));
+    }
+
+    // ── findBankInRoom ─────────────────────────────────────────────────
+
+    @Test
+    void findBankInRoom_returnsBank_whenPresent() {
+        Optional<Bank> result = bankService.findBankInRoom(BANK_ROOM);
+        assertTrue(result.isPresent());
+        assertEquals("Aldric the Banker", result.get().name());
+    }
+
+    @Test
+    void findBankInRoom_returnsEmpty_whenNoBankInRoom() {
+        Optional<Bank> result = bankService.findBankInRoom(OTHER_ROOM);
+        assertTrue(result.isEmpty());
+    }
+
+    // ── deposit ───────────────────────────────────────────────────────
+
+    @Test
+    void deposit_success_movesGoldFromCarriedToBanked() {
+        Player player = playerWithGold(100, 0);
+        BankTransactionResult result = bankService.deposit(player, 60);
+
+        assertTrue(result.success());
+        assertNotNull(result.updatedPlayer());
+        assertEquals(40, result.updatedPlayer().getGold(), "carried gold should decrease by deposit amount");
+        assertEquals(60, result.updatedPlayer().getBankedGold(), "banked gold should increase by deposit amount");
+    }
+
+    @Test
+    void deposit_success_addsToExistingBankedGold() {
+        Player player = playerWithGold(50, 200);
+        BankTransactionResult result = bankService.deposit(player, 50);
+
+        assertTrue(result.success());
+        assertEquals(0, result.updatedPlayer().getGold());
+        assertEquals(250, result.updatedPlayer().getBankedGold());
+    }
+
+    @Test
+    void deposit_failure_insufficientCarriedGold() {
+        Player player = playerWithGold(30, 0);
+        BankTransactionResult result = bankService.deposit(player, 50);
+
+        assertFalse(result.success());
+        assertNull(result.updatedPlayer());
+        assertTrue(result.message().contains("30"), "message should mention current balance");
+    }
+
+    @Test
+    void deposit_failure_zeroAmount() {
+        Player player = playerWithGold(100, 0);
+        BankTransactionResult result = bankService.deposit(player, 0);
+
+        assertFalse(result.success());
+        assertNull(result.updatedPlayer());
+    }
+
+    @Test
+    void deposit_failure_negativeAmount() {
+        Player player = playerWithGold(100, 0);
+        BankTransactionResult result = bankService.deposit(player, -10);
+
+        assertFalse(result.success());
+        assertNull(result.updatedPlayer());
+    }
+
+    // ── withdraw ──────────────────────────────────────────────────────
+
+    @Test
+    void withdraw_success_movesGoldFromBankedToCarried() {
+        Player player = playerWithGold(0, 200);
+        BankTransactionResult result = bankService.withdraw(player, 75);
+
+        assertTrue(result.success());
+        assertNotNull(result.updatedPlayer());
+        assertEquals(75, result.updatedPlayer().getGold(), "carried gold should increase by withdraw amount");
+        assertEquals(125, result.updatedPlayer().getBankedGold(), "banked gold should decrease by withdraw amount");
+    }
+
+    @Test
+    void withdraw_success_addsToExistingCarriedGold() {
+        Player player = playerWithGold(50, 100);
+        BankTransactionResult result = bankService.withdraw(player, 100);
+
+        assertTrue(result.success());
+        assertEquals(150, result.updatedPlayer().getGold());
+        assertEquals(0, result.updatedPlayer().getBankedGold());
+    }
+
+    @Test
+    void withdraw_failure_insufficientBankedGold() {
+        Player player = playerWithGold(0, 20);
+        BankTransactionResult result = bankService.withdraw(player, 50);
+
+        assertFalse(result.success());
+        assertNull(result.updatedPlayer());
+        assertTrue(result.message().contains("20"), "message should mention current balance");
+    }
+
+    @Test
+    void withdraw_failure_zeroAmount() {
+        Player player = playerWithGold(0, 100);
+        BankTransactionResult result = bankService.withdraw(player, 0);
+
+        assertFalse(result.success());
+        assertNull(result.updatedPlayer());
+    }
+
+    @Test
+    void withdraw_failure_negativeAmount() {
+        Player player = playerWithGold(0, 100);
+        BankTransactionResult result = bankService.withdraw(player, -5);
+
+        assertFalse(result.success());
+        assertNull(result.updatedPlayer());
+    }
+
+    // ── gold conservation ─────────────────────────────────────────────
+
+    @Test
+    void deposit_goldTotalIsConserved() {
+        Player player = playerWithGold(100, 50);
+        int totalBefore = player.getGold() + player.getBankedGold();
+
+        BankTransactionResult result = bankService.deposit(player, 40);
+
+        assertTrue(result.success());
+        int totalAfter = result.updatedPlayer().getGold() + result.updatedPlayer().getBankedGold();
+        assertEquals(totalBefore, totalAfter, "no gold should be created or destroyed on deposit");
+    }
+
+    @Test
+    void withdraw_goldTotalIsConserved() {
+        Player player = playerWithGold(20, 80);
+        int totalBefore = player.getGold() + player.getBankedGold();
+
+        BankTransactionResult result = bankService.withdraw(player, 30);
+
+        assertTrue(result.success());
+        int totalAfter = result.updatedPlayer().getGold() + result.updatedPlayer().getBankedGold();
+        assertEquals(totalBefore, totalAfter, "no gold should be created or destroyed on withdraw");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────
+
+    private static Player playerWithGold(int carried, int banked) {
+        User user = User.of(Username.of("testplayer"), Password.hash("pass", 1));
+        return Player.of(user, "{hp}hp>").withGold(carried).withBankedGold(banked);
+    }
+
+    // ── stub repository ───────────────────────────────────────────────
+
+    private record StubBankRepository(Bank bank) implements BankRepository {
+        @Override
+        public List<Bank> findAll() {
+            return List.of(bank);
+        }
+
+        @Override
+        public Optional<Bank> findByRoomId(RoomId roomId) {
+            if (bank.roomId().equals(roomId)) {
+                return Optional.of(bank);
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/TrainCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/TrainCommandTest.java
@@ -223,7 +223,8 @@ class TrainCommandTest {
             0,
             null,
             0L,
-            practicePoints
+            practicePoints,
+            0
         );
     }
 


### PR DESCRIPTION
Closes #159

## Summary

- Adds persistent `bankedGold` field to `Player` (defaults to 0, existing saves unaffected)
- New `core.bank` package: `Bank`, `BankId`, `BankRepository`, `BankRepositoryException`, `BankService`, `BankTransactionResult`, and `JsonBankRepository` with DTO/mapper
- `DepositCommand` and `WithdrawCommand` socket handlers registered in `SocketCommandRegistry`
- `GoldCommand` updated to display both carried and banked gold
- `data/banks/bank.town.json` defines Aldric the Banker in the Courtyard
- 12 unit tests in `BankServiceTest` covering all acceptance criteria
- `TrainCommandTest` updated for new `Player` constructor signature

## Test plan

- [ ] Build passes with `./gradlew build`
- [ ] `GOLD` command shows both carried and banked gold totals
- [ ] `DEPOSIT <amount>` transfers gold from carried to bank; error on insufficient funds or invalid amount
- [ ] `WITHDRAW <amount>` transfers gold from bank to carried; error on insufficient funds or invalid amount
- [ ] Bank balance persists across sessions (bankedGold saved with player)
- [ ] All 12 `BankServiceTest` unit tests pass

Generated with [Claude Code](https://claude.com/claude-code)