### PR TITLE
feat(shop): add sell value column to LIST command output

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -61,7 +61,7 @@
 - [x] Add CAST command as an explicit spell-use alias alongside the existing ability system
 - [x] Add mana potions with QUAFF restoring mana and add them to shops and mob loot tables
 - [x] Add BANK NPC with DEPOSIT and WITHDRAW commands for safe gold storage
-- [ ] Add item sell-value and item description visible in LIST so players can compare gear
+- [x] Add item sell-value and item description visible in LIST so players can compare gear
 - [ ] Add weapon type variety: blunt, piercing, slashing with different damage dice and attack messages
 - [ ] Add armour items (chest, legs, head slots) with AC value reducing incoming damage in combat engine
 - [ ] Add SCORE prompt stat: show current AC derived from equipped armour

--- a/src/main/java/io/taanielo/jmud/core/shop/ShopService.java
+++ b/src/main/java/io/taanielo/jmud/core/shop/ShopService.java
@@ -56,8 +56,8 @@ public class ShopService {
         Objects.requireNonNull(shop, "shop is required");
         List<String> lines = new ArrayList<>();
         lines.add(shop.name() + " — wares for sale:");
-        lines.add(String.format("  %-24s %-30s %s", "Item", "Description", "Price"));
-        lines.add("  " + "-".repeat(62));
+        lines.add(String.format("  %-24s %-30s %-10s %s", "Item", "Description", "Price", "Sell"));
+        lines.add("  " + "-".repeat(74));
         for (StockEntry entry : shop.stock()) {
             try {
                 Optional<Item> itemOpt = itemRepository.findById(entry.itemId());
@@ -67,11 +67,13 @@ public class ShopService {
                 }
                 Item item = itemOpt.get();
                 int price = entry.price() != null ? entry.price() : item.getValue();
+                int sellValue = (int) Math.floor(item.getValue() * shop.sellRatio());
                 String desc = item.getDescription();
                 if (desc.length() > 29) {
                     desc = desc.substring(0, 26) + "...";
                 }
-                lines.add(String.format("  %-24s %-30s %d gold", item.getName(), desc, price));
+                lines.add(String.format("  %-24s %-30s %-10s %d gold",
+                    item.getName(), desc, price + " gold", sellValue));
             } catch (RepositoryException e) {
                 log.warn("Failed to load item {} for shop listing: {}", entry.itemId(), e.getMessage());
             }

--- a/src/test/java/io/taanielo/jmud/core/shop/ShopServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/shop/ShopServiceTest.java
@@ -97,6 +97,54 @@ class ShopServiceTest {
         assertTrue(joined.contains("25 gold"), "Listing should show item value 25 gold for Iron Sword");
     }
 
+    @Test
+    void formatListing_showsSellColumn_inHeaderAndRows() {
+        List<String> lines = shopService.formatListing(shop);
+        // Header must contain a "Sell" label
+        assertTrue(lines.stream().anyMatch(l -> l.contains("Sell")),
+            "Listing header should include 'Sell' column");
+    }
+
+    @Test
+    void formatListing_showsCorrectSellValue_forIronSword() {
+        // Iron Sword: value=25, sellRatio=0.5 → floor(25 * 0.5) = 12
+        List<String> lines = shopService.formatListing(shop);
+        // Find the Iron Sword line and verify it ends with sell value
+        String swordLine = lines.stream()
+            .filter(l -> l.contains("Iron Sword"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Iron Sword line not found"));
+        assertTrue(swordLine.endsWith("12 gold") || swordLine.contains("12 gold"),
+            "Iron Sword sell value should be 12 gold (floor(25*0.5)): " + swordLine);
+    }
+
+    @Test
+    void formatListing_showsCorrectSellValue_forHealthPotion() {
+        // Health Potion: value=10, sellRatio=0.5 → floor(10 * 0.5) = 5
+        List<String> lines = shopService.formatListing(shop);
+        String potionLine = lines.stream()
+            .filter(l -> l.contains("Health Potion"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Health Potion line not found"));
+        assertTrue(potionLine.contains("5 gold"),
+            "Health Potion sell value should be 5 gold (floor(10*0.5)): " + potionLine);
+    }
+
+    @Test
+    void formatListing_sellValueUsesItemBaseValue_notPriceOverride() {
+        // Health Potion has price override of 8, but item.value is 10.
+        // Sell value should be based on item.value (10), not price override (8).
+        // floor(10 * 0.5) = 5
+        List<String> lines = shopService.formatListing(shop);
+        String potionLine = lines.stream()
+            .filter(l -> l.contains("Health Potion"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Health Potion line not found"));
+        // Price column shows 8 gold, sell column shows 5 gold
+        assertTrue(potionLine.contains("8 gold"), "Price column should show 8 gold: " + potionLine);
+        assertTrue(potionLine.contains("5 gold"), "Sell column should show 5 gold: " + potionLine);
+    }
+
     // ── buy ───────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

- Extended `ShopService.formatListing()` with a Sell column showing `floor(item.value * shop.sellRatio)`
- Updated header row and separator to span the new column
- Added 4 new tests in `ShopServiceTest` asserting sell column content and values

Closes #161