### PR TITLE
fix(socket): fix telnet line framing buffer over-read crash

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommand.java
@@ -2,7 +2,6 @@ package io.taanielo.jmud.core.server.socket;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
@@ -14,32 +13,6 @@ public class SocketCommand {
      * Interpret as Command
      */
     private static final int IAC = -1;
-    /**
-     * Interrupt process (user pressed Ctrl + C)
-     */
-    private static final int IP = -12;
-
-    boolean isIAC(byte[] bytes) {
-        return bytes.length > 0 && IAC == bytes[0];
-    }
-
-    boolean isIP(byte[] bytes) {
-        return bytes.length > 1 && isIAC(bytes) && bytes[1] == IP;
-    }
-
-    String readString(byte[] bytes) {
-        if (bytes.length == 0) {
-            return "";
-        }
-        int crlfPos = 0;
-        for (int i = 0; i < bytes.length; i++) {
-            if (bytes[i] == 13 && bytes[i + 1] == 10 || bytes[i] == 10) {
-                crlfPos = i;
-                break;
-            }
-        }
-        return new String(bytes, 0, crlfPos, StandardCharsets.UTF_8);
-    }
 
     void disableEcho(OutputStream output) throws IOException {
         log.debug("Disabling local echo");

--- a/src/main/java/io/taanielo/jmud/core/server/socket/TelnetClientConnection.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/TelnetClientConnection.java
@@ -13,6 +13,7 @@ import io.taanielo.jmud.core.server.connection.ClientConnection;
 public class TelnetClientConnection implements ClientConnection {
 
     private final TelnetConnection connection;
+    private TelnetLineReader lineReader;
 
     public TelnetClientConnection(java.net.Socket socket) {
         this.connection = new TelnetConnection(Objects.requireNonNull(socket, "Socket is required"));
@@ -21,23 +22,23 @@ public class TelnetClientConnection implements ClientConnection {
     @Override
     public void open() throws IOException {
         connection.open();
+        this.lineReader = new TelnetLineReader(connection.input());
     }
 
     @Override
     public String readLine() throws IOException {
         while (true) {
-            byte[] bytes = new byte[1024];
-            int read = connection.input().read(bytes);
-            if (read == -1) {
-                return null;
-            }
-            if (SocketCommand.isIAC(bytes)) {
-                if (SocketCommand.isIP(bytes)) {
+            TelnetLineReader.Result result = lineReader.readLine();
+            switch (result) {
+                case TelnetLineReader.Result.EndOfStream ignored -> {
                     return null;
                 }
-                continue;
+                case TelnetLineReader.Result.Oversized ignored ->
+                    connection.writeLine("*** Line too long; input discarded. ***");
+                case TelnetLineReader.Result.Line line -> {
+                    return line.text();
+                }
             }
-            return SocketCommand.readString(bytes);
         }
     }
 

--- a/src/main/java/io/taanielo/jmud/core/server/socket/TelnetLineReader.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/TelnetLineReader.java
@@ -1,0 +1,208 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * Assembles telnet input bytes read from an {@link InputStream} into complete,
+ * LF-terminated lines, independent of how the underlying network reads fragment
+ * or coalesce data.
+ *
+ * <p>A single {@link #readLine()} call may issue any number of underlying
+ * {@code InputStream#read} calls before a full line is available; a client that
+ * sends one byte per read (character-mode telnet) is handled identically to one
+ * that sends whole lines or several lines in a single packet.
+ *
+ * <p>Telnet IAC negotiation sequences (option negotiation and subnegotiation) are
+ * recognized and stripped from the line content in-stream. An {@code IAC IP}
+ * (Interrupt Process) sequence is treated the same as end of stream, matching the
+ * previous behavior of disconnecting on Ctrl+C.
+ *
+ * <p>Lines longer than the configured maximum are discarded (bytes are dropped
+ * until the next line feed) and reported as {@link Result.Oversized} so the caller
+ * can warn the client instead of crashing or disconnecting.
+ */
+public class TelnetLineReader {
+
+    /** Interpret As Command. */
+    private static final int IAC = 255;
+    /** Subnegotiation begin. */
+    private static final int SB = 250;
+    /** Subnegotiation end. */
+    private static final int SE = 240;
+    /** Will perform option. */
+    private static final int WILL = 251;
+    /** Won't perform option. */
+    private static final int WONT = 252;
+    /** Do perform option. */
+    private static final int DO = 253;
+    /** Don't perform option. */
+    private static final int DONT = 254;
+    /** Interrupt Process. */
+    private static final int IP = 244;
+
+    private static final int DEFAULT_MAX_LINE_LENGTH = 512;
+    private static final int SCRATCH_BUFFER_SIZE = 1024;
+
+    private enum State {
+        NORMAL,
+        IAC_SEEN,
+        NEGOTIATION_OPTION,
+        SUBNEGOTIATION,
+        SUBNEGOTIATION_IAC_SEEN
+    }
+
+    /**
+     * Outcome of assembling telnet input: a complete line, end of stream (including
+     * an Interrupt Process command), or an over-length line that was discarded.
+     */
+    public sealed interface Result {
+        /** A complete, decoded line of input. */
+        record Line(String text) implements Result {}
+
+        /** The stream ended, or the client sent Interrupt Process (Ctrl+C). */
+        record EndOfStream() implements Result {}
+
+        /** A line exceeded the configured maximum length and was discarded. */
+        record Oversized() implements Result {}
+    }
+
+    private final InputStream input;
+    private final int maxLineLength;
+    private final byte[] scratch = new byte[SCRATCH_BUFFER_SIZE];
+    private final ByteArrayOutputStream lineBuffer = new ByteArrayOutputStream();
+
+    private State state = State.NORMAL;
+    private boolean oversized;
+    private int scratchPosition;
+    private int scratchLength;
+
+    /**
+     * Creates a reader with the default maximum line length (512 bytes).
+     */
+    public TelnetLineReader(InputStream input) {
+        this(input, DEFAULT_MAX_LINE_LENGTH);
+    }
+
+    /**
+     * Creates a reader with an explicit maximum line length.
+     */
+    public TelnetLineReader(InputStream input, int maxLineLength) {
+        this.input = Objects.requireNonNull(input, "Input stream is required");
+        if (maxLineLength <= 0) {
+            throw new IllegalArgumentException("Max line length must be positive");
+        }
+        this.maxLineLength = maxLineLength;
+    }
+
+    /**
+     * Blocks until a full line has been assembled, the stream ends, or an
+     * Interrupt Process command is received.
+     *
+     * @throws IOException if the underlying stream read fails
+     */
+    public Result readLine() throws IOException {
+        while (true) {
+            if (scratchPosition >= scratchLength) {
+                int n = input.read(scratch);
+                if (n == -1) {
+                    return new Result.EndOfStream();
+                }
+                scratchPosition = 0;
+                scratchLength = n;
+            }
+            while (scratchPosition < scratchLength) {
+                Result result = consume(scratch[scratchPosition++]);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+    }
+
+    private Result consume(byte rawByte) {
+        int value = rawByte & 0xFF;
+        return switch (state) {
+            case NORMAL -> consumeNormal(value);
+            case IAC_SEEN -> consumeIacSeen(value);
+            case NEGOTIATION_OPTION -> {
+                // Option byte of WILL/WONT/DO/DONT consumed; we do not reply.
+                state = State.NORMAL;
+                yield null;
+            }
+            case SUBNEGOTIATION -> {
+                if (value == IAC) {
+                    state = State.SUBNEGOTIATION_IAC_SEEN;
+                }
+                yield null;
+            }
+            case SUBNEGOTIATION_IAC_SEEN -> {
+                state = value == SE ? State.NORMAL : State.SUBNEGOTIATION;
+                yield null;
+            }
+        };
+    }
+
+    private Result consumeNormal(int value) {
+        if (value == IAC) {
+            state = State.IAC_SEEN;
+            return null;
+        }
+        if (value == '\n') {
+            return emitLine();
+        }
+        appendToLine(value);
+        return null;
+    }
+
+    private Result consumeIacSeen(int value) {
+        state = State.NORMAL;
+        if (value == IP) {
+            return new Result.EndOfStream();
+        }
+        if (value == WILL || value == WONT || value == DO || value == DONT) {
+            state = State.NEGOTIATION_OPTION;
+            return null;
+        }
+        if (value == SB) {
+            state = State.SUBNEGOTIATION;
+            return null;
+        }
+        if (value == IAC) {
+            // Escaped 0xFF data byte.
+            appendToLine(value);
+            return null;
+        }
+        // Other two-byte IAC commands (NOP, AYT, DM, ...) carry no line data.
+        return null;
+    }
+
+    private void appendToLine(int value) {
+        if (oversized) {
+            return;
+        }
+        if (lineBuffer.size() >= maxLineLength) {
+            oversized = true;
+            return;
+        }
+        lineBuffer.write(value);
+    }
+
+    private Result emitLine() {
+        byte[] bytes = lineBuffer.toByteArray();
+        lineBuffer.reset();
+        boolean wasOversized = oversized;
+        oversized = false;
+        if (wasOversized) {
+            return new Result.Oversized();
+        }
+        int length = bytes.length;
+        if (length > 0 && bytes[length - 1] == '\r') {
+            length--;
+        }
+        return new Result.Line(new String(bytes, 0, length, StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/TelnetLineReaderTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/TelnetLineReaderTest.java
@@ -1,0 +1,212 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link TelnetLineReader} assembles correct lines regardless of how the
+ * underlying transport fragments or coalesces bytes across reads, and that it
+ * strips telnet IAC sequences and enforces the maximum line length.
+ */
+class TelnetLineReaderTest {
+
+    @Test
+    void oneLineInOneRead() throws IOException {
+        TelnetLineReader reader = readerFor(chunk("look\n"));
+
+        TelnetLineReader.Result result = reader.readLine();
+
+        assertLine("look", result);
+    }
+
+    @Test
+    void lineDeliveredByteByByte() throws IOException {
+        TelnetLineReader reader = readerFor(byteByByte("say hi\n"));
+
+        TelnetLineReader.Result result = reader.readLine();
+
+        assertLine("say hi", result);
+    }
+
+    @Test
+    void twoLinesCoalescedInOneRead() throws IOException {
+        TelnetLineReader reader = readerFor(chunk("north\nsouth\n"));
+
+        assertLine("north", reader.readLine());
+        assertLine("south", reader.readLine());
+    }
+
+    @Test
+    void carriageReturnAsLastByteOfOneReadWithLineFeedInNext() throws IOException {
+        TelnetLineReader reader = readerFor(chunk("look\r"), chunk("\n"));
+
+        TelnetLineReader.Result result = reader.readLine();
+
+        assertLine("look", result);
+    }
+
+    @Test
+    void iacNegotiationInterleavedMidLine() throws IOException {
+        // IAC WILL ECHO (255, 251, 1) spliced into the middle of a command line.
+        byte[] withNegotiation = concat(
+            "lo".getBytes(StandardCharsets.UTF_8),
+            new byte[] {(byte) 255, (byte) 251, 1},
+            "ok\n".getBytes(StandardCharsets.UTF_8)
+        );
+        TelnetLineReader reader = readerFor(withNegotiation);
+
+        TelnetLineReader.Result result = reader.readLine();
+
+        assertLine("look", result);
+    }
+
+    @Test
+    void iacSubnegotiationIsSkipped() throws IOException {
+        // IAC SB NAWS ... IAC SE spliced mid-line.
+        byte[] withSubnegotiation = concat(
+            "lo".getBytes(StandardCharsets.UTF_8),
+            new byte[] {(byte) 255, (byte) 250, 31, 0, 80, 0, 24, (byte) 255, (byte) 240},
+            "ok\n".getBytes(StandardCharsets.UTF_8)
+        );
+        TelnetLineReader reader = readerFor(withSubnegotiation);
+
+        TelnetLineReader.Result result = reader.readLine();
+
+        assertLine("look", result);
+    }
+
+    @Test
+    void interruptProcessEndsLikeEndOfStream() throws IOException {
+        TelnetLineReader reader = readerFor(new byte[] {(byte) 255, (byte) 244});
+
+        TelnetLineReader.Result result = reader.readLine();
+
+        assertInstanceOf(TelnetLineReader.Result.EndOfStream.class, result);
+    }
+
+    @Test
+    void endOfStreamReturnsEndOfStreamResult() throws IOException {
+        TelnetLineReader reader = readerFor();
+
+        TelnetLineReader.Result result = reader.readLine();
+
+        assertInstanceOf(TelnetLineReader.Result.EndOfStream.class, result);
+    }
+
+    @Test
+    void overLengthLineIsDiscardedAndReported() throws IOException {
+        String longLine = "a".repeat(600) + "\n";
+        TelnetLineReader reader = new TelnetLineReader(new ByteArrayInputStream(
+            longLine.getBytes(StandardCharsets.UTF_8)), 16);
+
+        TelnetLineReader.Result result = reader.readLine();
+
+        assertInstanceOf(TelnetLineReader.Result.Oversized.class, result);
+    }
+
+    @Test
+    void readerRecoversAfterOverLengthLine() throws IOException {
+        String input = "a".repeat(600) + "\nlook\n";
+        TelnetLineReader reader = new TelnetLineReader(new ByteArrayInputStream(
+            input.getBytes(StandardCharsets.UTF_8)), 16);
+
+        assertInstanceOf(TelnetLineReader.Result.Oversized.class, reader.readLine());
+        assertLine("look", reader.readLine());
+    }
+
+    @Test
+    void utf8MultiByteCharacterSplitAcrossTwoReads() throws IOException {
+        // "café\n" - the 'é' (U+00E9) is 2 bytes in UTF-8: 0xC3 0xA9.
+        byte[] full = "café\n".getBytes(StandardCharsets.UTF_8);
+        // Split so the multi-byte character straddles two reads.
+        int splitPoint = full.length - 2;
+        byte[] first = new byte[splitPoint + 1];
+        System.arraycopy(full, 0, first, 0, splitPoint + 1);
+        byte[] second = new byte[full.length - first.length];
+        System.arraycopy(full, first.length, second, 0, second.length);
+
+        TelnetLineReader reader = readerFor(first, second);
+
+        TelnetLineReader.Result result = reader.readLine();
+
+        assertLine("café", result);
+    }
+
+    private static void assertLine(String expected, TelnetLineReader.Result result) {
+        assertInstanceOf(TelnetLineReader.Result.Line.class, result);
+        assertEquals(expected, ((TelnetLineReader.Result.Line) result).text());
+    }
+
+    private static byte[] chunk(String text) {
+        return text.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static List<byte[]> byteByByte(String text) {
+        List<byte[]> chunks = new ArrayList<>();
+        for (byte b : text.getBytes(StandardCharsets.UTF_8)) {
+            chunks.add(new byte[] {b});
+        }
+        return chunks;
+    }
+
+    private static byte[] concat(byte[]... parts) {
+        int total = 0;
+        for (byte[] part : parts) {
+            total += part.length;
+        }
+        byte[] result = new byte[total];
+        int offset = 0;
+        for (byte[] part : parts) {
+            System.arraycopy(part, 0, result, offset, part.length);
+            offset += part.length;
+        }
+        return result;
+    }
+
+    private static TelnetLineReader readerFor(byte[]... chunks) {
+        return new TelnetLineReader(new ChunkedInputStream(List.of(chunks)));
+    }
+
+    private static TelnetLineReader readerFor(List<byte[]> chunks) {
+        return new TelnetLineReader(new ChunkedInputStream(chunks));
+    }
+
+    /**
+     * An {@link InputStream} that returns exactly one supplied chunk per {@code read} call,
+     * simulating arbitrary fragmentation or coalescing of network reads.
+     */
+    private static final class ChunkedInputStream extends InputStream {
+        private final Deque<byte[]> chunks;
+
+        ChunkedInputStream(List<byte[]> chunks) {
+            this.chunks = new ArrayDeque<>(chunks);
+        }
+
+        @Override
+        public int read() {
+            throw new UnsupportedOperationException("Not used by TelnetLineReader");
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) {
+            if (chunks.isEmpty()) {
+                return -1;
+            }
+            byte[] next = chunks.poll();
+            int count = Math.min(len, next.length);
+            System.arraycopy(next, 0, b, off, count);
+            return count;
+        }
+    }
+}


### PR DESCRIPTION
Closes #168

Adds a proper per-connection telnet line reader (`TelnetLineReader`) that buffers bytes across reads, strips IAC negotiation sequences in-stream, enforces a max line length, and correctly handles character-mode telnet clients. Rewires `TelnetClientConnection.readLine()` to use it and removes the broken buffer-scanning logic from `SocketCommand.readString()`.

Includes `TelnetLineReaderTest` covering fragmentation, coalescing, IAC negotiation, oversized lines, and UTF-8 splitting.

Build and smoke test both passed (488 tests, 0 failures).