### PR TITLE
feat(server): add orderly shutdown coordinator

### DIFF
--- a/src/main/java/io/taanielo/jmud/Main.java
+++ b/src/main/java/io/taanielo/jmud/Main.java
@@ -1,5 +1,7 @@
 package io.taanielo.jmud;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import lombok.extern.slf4j.Slf4j;
@@ -8,6 +10,7 @@ import io.taanielo.jmud.core.server.ClientPool;
 import io.taanielo.jmud.core.server.Server;
 import io.taanielo.jmud.core.server.socket.DefaultClientPool;
 import io.taanielo.jmud.core.server.socket.GameContext;
+import io.taanielo.jmud.core.server.socket.ShutdownCoordinator;
 import io.taanielo.jmud.core.server.socket.SocketServer;
 import io.taanielo.jmud.core.server.ssh.SshServer;
 
@@ -23,13 +26,27 @@ public class Main {
         ClientPool clientPool = new DefaultClientPool();
         GameContext context = GameContext.create();
         context.tickScheduler().start();
-        Runtime.getRuntime().addShutdownHook(Thread.ofVirtual().name("jmud-shutdown").unstarted(() -> {
-            context.tickScheduler().stop();
-            context.tickRegistry().clear();
-        }));
 
         Server telnetServer = telnetEnabled ? new SocketServer(telnetHost, telnetPort, context, clientPool) : null;
         Server sshServer = new SshServer(sshHost, sshPort, context, clientPool);
+        List<Server> servers = new ArrayList<>();
+        if (telnetServer != null) {
+            servers.add(telnetServer);
+        }
+        servers.add(sshServer);
+
+        ShutdownCoordinator shutdownCoordinator = new ShutdownCoordinator(
+            servers,
+            clientPool,
+            context.tickScheduler(),
+            context.tickRegistry(),
+            context.playerRepository(),
+            context.auditService()
+        );
+        Runtime.getRuntime().addShutdownHook(
+            Thread.ofVirtual().name("jmud-shutdown").unstarted(shutdownCoordinator::shutdown)
+        );
+
         log.info("Starting servers ..");
         if (telnetEnabled && !isLoopbackHost(telnetHost)) {
             log.warn("Telnet is enabled on non-loopback host {}. Telnet is unencrypted.", telnetHost);

--- a/src/main/java/io/taanielo/jmud/core/audit/AsyncAuditSink.java
+++ b/src/main/java/io/taanielo/jmud/core/audit/AsyncAuditSink.java
@@ -1,5 +1,6 @@
 package io.taanielo.jmud.core.audit;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -42,6 +43,48 @@ public class AsyncAuditSink implements AuditSink {
             return;
         }
         worker.interrupt();
+    }
+
+    /**
+     * Blocks (up to {@code timeout}) while the background worker drains the
+     * queue, without stopping the worker. Call {@link #close()} afterward to
+     * stop the worker thread and release the delegate sink.
+     *
+     * @param timeout the maximum time to wait for the queue to drain
+     * @return true if the queue was empty before the timeout elapsed
+     */
+    @Override
+    public boolean flush(Duration timeout) {
+        Objects.requireNonNull(timeout, "Timeout is required");
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        while (!queue.isEmpty()) {
+            if (System.nanoTime() >= deadlineNanos) {
+                log.warn("Audit queue flush timed out with {} entries remaining", queue.size());
+                return false;
+            }
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return queue.isEmpty();
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Stops the background worker and closes the delegate sink. Safe to call
+     * multiple times.
+     */
+    @Override
+    public void close() {
+        stop();
+        try {
+            worker.join(Duration.ofSeconds(2).toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        delegate.close();
     }
 
     private void drainQueue() {

--- a/src/main/java/io/taanielo/jmud/core/audit/AuditService.java
+++ b/src/main/java/io/taanielo/jmud/core/audit/AuditService.java
@@ -2,6 +2,7 @@ package io.taanielo.jmud.core.audit;
 
 import java.nio.file.Path;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -9,6 +10,9 @@ import java.util.UUID;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class AuditService {
     public static final int SCHEMA_VERSION = 1;
 
@@ -64,6 +68,21 @@ public class AuditService {
 
     public String newCorrelationId() {
         return correlationSupplier.get();
+    }
+
+    /**
+     * Drains any buffered audit entries (bounded by {@code timeout}) and closes
+     * the underlying sink. Intended for use during orderly shutdown, after the
+     * tick scheduler has stopped, so no further events are emitted concurrently.
+     *
+     * @param timeout the maximum time to wait for buffered entries to flush
+     */
+    public void shutdown(Duration timeout) {
+        boolean drained = sink.flush(timeout);
+        if (!drained) {
+            log.warn("Audit sink did not fully drain within {} before shutdown", timeout);
+        }
+        sink.close();
     }
 
     private String normalizeCorrelationId(String correlationId) {

--- a/src/main/java/io/taanielo/jmud/core/audit/AuditSink.java
+++ b/src/main/java/io/taanielo/jmud/core/audit/AuditSink.java
@@ -1,5 +1,26 @@
 package io.taanielo.jmud.core.audit;
 
+import java.time.Duration;
+
 public interface AuditSink {
     void write(AuditEntry entry);
+
+    /**
+     * Blocks (up to {@code timeout}) until any buffered entries have been handed
+     * off to the underlying storage. Sinks with no internal buffering can rely on
+     * the default no-op.
+     *
+     * @param timeout the maximum time to wait for buffered entries to drain
+     * @return true if the sink was fully drained before the timeout elapsed
+     */
+    default boolean flush(Duration timeout) {
+        return true;
+    }
+
+    /**
+     * Releases any resources (file handles, worker threads) held by this sink.
+     * Safe to call multiple times.
+     */
+    default void close() {
+    }
 }

--- a/src/main/java/io/taanielo/jmud/core/audit/JsonlFileAuditSink.java
+++ b/src/main/java/io/taanielo/jmud/core/audit/JsonlFileAuditSink.java
@@ -71,6 +71,14 @@ public class JsonlFileAuditSink implements AuditSink {
         return parent == null ? Path.of(dated) : parent.resolve(dated);
     }
 
+    /**
+     * Closes the underlying file writer, if open. Safe to call multiple times.
+     */
+    @Override
+    public synchronized void close() {
+        closeWriter();
+    }
+
     private void closeWriter() {
         if (writer == null) {
             return;

--- a/src/main/java/io/taanielo/jmud/core/messaging/SystemNoticeMessage.java
+++ b/src/main/java/io/taanielo/jmud/core/messaging/SystemNoticeMessage.java
@@ -1,0 +1,21 @@
+package io.taanielo.jmud.core.messaging;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Plain-text operational announcement (e.g. an impending server shutdown),
+ * sent with no ANSI styling so it renders identically for every client.
+ */
+public record SystemNoticeMessage(String text) implements Message {
+
+    public SystemNoticeMessage {
+        Objects.requireNonNull(text, "Text is required");
+    }
+
+    @Override
+    public void send(MessageWriter messageWriter) throws IOException {
+        messageWriter.writeLine();
+        messageWriter.writeLine(text);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/Client.java
+++ b/src/main/java/io/taanielo/jmud/core/server/Client.java
@@ -1,10 +1,25 @@
 package io.taanielo.jmud.core.server;
 
+import java.util.Optional;
+
 import io.taanielo.jmud.core.messaging.Message;
+import io.taanielo.jmud.core.player.Player;
 
 public interface Client extends Runnable {
 
     void sendMessage(Message message);
 
     void close();
+
+    /**
+     * Returns the player currently authenticated on this client, if any.
+     *
+     * <p>Used by administrative flows (e.g. orderly shutdown) that need to
+     * enumerate online players without depending on transport internals.
+     * Defaults to {@link Optional#empty()} so existing/simple implementations
+     * are unaffected.
+     */
+    default Optional<Player> currentPlayer() {
+        return Optional.empty();
+    }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/Server.java
+++ b/src/main/java/io/taanielo/jmud/core/server/Server.java
@@ -2,4 +2,12 @@ package io.taanielo.jmud.core.server;
 
 public interface Server extends Runnable {
 
+    /**
+     * Stops accepting new connections and releases listening resources.
+     *
+     * <p>Safe to call from a thread other than the one running {@link #run()};
+     * implementations must cause any blocking accept loop in {@link #run()} to
+     * return promptly. Idempotent.
+     */
+    void stop();
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinator.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinator.java
@@ -1,0 +1,133 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.taanielo.jmud.core.audit.AuditService;
+import io.taanielo.jmud.core.messaging.SystemNoticeMessage;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.server.ClientPool;
+import io.taanielo.jmud.core.server.Server;
+import io.taanielo.jmud.core.tick.FixedRateTickScheduler;
+import io.taanielo.jmud.core.tick.TickRegistry;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+
+/**
+ * Executes the server's orderly shutdown sequence: stop accepting new
+ * connections, notify connected clients, stop the tick scheduler, save every
+ * online player, flush and close the audit sink, and clear tick registrations.
+ *
+ * <p>The whole sequence runs synchronously on the calling thread (the JVM
+ * shutdown-hook thread) and is bounded, so a {@code SIGTERM} does not force a
+ * container/systemd stop to kill the process mid-save. Once the tick
+ * scheduler has stopped, no tick thread exists, so subsequent state reads are
+ * race-free.
+ */
+@Slf4j
+public class ShutdownCoordinator {
+
+    private static final Duration DEFAULT_AUDIT_FLUSH_TIMEOUT = Duration.ofSeconds(2);
+
+    private final List<Server> servers;
+    private final ClientPool clientPool;
+    private final FixedRateTickScheduler tickScheduler;
+    private final TickRegistry tickRegistry;
+    private final PlayerRepository playerRepository;
+    private final AuditService auditService;
+    private final Duration auditFlushTimeout;
+
+    public ShutdownCoordinator(
+        List<Server> servers,
+        ClientPool clientPool,
+        FixedRateTickScheduler tickScheduler,
+        TickRegistry tickRegistry,
+        PlayerRepository playerRepository,
+        AuditService auditService
+    ) {
+        this(servers, clientPool, tickScheduler, tickRegistry, playerRepository, auditService, DEFAULT_AUDIT_FLUSH_TIMEOUT);
+    }
+
+    public ShutdownCoordinator(
+        List<Server> servers,
+        ClientPool clientPool,
+        FixedRateTickScheduler tickScheduler,
+        TickRegistry tickRegistry,
+        PlayerRepository playerRepository,
+        AuditService auditService,
+        Duration auditFlushTimeout
+    ) {
+        this.servers = List.copyOf(Objects.requireNonNull(servers, "Servers are required"));
+        this.clientPool = Objects.requireNonNull(clientPool, "Client pool is required");
+        this.tickScheduler = Objects.requireNonNull(tickScheduler, "Tick scheduler is required");
+        this.tickRegistry = Objects.requireNonNull(tickRegistry, "Tick registry is required");
+        this.playerRepository = Objects.requireNonNull(playerRepository, "Player repository is required");
+        this.auditService = Objects.requireNonNull(auditService, "Audit service is required");
+        this.auditFlushTimeout = Objects.requireNonNull(auditFlushTimeout, "Audit flush timeout is required");
+    }
+
+    /**
+     * Runs the shutdown sequence in order: stop accepting, notify clients,
+     * stop ticks, save online players, flush audit, clear tick registrations.
+     * A failure for one step or one player must not prevent the remaining
+     * steps/players from being processed.
+     */
+    public void shutdown() {
+        log.info("Shutdown sequence starting");
+        stopAccepting();
+        notifyClientsOfShutdown();
+        stopTickScheduler();
+        saveOnlinePlayers();
+        flushAudit();
+        tickRegistry.clear();
+        log.info("Shutdown sequence complete");
+    }
+
+    private void stopAccepting() {
+        for (Server server : servers) {
+            try {
+                server.stop();
+            } catch (RuntimeException e) {
+                log.warn("Failed to stop server {}", server, e);
+            }
+        }
+    }
+
+    private void notifyClientsOfShutdown() {
+        SystemNoticeMessage notice = new SystemNoticeMessage("Server is shutting down.");
+        for (Client client : clientPool.clients()) {
+            try {
+                client.sendMessage(notice);
+            } catch (RuntimeException e) {
+                log.warn("Failed to notify client of shutdown", e);
+            }
+        }
+    }
+
+    private void stopTickScheduler() {
+        tickScheduler.stop();
+    }
+
+    private void saveOnlinePlayers() {
+        for (Client client : clientPool.clients()) {
+            client.currentPlayer().ifPresent(this::saveOrLog);
+        }
+    }
+
+    private void saveOrLog(Player player) {
+        try {
+            playerRepository.savePlayer(player);
+            log.info("Saved player {} during shutdown", player.getUsername());
+        } catch (RepositoryException e) {
+            log.error("Failed to save player {} during shutdown", player.getUsername(), e);
+        }
+    }
+
+    private void flushAudit() {
+        auditService.shutdown(auditFlushTimeout);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -214,6 +214,11 @@ public class SocketClient implements Client {
         sendPrompt();
     }
 
+    @Override
+    public Optional<Player> currentPlayer() {
+        return session.isAuthenticated() ? Optional.ofNullable(session.getPlayer()) : Optional.empty();
+    }
+
     public void sendMessage(UserSayMessage message) {
         Player player = session.getPlayer();
         if (player != null && message.getUsername().equals(player.getUsername())) {

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketServer.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketServer.java
@@ -5,6 +5,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,6 +20,8 @@ public class SocketServer implements Server {
 
     private final ClientPool clientPool;
     private final GameContext context;
+    private final AtomicBoolean stopping = new AtomicBoolean(false);
+    private volatile ServerSocket serverSocket;
 
     public SocketServer(String host, int port, GameContext context, ClientPool clientPool) {
         this.host = Objects.requireNonNull(host, "Host is required");
@@ -33,6 +36,7 @@ public class SocketServer implements Server {
 
         try (ServerSocket server = new ServerSocket()) {
             server.bind(new InetSocketAddress(host, port));
+            serverSocket = server;
             //noinspection InfiniteLoopStatement
             while (true) {
                 Socket clientSocket = server.accept();
@@ -56,8 +60,28 @@ public class SocketServer implements Server {
                 clientPool.add(client);
             }
         } catch (IOException e) {
-            log.error("Server error", e);
+            if (stopping.get()) {
+                log.info("Telnet server stopped accepting connections.");
+            } else {
+                log.error("Server error", e);
+            }
+        } finally {
+            serverSocket = null;
         }
+    }
 
+    @Override
+    public void stop() {
+        if (!stopping.compareAndSet(false, true)) {
+            return;
+        }
+        ServerSocket server = serverSocket;
+        if (server != null) {
+            try {
+                server.close();
+            } catch (IOException e) {
+                log.warn("Error closing telnet server socket", e);
+            }
+        }
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/ssh/SshServer.java
+++ b/src/main/java/io/taanielo/jmud/core/server/ssh/SshServer.java
@@ -7,6 +7,7 @@ import java.security.Security;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -39,6 +40,9 @@ public class SshServer implements Server {
     private final String host;
     private final GameContext context;
     private final ClientPool clientPool;
+    private final AtomicBoolean stopRequested = new AtomicBoolean(false);
+    private volatile org.apache.sshd.server.SshServer sshdServer;
+    private volatile Thread runningThread;
 
     public SshServer(String host, int port, GameContext context, ClientPool clientPool) {
         this.host = Objects.requireNonNull(host, "Host is required");
@@ -51,6 +55,7 @@ public class SshServer implements Server {
     public void run() {
         ensureSecurityProviders();
         log.debug("Starting SSH server @ port {}", port);
+        runningThread = Thread.currentThread();
         org.apache.sshd.server.SshServer server = org.apache.sshd.server.SshServer.setUpDefaultServer();
         server.setHost(host);
         server.setPort(port);
@@ -66,7 +71,8 @@ public class SshServer implements Server {
             Files.createDirectories(hostKeyPath.getParent());
             server.setKeyPairProvider(buildHostKeyProvider(hostKeyPath));
             server.start();
-            while (!Thread.currentThread().isInterrupted()) {
+            sshdServer = server;
+            while (!Thread.currentThread().isInterrupted() && !stopRequested.get()) {
                 Thread.sleep(1000L);
             }
         } catch (IOException e) {
@@ -79,6 +85,26 @@ public class SshServer implements Server {
             } catch (IOException e) {
                 log.error("Failed to stop SSH server", e);
             }
+            sshdServer = null;
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (!stopRequested.compareAndSet(false, true)) {
+            return;
+        }
+        org.apache.sshd.server.SshServer server = sshdServer;
+        if (server != null) {
+            try {
+                server.stop();
+            } catch (IOException e) {
+                log.warn("Error stopping SSH server", e);
+            }
+        }
+        Thread thread = runningThread;
+        if (thread != null) {
+            thread.interrupt();
         }
     }
 

--- a/src/test/java/io/taanielo/jmud/core/audit/AsyncAuditSinkTest.java
+++ b/src/test/java/io/taanielo/jmud/core/audit/AsyncAuditSinkTest.java
@@ -1,0 +1,89 @@
+package io.taanielo.jmud.core.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link AsyncAuditSink#flush(Duration)} drains queued entries to the
+ * delegate sink, and that {@link AsyncAuditSink#close()} stops the worker and
+ * closes the delegate (issue #170).
+ */
+class AsyncAuditSinkTest {
+
+    @Test
+    void flushDrainsQueuedEntriesBeforeTimeoutElapses() {
+        RecordingSink delegate = new RecordingSink();
+        AsyncAuditSink sink = new AsyncAuditSink(delegate, 100);
+
+        for (int i = 0; i < 20; i++) {
+            sink.write(entry(i));
+        }
+
+        boolean drained = sink.flush(Duration.ofSeconds(2));
+
+        assertTrue(drained, "Queue should be fully drained within the timeout");
+        assertEquals(20, delegate.entries.size(), "All written entries must reach the delegate sink");
+
+        sink.close();
+        assertTrue(delegate.closed.get(), "close() must close the delegate sink");
+    }
+
+    @Test
+    void flushReturnsFalseWhenDelegateIsTooSlow() {
+        SlowSink delegate = new SlowSink(Duration.ofMillis(500));
+        AsyncAuditSink sink = new AsyncAuditSink(delegate, 100);
+
+        sink.write(entry(1));
+        sink.write(entry(2));
+        sink.write(entry(3));
+
+        boolean drained = sink.flush(Duration.ofMillis(50));
+
+        assertTrue(!drained, "Flush must report timeout when the delegate can't keep up");
+
+        sink.close();
+    }
+
+    private static AuditEntry entry(int i) {
+        return new AuditEntry(1, System.currentTimeMillis(), "test.event", "corr-" + i, 0L, null, null, null, "success", null);
+    }
+
+    private static final class RecordingSink implements AuditSink {
+        private final List<AuditEntry> entries = new CopyOnWriteArrayList<>();
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        @Override
+        public void write(AuditEntry entry) {
+            entries.add(entry);
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+    }
+
+    private static final class SlowSink implements AuditSink {
+        private final Duration delayPerEntry;
+
+        private SlowSink(Duration delayPerEntry) {
+            this.delayPerEntry = delayPerEntry;
+        }
+
+        @Override
+        public void write(AuditEntry entry) {
+            try {
+                Thread.sleep(delayPerEntry.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinatorTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinatorTest.java
@@ -1,0 +1,240 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.audit.AuditEntry;
+import io.taanielo.jmud.core.audit.AuditService;
+import io.taanielo.jmud.core.audit.AuditSink;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.messaging.Message;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.server.ClientPool;
+import io.taanielo.jmud.core.server.Server;
+import io.taanielo.jmud.core.tick.FixedRateTickScheduler;
+import io.taanielo.jmud.core.tick.TickRegistry;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+
+/**
+ * Verifies the {@link ShutdownCoordinator} runs its steps in the mandated
+ * order (stop accepting -> notify -> stop ticks -> save players -> flush
+ * audit -> clear tick registry) and that one player's failed save does not
+ * prevent the others from being attempted (issue #170).
+ */
+class ShutdownCoordinatorTest {
+
+    @Test
+    void runsStepsInMandatedOrder() {
+        List<String> events = new ArrayList<>();
+
+        Server server = new RecordingServer(events);
+        RecordingClient onlineClient = new RecordingClient(events, "ana", true);
+        RecordingClient anonymousClient = new RecordingClient(events, null, false);
+        ClientPool clientPool = new FixedClientPool(List.of(onlineClient, anonymousClient));
+
+        TickRegistry tickRegistry = new TickRegistry() {
+            @Override
+            public void clear() {
+                events.add("tickRegistry.clear");
+                super.clear();
+            }
+        };
+        FixedRateTickScheduler tickScheduler = new FixedRateTickScheduler(
+            tickRegistry, 50, Executors.newSingleThreadScheduledExecutor()
+        ) {
+            @Override
+            public void stop() {
+                events.add("tickScheduler.stop");
+                super.stop();
+            }
+        };
+        tickScheduler.start();
+
+        RecordingPlayerRepository playerRepository = new RecordingPlayerRepository(events);
+
+        AuditService auditService = new AuditService(new AuditSink() {
+            @Override
+            public void write(AuditEntry entry) {
+            }
+        }, java.time.Clock.systemUTC(), () -> 0L, () -> "corr") {
+            @Override
+            public void shutdown(Duration timeout) {
+                events.add("auditService.shutdown");
+                super.shutdown(timeout);
+            }
+        };
+
+        ShutdownCoordinator coordinator = new ShutdownCoordinator(
+            List.of(server), clientPool, tickScheduler, tickRegistry, playerRepository, auditService, Duration.ofMillis(200)
+        );
+
+        coordinator.shutdown();
+
+        assertEquals(
+            List.of(
+                "server.stop",
+                "notify:ana",
+                "notify:anonymous",
+                "tickScheduler.stop",
+                "save:ana",
+                "auditService.shutdown",
+                "tickRegistry.clear"
+            ),
+            events
+        );
+    }
+
+    @Test
+    void onePlayersFailedSaveDoesNotPreventOthersFromSaving() {
+        List<String> events = new ArrayList<>();
+
+        RecordingClient failing = new RecordingClient(events, "grumpy", true);
+        RecordingClient healthy = new RecordingClient(events, "happy", true);
+        ClientPool clientPool = new FixedClientPool(List.of(failing, healthy));
+
+        TickRegistry tickRegistry = new TickRegistry();
+        FixedRateTickScheduler tickScheduler = new FixedRateTickScheduler(
+            tickRegistry, 50, Executors.newSingleThreadScheduledExecutor()
+        );
+        tickScheduler.start();
+
+        PlayerRepository playerRepository = new PlayerRepository() {
+            @Override
+            public void savePlayer(Player player) throws RepositoryException {
+                events.add("save:" + player.getUsername().getValue());
+                if (player.getUsername().getValue().equals("grumpy")) {
+                    throw new RepositoryException("disk full (simulated)");
+                }
+            }
+
+            @Override
+            public Optional<Player> loadPlayer(Username username) {
+                return Optional.empty();
+            }
+        };
+
+        AuditService auditService = new AuditService(new AuditSink() {
+            @Override
+            public void write(AuditEntry entry) {
+            }
+        }, java.time.Clock.systemUTC(), () -> 0L, () -> "corr");
+
+        ShutdownCoordinator coordinator = new ShutdownCoordinator(
+            List.of(), clientPool, tickScheduler, tickRegistry, playerRepository, auditService, Duration.ofMillis(200)
+        );
+
+        coordinator.shutdown();
+
+        assertTrue(events.contains("save:grumpy"), "Failing save must still be attempted");
+        assertTrue(events.contains("save:happy"), "Other players must still be saved despite one failure");
+    }
+
+    private static Player newPlayer(String username) {
+        User user = User.of(Username.of(username), Password.hash("pw", 1));
+        return Player.of(user, "%hp> ");
+    }
+
+    private static final class RecordingServer implements Server {
+        private final List<String> events;
+
+        private RecordingServer(List<String> events) {
+            this.events = events;
+        }
+
+        @Override
+        public void run() {
+        }
+
+        @Override
+        public void stop() {
+            events.add("server.stop");
+        }
+    }
+
+    private static final class RecordingClient implements Client {
+        private final List<String> events;
+        private final Optional<Player> player;
+
+        private RecordingClient(List<String> events, String username, boolean online) {
+            this.events = events;
+            this.player = online ? Optional.of(newPlayer(username)) : Optional.empty();
+        }
+
+        @Override
+        public void run() {
+        }
+
+        @Override
+        public void sendMessage(Message message) {
+            player.ifPresentOrElse(
+                p -> events.add("notify:" + p.getUsername().getValue()),
+                () -> events.add("notify:anonymous")
+            );
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public Optional<Player> currentPlayer() {
+            return player;
+        }
+    }
+
+    private static final class RecordingPlayerRepository implements PlayerRepository {
+        private final List<String> events;
+
+        private RecordingPlayerRepository(List<String> events) {
+            this.events = events;
+        }
+
+        @Override
+        public void savePlayer(Player player) throws RepositoryException {
+            events.add("save:" + player.getUsername().getValue());
+        }
+
+        @Override
+        public Optional<Player> loadPlayer(Username username) {
+            return Optional.empty();
+        }
+    }
+
+    private static final class FixedClientPool implements ClientPool {
+        private final List<Client> clients;
+
+        private FixedClientPool(List<Client> clients) {
+            this.clients = clients;
+        }
+
+        @Override
+        public void add(Client client) {
+        }
+
+        @Override
+        public void remove(Client client) {
+        }
+
+        @Override
+        public int getNextId() {
+            return 0;
+        }
+
+        @Override
+        public List<Client> clients() {
+            return clients;
+        }
+    }
+}


### PR DESCRIPTION
Closes #170

Adds `stop()` to the `Server` interface (implemented in `SocketServer` and `SshServer`) and `Client.currentPlayer()` so shutdown logic can enumerate online players without depending on transport internals. Adds a `SystemNoticeMessage` for the shutdown notice, and `flush(Duration)`/`close()` to the audit sink chain (`AuditSink`/`AsyncAuditSink`/`JsonlFileAuditSink`/`AuditService`) to drain the async queue and close the writer.

A new `ShutdownCoordinator` (in `core.server.socket`) executes the mandated shutdown order: stop accepting -> notify connected clients -> stop tick scheduler -> save every online player (per-player try/catch, one failure doesn't block others) -> flush/close audit -> clear tick registry. `Main.java`'s shutdown hook now delegates to the coordinator instead of only stopping ticks.

New tests: `ShutdownCoordinatorTest` (verifies ordering and per-player failure isolation) and `AsyncAuditSinkTest` (verifies flush drains the queue within a timeout).

Build and smoke test both passed (full suite green, 8/8 smoke checks, verified via clean rebuild).