### PR TITLE
feat(tick): detect and log tick overruns in FixedRateTickScheduler

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/tick/FixedRateTickScheduler.java
+++ b/src/main/java/io/taanielo/jmud/core/tick/FixedRateTickScheduler.java
@@ -10,6 +10,12 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Single-writer tick loop scheduler. Drains every registered {@link Tickable} at a fixed
+ * interval on one dedicated thread; player command queues, mob AI, effects and other game
+ * state mutations run here and nowhere else. Also tracks per-tick duration and overrun
+ * counters so tick health can be observed without profiling.
+ */
 @Slf4j
 public class FixedRateTickScheduler {
 
@@ -18,6 +24,10 @@ public class FixedRateTickScheduler {
     private final long intervalMillis;
     private final AtomicBoolean started = new AtomicBoolean(false);
     private final AtomicLong tickCounter = new AtomicLong();
+    private final AtomicLong overrunCount = new AtomicLong();
+    private volatile long lastTickNanos;
+    private volatile long maxTickNanos;
+    private volatile boolean previousTickOverran;
     private ScheduledFuture<?> task;
 
     public FixedRateTickScheduler(TickRegistry tickRegistry) {
@@ -64,16 +74,93 @@ public class FixedRateTickScheduler {
         log.info("Tick scheduler stopped");
     }
 
+    /**
+     * Package-private test hook that runs a single tick synchronously on the calling thread,
+     * bypassing the scheduler. Production code always goes through {@link #start()}.
+     */
+    void runTickForTest() {
+        runTick();
+    }
+
     private void runTick() {
         long tick = tickCounter.incrementAndGet();
         java.util.List<Tickable> snapshot = tickRegistry.snapshot();
         log.debug("Tick {} start ({} tickables)", tick, snapshot.size());
+        boolean traceSlowest = previousTickOverran;
+        Tickable slowest = null;
+        long slowestNanos = -1;
+
+        long startNanos = System.nanoTime();
         for (Tickable tickable : snapshot) {
+            long tickableStart = traceSlowest ? System.nanoTime() : 0L;
             try {
                 tickable.tick();
             } catch (Exception e) {
                 log.error("Tickable failed during tick", e);
             }
+            if (traceSlowest) {
+                long tickableElapsed = System.nanoTime() - tickableStart;
+                if (tickableElapsed > slowestNanos) {
+                    slowestNanos = tickableElapsed;
+                    slowest = tickable;
+                }
+            }
         }
+        long elapsedNanos = System.nanoTime() - startNanos;
+
+        lastTickNanos = elapsedNanos;
+        if (elapsedNanos > maxTickNanos) {
+            maxTickNanos = elapsedNanos;
+        }
+
+        long elapsedMs = elapsedNanos / 1_000_000L;
+        boolean overran = elapsedMs > intervalMillis;
+        if (overran) {
+            overrunCount.incrementAndGet();
+            log.warn(
+                "Tick {} overran: {} ms (budget {} ms, {} tickables)",
+                tick,
+                elapsedMs,
+                intervalMillis,
+                snapshot.size()
+            );
+        }
+        previousTickOverran = overran;
+
+        if (traceSlowest && slowest != null) {
+            log.debug(
+                "Tick {} slowest tickable: {} ({} ms)",
+                tick,
+                slowest.getClass().getName(),
+                slowestNanos / 1_000_000L
+            );
+        }
+    }
+
+    /**
+     * Number of ticks that have exceeded the configured interval budget since scheduler creation.
+     *
+     * @return the running overrun count
+     */
+    public long overrunCount() {
+        return overrunCount.get();
+    }
+
+    /**
+     * Duration of the most recently completed tick.
+     *
+     * @return elapsed nanoseconds of the last tick
+     */
+    public long lastTickDurationNanos() {
+        return lastTickNanos;
+    }
+
+    /**
+     * Longest observed tick duration since scheduler creation.
+     *
+     * @return elapsed nanoseconds of the slowest tick observed so far
+     */
+    public long maxTickDurationNanos() {
+        return maxTickNanos;
     }
 }

--- a/src/test/java/io/taanielo/jmud/core/tick/FixedRateTickSchedulerTest.java
+++ b/src/test/java/io/taanielo/jmud/core/tick/FixedRateTickSchedulerTest.java
@@ -1,10 +1,13 @@
 package io.taanielo.jmud.core.tick;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -37,5 +40,103 @@ class FixedRateTickSchedulerTest {
 
         assertTrue(completed);
         assertTrue(ticks.get() >= 3);
+    }
+
+    @Test
+    void recordsOverrunWhenTickExceedsBudget() {
+        TickRegistry registry = new TickRegistry();
+        long intervalMillis = 20;
+        registry.register(() -> {
+            try {
+                Thread.sleep(intervalMillis + 50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        FixedRateTickScheduler scheduler = new FixedRateTickScheduler(
+            registry,
+            intervalMillis,
+            new DirectScheduledExecutorService()
+        );
+
+        scheduler.runTickForTest();
+
+        assertEquals(1, scheduler.overrunCount());
+        assertTrue(scheduler.lastTickDurationNanos() >= TimeUnit.MILLISECONDS.toNanos(intervalMillis + 50));
+        assertTrue(scheduler.maxTickDurationNanos() >= scheduler.lastTickDurationNanos());
+    }
+
+    @Test
+    void doesNotRecordOverrunForFastTicks() {
+        TickRegistry registry = new TickRegistry();
+        registry.register(() -> { });
+
+        FixedRateTickScheduler scheduler = new FixedRateTickScheduler(
+            registry,
+            1000,
+            new DirectScheduledExecutorService()
+        );
+
+        scheduler.runTickForTest();
+
+        assertEquals(0, scheduler.overrunCount());
+    }
+
+    /**
+     * Minimal synchronous {@link ScheduledExecutorService} that runs submitted tasks
+     * immediately on the calling thread, giving deterministic tests without real scheduling.
+     */
+    private static final class DirectScheduledExecutorService extends AbstractExecutorService
+        implements ScheduledExecutorService {
+
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+
+        @Override
+        public void shutdown() {
+        }
+
+        @Override
+        public java.util.List<Runnable> shutdownNow() {
+            return java.util.List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return true;
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(java.util.concurrent.Callable<V> callable, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
     }
 }


### PR DESCRIPTION
Closes #171

Times each tick in `FixedRateTickScheduler.runTick()` with `System.nanoTime()`, records `lastTickNanos`/`maxTickNanos`, and increments an `AtomicLong overrunCount` with a WARN log (tick number, elapsed ms, budget ms, tickable count) when a tick exceeds its budget. New getters: `overrunCount()`, `lastTickDurationNanos()`, `maxTickDurationNanos()`. When the previous tick overran, the next tick times each individual `Tickable` and DEBUG-logs the slowest one for attribution.

No locks or blocking I/O added to the tick path — only `nanoTime()` calls and volatile/atomic writes.

## Test plan
- [x] `recordsOverrunWhenTickExceedsBudget` and `doesNotRecordOverrunForFastTicks` added to `FixedRateTickSchedulerTest`
- [x] `./gradlew build` passes
- [ ] Smoke test skipped — change has no player-visible command/output surface