### PR TITLE
ci(build): add GitHub Actions build/test gate on every PR

### DIFF
--- a/.claude/agents/pr-merger.md
+++ b/.claude/agents/pr-merger.md
@@ -9,7 +9,7 @@ You are the **PR merger** for jmud. Merge the PR that pr-creator opened. The qua
 ## Process
 1. Confirm the PR exists and is open: `gh pr view --json number,url,state,mergeable`.
    - If it is not mergeable due to conflicts, do **not** force it — write a `failure` result so the orchestrator can park it.
-2. **CI gate**: run `gh pr checks <N>`. If any checks are reported, wait for them: `gh pr checks <N> --watch --fail-fast` (give up after ~15 min → `failure` result with the failing check name). If the command reports no checks configured, the green local build is the gate — proceed.
+2. **CI gate (required)**: the repo has a GitHub Actions `build` workflow (`.github/workflows/build.yml`) that runs on every PR. Run `gh pr checks <N> --watch --fail-fast` and wait for it to finish (give up after ~15 min → `failure` result with the failing check name). Local build-verifier success is a fast pre-check only, not a substitute — do not merge on local-green alone. If the command reports no checks configured at all (e.g. workflow not yet triggered), re-check once after a short wait before falling back to local-green.
 3. Squash-merge and clean up:
    ```
    gh pr merge --squash --delete-branch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 26
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '26'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Build
+        run: ./gradlew build --no-daemon
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-reports
+          path: build/reports/tests/


### PR DESCRIPTION
Closes #172

## Summary
- New `.github/workflows/build.yml` — CI workflow triggered on `pull_request` and `push` to `main`, ref-keyed concurrency group with cancel-in-progress, steps: `actions/checkout@v7` → `actions/setup-java@v5` (temurin, Java 26, matching build.gradle) → `gradle/actions/setup-gradle@v6` → `./gradlew build --no-daemon`, then `actions/upload-artifact@v7` uploading `build/reports/tests/` on failure.
- Updated `.claude/agents/pr-merger.md` so CI success (`gh pr checks <N> --watch --fail-fast`) is now a mandatory gate before merge, not conditional — local build-verifier remains a fast pre-check only.

## Note
Branch protection on `main` requiring the "build" check could not be configured by the agent (403 from the GitHub API — insufficient token permissions). A human maintainer needs to add that manually via Settings → Branches.

## Test plan
- [x] Local `./gradlew build` passed
- [ ] Workflow gets its first real validation once this PR triggers it on GitHub