### PR TITLE
test(build): add JaCoCo coverage floors and scheduled PIT mutation testing

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,56 @@
+name: mutation
+
+# PIT mutation testing is far slower than the regular unit test suite (it recompiles and
+# re-runs tests once per surviving mutant), so it deliberately does not run on every PR/push —
+# see .github/workflows/build.yml for that gate. Instead it runs on a weekly schedule plus
+# manual dispatch, against the numeric game engines only (combat, effects, ability — see the
+# `pitest {}` block in build.gradle), and publishes a browsable HTML report as an artifact.
+
+on:
+  schedule:
+    # Every Monday at 03:00 UTC.
+    - cron: '0 3 * * 1'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 26
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '26'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Run PIT mutation testing
+        run: ./gradlew pitest --no-daemon | tee pitest-output.log
+
+      - name: Record mutation score in job summary
+        if: always()
+        run: |
+          {
+            echo "## PIT mutation testing summary"
+            echo
+            echo '```'
+            grep -E '^>>' pitest-output.log || echo "No PIT summary line found in output."
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload PIT HTML report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pitest-report
+          path: build/reports/pitest/

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 plugins {
     id 'application'
+    id 'jacoco'
     alias libs.plugins.errorprone
     alias libs.plugins.spotless
+    alias libs.plugins.pitest
 }
 
 group = 'io.taanielo'
@@ -39,6 +41,8 @@ dependencies {
     testImplementation libs.junit.jupiter
     testRuntimeOnly libs.junit.platform.launcher
     testImplementation libs.archunit.junit5
+
+    pitest libs.pitest.junit5.plugin
 }
 
 application {
@@ -47,6 +51,14 @@ application {
 
 test {
     useJUnitPlatform()
+
+    // JaCoCo's runtime agent instruments every class loaded in the forked test JVM unless told
+    // otherwise; on JDK 26 that trips over JDK-internal classes (e.g. CLDR locale providers)
+    // whose class file version is newer than the JaCoCo 0.8.x agent expects. We only care about
+    // coverage of our own code, so exclude JDK-internal packages from instrumentation.
+    jacoco {
+        excludes += ['jdk/**', 'sun/**', 'com/sun/**']
+    }
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -79,4 +91,78 @@ spotless {
         trimTrailingWhitespace()
         endWithNewline()
     }
+}
+
+jacoco {
+    toolVersion = libs.versions.jacoco.get()
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+// Coverage floors are scoped to the numeric game engines (combat, effects, ability) rather
+// than the whole codebase: these packages hold the damage/healing/stacking math that is most
+// valuable to pin down with regression tests, whereas infrastructure/adapters (sockets,
+// persistence) are better covered by the e2e smoke test (AGENTS.md #10.1) than by unit line
+// coverage. dto/ and repository/ subpackages are excluded because they are largely generated
+// data carriers and JSON-mapping glue with little branching logic worth a coverage floor.
+//
+// 0.70 is the floor mandated by issue #176. Measured line coverage on 2026-07-04 was combat
+// 73.1%, effects 72.5%, ability 71.0% (ability needed two small tests added alongside this
+// change — CooldownTrackerTest, AbilityCostTest — to clear the floor; it sat at 69.4% before
+// them). The floor is pinned at the mandated minimum rather than ratcheted up to current
+// coverage, leaving a little headroom while still guarding against regressions.
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            element = 'PACKAGE'
+            includes = [
+                'io.taanielo.jmud.core.combat.*',
+                'io.taanielo.jmud.core.effects.*',
+                'io.taanielo.jmud.core.ability.*',
+            ]
+            limit {
+                counter = 'LINE'
+                minimum = 0.70
+            }
+        }
+    }
+    afterEvaluate {
+        classDirectories.setFrom(
+            files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: ['**/dto/**', '**/repository/**'])
+            })
+        )
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification
+
+// PIT mutation testing runs only from the weekly scheduled workflow (.github/workflows/mutation.yml),
+// not on every PR: mutation testing is far slower than plain unit tests, so it is not wired into `check`.
+pitest {
+    junit5PluginVersion = libs.versions.pitestJunit5Plugin
+    pitestVersion = libs.versions.pitest
+    targetClasses.set([
+        'io.taanielo.jmud.core.combat.*',
+        'io.taanielo.jmud.core.effects.*',
+        'io.taanielo.jmud.core.ability.*',
+    ])
+    targetTests.set([
+        'io.taanielo.jmud.core.combat.*',
+        'io.taanielo.jmud.core.effects.*',
+        'io.taanielo.jmud.core.ability.*',
+    ])
+    excludedClasses.set([
+        '*.dto.*',
+        '*.repository.*',
+    ])
+    outputFormats.set(['HTML', 'XML'])
+    timestampedReports.set(false)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,10 @@ nullaway = "0.12.7"
 jspecify = "1.0.0"
 spotless = "8.8.0"
 archunit = "1.4.2"
+jacoco = "0.8.15"
+pitest = "1.19.1"
+pitestGradlePlugin = "1.19.0"
+pitestJunit5Plugin = "1.2.2"
 
 [libraries]
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
@@ -39,6 +43,8 @@ junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher
 
 archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit" }
 
+pitest-junit5-plugin = { module = "org.pitest:pitest-junit5-plugin", version.ref = "pitestJunit5Plugin" }
+
 errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "errorproneCore" }
 nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
@@ -49,3 +55,4 @@ log4j = ["log4j-api", "log4j-core", "log4j-slf4j-impl"]
 [plugins]
 errorprone = { id = "net.ltgt.errorprone", version.ref = "errorpronePlugin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+pitest = { id = "info.solidsoft.pitest", version.ref = "pitestGradlePlugin" }

--- a/src/test/java/io/taanielo/jmud/core/ability/AbilityCostTest.java
+++ b/src/test/java/io/taanielo/jmud/core/ability/AbilityCostTest.java
@@ -1,0 +1,27 @@
+package io.taanielo.jmud.core.ability;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class AbilityCostTest {
+
+    @Test
+    void storesManaAndMoveCosts() {
+        AbilityCost cost = new AbilityCost(5, 2);
+
+        assertEquals(5, cost.mana());
+        assertEquals(2, cost.move());
+    }
+
+    @Test
+    void rejectsNegativeMana() {
+        assertThrows(IllegalArgumentException.class, () -> new AbilityCost(-1, 0));
+    }
+
+    @Test
+    void rejectsNegativeMove() {
+        assertThrows(IllegalArgumentException.class, () -> new AbilityCost(0, -1));
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/ability/CooldownTrackerTest.java
+++ b/src/test/java/io/taanielo/jmud/core/ability/CooldownTrackerTest.java
@@ -1,0 +1,30 @@
+package io.taanielo.jmud.core.ability;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.tick.system.CooldownSystem;
+
+class CooldownTrackerTest {
+
+    private final CooldownSystem cooldownSystem = new CooldownSystem();
+    private final CooldownTracker tracker = new CooldownTracker(cooldownSystem);
+    private final AbilityId abilityId = AbilityId.of("kick");
+
+    @Test
+    void abilityIsNotOnCooldownBeforeBeingStarted() {
+        assertFalse(tracker.isOnCooldown(abilityId));
+        assertEquals(0, tracker.remainingTicks(abilityId));
+    }
+
+    @Test
+    void startCooldownRegistersRemainingTicks() {
+        tracker.startCooldown(abilityId, 3);
+
+        assertTrue(tracker.isOnCooldown(abilityId));
+        assertEquals(3, tracker.remainingTicks(abilityId));
+    }
+}


### PR DESCRIPTION
Closes #176

## Summary
- Adds a JaCoCo coverage floor (0.70 line coverage) scoped to the numeric game engines (`io.taanielo.jmud.core.combat`, `core.effects`, `core.ability`), wired into `check` via `jacocoTestCoverageVerification`. `dto` and `repository` subpackages are excluded as low-value generated/mapping code.
- Adds a weekly scheduled PIT mutation-testing workflow (`.github/workflows/mutation.yml`) scoped to the same three packages. Mutation testing is intentionally kept out of the main build/PR gate because it is far slower than plain unit tests — it only runs on its own schedule.
- `core.ability` measured 69.4% coverage, just under the floor. Rather than lowering the floor, two small tests (`CooldownTrackerTest`, `AbilityCostTest`) were added to bring it to 71.0%.

## Test plan
- [x] `./gradlew build` verified green, including the new JaCoCo 0.70 line-coverage floor gate on `core.combat`/`core.effects`/`core.ability`
- [x] PIT is configured but intentionally not run as part of the main build; it runs from its own weekly workflow at `.github/workflows/mutation.yml`