### PR TITLE
docs(agents): sync agent instructions with quality-gate changes

### DIFF
--- a/.claude/agents/code-writer.md
+++ b/.claude/agents/code-writer.md
@@ -31,6 +31,6 @@ You are the **code writer** for jmud. Implement exactly what the issue asks on t
 
 ## Rules
 - One logical change per cycle (AGENTS.md §11). No cross-cutting refactors.
-- Do not commit, push, or run gradle — later agents handle that.
+- Do not commit, push, or run gradle — build-verifier runs `./gradlew check` (compile, tests, static analysis, ArchUnit, coverage) next, not just `build`; write code that will pass all of it, not merely compile.
 - Never log secrets/keys/tokens.
 - On failure (e.g. requirement unclear/impossible), write `last-result.json` with `"status": "failure"` and a short reason.

--- a/.claude/commands/orchestrator.md
+++ b/.claude/commands/orchestrator.md
@@ -1,5 +1,5 @@
 ---
-description: Run one cycle of jmud's autonomous feature loop (pick issue → branch → code → build → PR → merge).
+description: Run one cycle of jmud's autonomous feature loop (pick issue → branch → code → verify with `./gradlew check` → PR → merge gated on CI).
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(./gradlew:*), Bash(gradle:*), Bash(cat:*), Bash(date:*), Bash(mkdir:*), Bash(mv:*), Bash(rm:*), Bash(test:*), Read, Write, Edit, Task
 argument-hint: (no arguments)
 ---
@@ -40,12 +40,12 @@ Run this command on a self-paced `/loop` (no fixed interval) so the next cycle s
   Whatever was picked: `gh issue edit <N> --add-assignee @me`, set `current_issue`, `stage = CREATE_BRANCH`.
 - **CREATE_BRANCH** — spawn **branch-manager** (pass issue number + title). Success → `stage = WRITE_CODE`.
 - **WRITE_CODE** — spawn **code-writer** (pass the **full issue body** — architecture issues contain a binding "How (implementation guide)" section; if `build_retries > 0`, also pass the build error from `last-result.json`). Success → `stage = VERIFY_BUILD`.
-- **VERIFY_BUILD** — spawn **build-verifier**.
+- **VERIFY_BUILD** — spawn **build-verifier**, which runs `./gradlew check` (compile, tests, static analysis, ArchUnit, coverage — the full quality-gate suite, not just `build`).
   - PASS → `build_retries = 0`, `stage = CREATE_PR`.
   - FAIL and `build_retries < 2` → `build_retries += 1`, `stage = WRITE_CODE`.
   - FAIL and `build_retries >= 2` → `gh issue create --title "blocked: <title>" --body "<scrubbed error summary>" --label bug`; append the number to `blocked_issues`; notify (PushNotification if available); `build_retries = 0`, `current_issue = null`, `stage = FIND_ISSUE`.
 - **CREATE_PR** — spawn **pr-creator**. Success → `stage = MERGE_PR`.
-- **MERGE_PR** — spawn **pr-merger**.
+- **MERGE_PR** — spawn **pr-merger**, which additionally gates on GitHub CI status (`gh pr checks --watch`) before merging — local `check` success alone is not sufficient.
   - MERGED → append `{ "issue":N, "pr":M, "merged_at":"..." }` to `cycle-log.jsonl`; `cycles_since_last_optimization += 1`; `current_issue = null`; `stage = FIND_ISSUE`. If `cycles_since_last_optimization >= 5` → spawn **workflow-optimizer**, then reset it to 0.
 
 ## Step 2 — Persist & finish


### PR DESCRIPTION
## Summary
- Updates `.claude/agents/code-writer.md` and `.claude/commands/orchestrator.md` to reflect that build-verifier runs the full `./gradlew check` suite (tests, static analysis, ArchUnit, coverage), not just `build`, and that pr-merger additionally gates merges on GitHub CI status via `gh pr checks --watch`.
- Most acceptance criteria for #177 were already satisfied by prior cycles' edits to these files; this PR is the small remaining targeted update.
- Item 5 of the issue (updating `../agent-rules/java.md` and `github.md`, which live outside this repo checkout) could not be applied from here and needs manual maintainer action outside the jmud repo.

Closes #177

## Test plan
- [x] Docs-only change (`.claude/agents/code-writer.md`, `.claude/commands/orchestrator.md`); `./gradlew check` already verified green prior to this update
- [ ] Maintainer to manually sync `../agent-rules/java.md` and `../agent-rules/github.md` outside this repo