### PR TITLE
feat(persistence): move player saves off tick thread with write-behind queue

### DIFF
--- a/src/main/java/io/taanielo/jmud/Main.java
+++ b/src/main/java/io/taanielo/jmud/Main.java
@@ -40,7 +40,7 @@ public class Main {
             clientPool,
             context.tickScheduler(),
             context.tickRegistry(),
-            context.playerRepository(),
+            context.persistenceQueue(),
             context.auditService()
         );
         Runtime.getRuntime().addShutdownHook(

--- a/src/main/java/io/taanielo/jmud/core/effects/EffectInstance.java
+++ b/src/main/java/io/taanielo/jmud/core/effects/EffectInstance.java
@@ -76,4 +76,19 @@ public class EffectInstance {
             remainingTicks -= 1;
         }
     }
+
+    /**
+     * Returns an independent copy of this instance with the same state.
+     *
+     * <p>Unlike most value objects in this codebase, {@code EffectInstance} is mutable
+     * (see {@link #tickDown()}, {@link #refresh}, {@link #stack}, {@link #replace}), so
+     * code that hands an effect list to another thread (e.g. the persistence
+     * write-behind queue) must copy each instance rather than share the live reference.
+     *
+     * @return a new, independently mutable {@code EffectInstance} with the same id,
+     *         remaining ticks, and stack count
+     */
+    public EffectInstance copy() {
+        return new EffectInstance(id, remainingTicks, stacks);
+    }
 }

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -16,19 +16,17 @@ import lombok.extern.slf4j.Slf4j;
 import io.taanielo.jmud.core.action.GameActionResult;
 import io.taanielo.jmud.core.action.GameMessage;
 import io.taanielo.jmud.core.action.PlayerEventBus;
-import io.taanielo.jmud.core.audit.AuditEvent;
-import io.taanielo.jmud.core.audit.AuditService;
-import io.taanielo.jmud.core.audit.AuditSubject;
 import io.taanielo.jmud.core.authentication.Username;
 import io.taanielo.jmud.core.combat.AttackDefinition;
 import io.taanielo.jmud.core.combat.AttackId;
-import io.taanielo.jmud.core.combat.repository.AttackRepository;
 import io.taanielo.jmud.core.combat.CombatSettings;
+import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.party.PartyService;
+import io.taanielo.jmud.core.persistence.PersistenceQueue;
 import io.taanielo.jmud.core.player.LevelUpService;
 import io.taanielo.jmud.core.player.LevelUpService.LevelUpResult;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerRepository;
-import io.taanielo.jmud.core.party.PartyService;
 import io.taanielo.jmud.core.quest.QuestKillService;
 import io.taanielo.jmud.core.tick.Tickable;
 import io.taanielo.jmud.core.world.Direction;
@@ -54,14 +52,13 @@ public class MobRegistry implements Tickable {
     private final AttackRepository attackRepository;
     private final RoomService roomService;
     private final PlayerRepository playerRepository;
+    private final PersistenceQueue persistenceQueue;
     private final PlayerEventBus playerEventBus;
     private final LevelUpService levelUpService = new LevelUpService();
     /** Optional quest kill hook; may be null when quests are disabled. */
     private QuestKillService questKillService;
     /** Optional party service for XP splitting; may be null when parties are disabled. */
     private PartyService partyService;
-    /** Optional audit service used to record save failures; may be null when auditing is disabled. */
-    private AuditService auditService;
 
     private final ConcurrentHashMap<UUID, MobInstance> instances = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Username, UUID> playerCombatTargets = new ConcurrentHashMap<>();
@@ -72,6 +69,7 @@ public class MobRegistry implements Tickable {
         AttackRepository attackRepository,
         RoomService roomService,
         PlayerRepository playerRepository,
+        PersistenceQueue persistenceQueue,
         PlayerEventBus playerEventBus
     ) {
         this.templateRepository = Objects.requireNonNull(templateRepository, "Template repository is required");
@@ -79,6 +77,7 @@ public class MobRegistry implements Tickable {
         this.attackRepository = Objects.requireNonNull(attackRepository, "Attack repository is required");
         this.roomService = Objects.requireNonNull(roomService, "Room service is required");
         this.playerRepository = Objects.requireNonNull(playerRepository, "Player repository is required");
+        this.persistenceQueue = Objects.requireNonNull(persistenceQueue, "Persistence queue is required");
         this.playerEventBus = Objects.requireNonNull(playerEventBus, "Player event bus is required");
     }
 
@@ -98,16 +97,6 @@ public class MobRegistry implements Tickable {
      */
     public void setPartyService(PartyService partyService) {
         this.partyService = partyService;
-    }
-
-    /**
-     * Registers the audit service used to record player-save failures encountered
-     * while awarding XP or applying combat damage during mob AI ticks.
-     *
-     * @param auditService the audit service; may be null to disable auditing
-     */
-    public void setAuditService(AuditService auditService) {
-        this.auditService = auditService;
     }
 
     /**
@@ -548,28 +537,15 @@ public class MobRegistry implements Tickable {
     }
 
     /**
-     * Attempts to persist the given player, logging an error and emitting an audit
-     * event on failure rather than propagating the exception into the tick loop.
+     * Hands the given player off to the write-behind persistence queue rather than
+     * saving synchronously, so a slow disk write during mob AI processing (XP/damage
+     * application) never stalls the tick thread (AGENTS.md §5). Failures (including
+     * retries) are logged and audited by the queue itself.
      *
      * @param player the player to save
      */
     private void saveOrLog(Player player) {
-        try {
-            playerRepository.savePlayer(player);
-        } catch (RepositoryException e) {
-            log.error("Failed to save player {} during mob tick processing", player.getUsername(), e);
-            if (auditService != null) {
-                auditService.emit(new AuditEvent(
-                    "player.save.failed",
-                    AuditSubject.player(player.getUsername()),
-                    null,
-                    null,
-                    "failure",
-                    auditService.newCorrelationId(),
-                    Map.of()
-                ));
-            }
-        }
+        persistenceQueue.enqueueSave(player);
     }
 
     private AttackDefinition loadAttack(AttackId attackId) {

--- a/src/main/java/io/taanielo/jmud/core/persistence/PersistenceQueue.java
+++ b/src/main/java/io/taanielo/jmud/core/persistence/PersistenceQueue.java
@@ -1,0 +1,210 @@
+package io.taanielo.jmud.core.persistence;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jspecify.annotations.Nullable;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.taanielo.jmud.core.audit.AuditEvent;
+import io.taanielo.jmud.core.audit.AuditService;
+import io.taanielo.jmud.core.audit.AuditSubject;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+
+/**
+ * Moves {@link Player} persistence off the tick thread with a write-behind queue.
+ *
+ * <p>Game code calls {@link #enqueueSave(Player)} to hand off an immutable snapshot;
+ * a single dedicated virtual thread performs the actual (blocking) file write, so the
+ * tick thread that drains player command queues never touches disk (AGENTS.md §5).
+ *
+ * <p>Saves are coalesced per username: only the latest enqueued snapshot for a given
+ * player is kept, so a burst of saves for the same player (e.g. repeated XP gains in
+ * a single combat) collapses into at most a couple of actual writes. {@link #flush}
+ * provides a synchronous drain for call sites (QUIT, shutdown) that must guarantee
+ * pending writes have completed before proceeding.
+ */
+@Slf4j
+public class PersistenceQueue implements AutoCloseable {
+
+    private static final Duration RETRY_BACKOFF = Duration.ofMillis(200);
+    private static final long IDLE_POLL_MILLIS = 25;
+
+    private final PlayerRepository playerRepository;
+    private final AuditService auditService;
+
+    /** Latest snapshot pending write for each dirty username. */
+    private final ConcurrentHashMap<Username, Player> pending = new ConcurrentHashMap<>();
+    /** Usernames currently queued for the worker to pick up; guards against duplicate queue entries. */
+    private final Set<Username> queued = ConcurrentHashMap.newKeySet();
+    private final BlockingQueue<Username> dirtyUsernames = new LinkedBlockingQueue<>();
+
+    private final AtomicLong failureCount = new AtomicLong();
+    /** Number of usernames currently being processed (dequeued but not yet saved/retried). */
+    private final AtomicLong inFlight = new AtomicLong();
+    private final AtomicReference<@Nullable Thread> workerThread = new AtomicReference<>();
+    private volatile boolean running = true;
+
+    /**
+     * Creates a persistence queue backed by the given repository, starting its worker thread.
+     *
+     * @param playerRepository the repository used to perform the actual writes
+     * @param auditService audit sink used to record save failures
+     */
+    public PersistenceQueue(PlayerRepository playerRepository, AuditService auditService) {
+        this.playerRepository = Objects.requireNonNull(playerRepository, "Player repository is required");
+        this.auditService = Objects.requireNonNull(auditService, "Audit service is required");
+        Thread thread = Thread.ofVirtual().name("persistence-queue-writer").start(this::runWorker);
+        workerThread.set(thread);
+    }
+
+    /**
+     * Enqueues a player snapshot for a future write-behind save.
+     *
+     * <p>The player is defensively snapshotted via {@link Player#snapshotForPersistence()}
+     * so later tick-thread mutation of the caller's {@code player} instance cannot be
+     * observed by the writer thread. If a save for the same username is already
+     * pending, it is replaced by this newer snapshot (coalescing).
+     *
+     * @param player the player to save; must not be {@code null}
+     */
+    public void enqueueSave(Player player) {
+        Objects.requireNonNull(player, "Player is required");
+        Username username = player.getUsername();
+        Player snapshot = player.snapshotForPersistence();
+        pending.put(username, snapshot);
+        if (queued.add(username)) {
+            dirtyUsernames.add(username);
+        }
+    }
+
+    /**
+     * Blocks the calling thread until all currently pending and in-flight saves have
+     * completed, or the timeout elapses.
+     *
+     * @param timeout the maximum time to wait
+     * @return {@code true} if the queue drained before the timeout, {@code false} otherwise
+     */
+    public boolean flush(Duration timeout) {
+        Objects.requireNonNull(timeout, "Timeout is required");
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        while (!isIdle()) {
+            long remainingNanos = deadlineNanos - System.nanoTime();
+            if (remainingNanos <= 0) {
+                return false;
+            }
+            long sleepMillis = Math.min(IDLE_POLL_MILLIS, Math.max(1, remainingNanos / 1_000_000));
+            try {
+                Thread.sleep(sleepMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the number of save attempts that ultimately failed (after the single
+     * retry). Exposed for future metrics/monitoring; not currently alerted on.
+     *
+     * @return the cumulative count of failed saves since this queue was created
+     */
+    public long getFailureCount() {
+        return failureCount.get();
+    }
+
+    /**
+     * Stops the worker thread. Callers that need pending saves to be durable first
+     * must call {@link #flush(Duration)} before closing.
+     */
+    @Override
+    public void close() {
+        running = false;
+        Thread thread = workerThread.get();
+        if (thread != null) {
+            thread.interrupt();
+            try {
+                thread.join(Duration.ofSeconds(5).toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private boolean isIdle() {
+        return pending.isEmpty() && dirtyUsernames.isEmpty() && inFlight.get() == 0;
+    }
+
+    private void runWorker() {
+        while (running) {
+            Username username;
+            try {
+                username = dirtyUsernames.poll(IDLE_POLL_MILLIS, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                if (!running) {
+                    return;
+                }
+                continue;
+            }
+            if (username == null) {
+                continue;
+            }
+            // Mark this username as "in flight" before touching pending/queued so a
+            // concurrent flush() cannot observe a false "idle" window between the
+            // blocking-queue take (above) and the save (including its retry) completing.
+            inFlight.incrementAndGet();
+            try {
+                queued.remove(username);
+                Player snapshot = pending.remove(username);
+                if (snapshot != null) {
+                    saveWithRetry(snapshot);
+                }
+            } finally {
+                inFlight.decrementAndGet();
+            }
+        }
+    }
+
+    private void saveWithRetry(Player snapshot) {
+        try {
+            playerRepository.savePlayer(snapshot);
+            return;
+        } catch (RepositoryException e) {
+            log.warn("Failed to save player {} (write-behind); retrying once", snapshot.getUsername(), e);
+        }
+        try {
+            Thread.sleep(RETRY_BACKOFF.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        try {
+            playerRepository.savePlayer(snapshot);
+        } catch (RepositoryException e) {
+            failureCount.incrementAndGet();
+            log.error("Failed to save player {} (write-behind) after retry", snapshot.getUsername(), e);
+            auditService.emit(new AuditEvent(
+                "player.save.failed",
+                AuditSubject.player(snapshot.getUsername()),
+                null,
+                null,
+                "failure",
+                auditService.newCorrelationId(),
+                Map.of()
+            ));
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/persistence/package-info.java
+++ b/src/main/java/io/taanielo/jmud/core/persistence/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Write-behind persistence for game state (currently {@link io.taanielo.jmud.core.player.Player}
+ * snapshots), so the tick thread never blocks on disk I/O (AGENTS.md §5). NullAway-checked
+ * ({@code @NullMarked}) as part of the ongoing nullness enforcement ratchet.
+ */
+@NullMarked
+package io.taanielo.jmud.core.persistence;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/io/taanielo/jmud/core/player/Player.java
+++ b/src/main/java/io/taanielo/jmud/core/player/Player.java
@@ -477,4 +477,41 @@ public class Player implements EffectTarget, Combatant {
     public Player withPracticePoints(int newPracticePoints) {
         return new Player(identity, combatState, preferences, abilities, inventory, equipment, resting, gold, activeQuest, totalKills, newPracticePoints, bankedGold);
     }
+
+    /**
+     * Returns a fully independent copy of this player, safe to hand to another thread
+     * (e.g. the persistence write-behind queue).
+     *
+     * <p>Every other component of {@code Player} is immutable, but the active effects
+     * held in {@link PlayerCombatState} are mutable ({@link EffectInstance#tickDown()}
+     * and friends run every tick), so a plain field copy would let a background writer
+     * observe a mid-tick mutation. This method deep-copies the effect list so the
+     * returned snapshot is stable regardless of subsequent tick-thread activity on
+     * the original instance.
+     *
+     * @return an independent snapshot of this player's current state
+     */
+    public Player snapshotForPersistence() {
+        List<EffectInstance> effectsCopy = combatState.effects().stream().map(EffectInstance::copy).toList();
+        return new Player(
+            identity.user(),
+            identity.level(),
+            identity.experience(),
+            combatState.vitals(),
+            effectsCopy,
+            preferences.promptFormat(),
+            preferences.ansiEnabled(),
+            abilities.learned(),
+            identity.race(),
+            identity.classId(),
+            combatState.dead(),
+            inventory.items(),
+            equipment,
+            gold,
+            activeQuest,
+            totalKills,
+            practicePoints,
+            bankedGold
+        );
+    }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
@@ -16,18 +16,22 @@ import io.taanielo.jmud.core.authentication.AuthenticationPolicy;
 import io.taanielo.jmud.core.authentication.JsonUserRegistry;
 import io.taanielo.jmud.core.authentication.UserRegistry;
 import io.taanielo.jmud.core.authentication.UserRegistryException;
-import io.taanielo.jmud.core.config.GameConfig;
+import io.taanielo.jmud.core.bank.BankRepository;
+import io.taanielo.jmud.core.bank.BankRepositoryException;
+import io.taanielo.jmud.core.bank.BankService;
+import io.taanielo.jmud.core.bank.repository.json.JsonBankRepository;
 import io.taanielo.jmud.core.character.repository.ClassRepositoryException;
 import io.taanielo.jmud.core.character.repository.RaceRepositoryException;
 import io.taanielo.jmud.core.character.repository.json.JsonClassRepository;
 import io.taanielo.jmud.core.character.repository.json.JsonRaceRepository;
-import io.taanielo.jmud.core.creation.CharacterCreationService;
 import io.taanielo.jmud.core.combat.CombatEngine;
 import io.taanielo.jmud.core.combat.CombatModifierResolver;
 import io.taanielo.jmud.core.combat.EquipmentArmorResolver;
 import io.taanielo.jmud.core.combat.RaceArmorBonusResolver;
 import io.taanielo.jmud.core.combat.ThreadLocalCombatRandom;
 import io.taanielo.jmud.core.combat.repository.json.JsonAttackRepository;
+import io.taanielo.jmud.core.config.GameConfig;
+import io.taanielo.jmud.core.creation.CharacterCreationService;
 import io.taanielo.jmud.core.effects.EffectEngine;
 import io.taanielo.jmud.core.effects.EffectRepository;
 import io.taanielo.jmud.core.effects.EffectRepositoryException;
@@ -37,22 +41,19 @@ import io.taanielo.jmud.core.healing.HealingEngine;
 import io.taanielo.jmud.core.mob.MobRegistry;
 import io.taanielo.jmud.core.mob.repository.json.JsonMobTemplateRepository;
 import io.taanielo.jmud.core.party.PartyService;
-import io.taanielo.jmud.core.quest.QuestKillService;
-import io.taanielo.jmud.core.quest.QuestRepository;
-import io.taanielo.jmud.core.quest.QuestRepositoryException;
-import io.taanielo.jmud.core.quest.repository.json.JsonQuestRepository;
-import io.taanielo.jmud.core.bank.BankRepository;
-import io.taanielo.jmud.core.bank.BankRepositoryException;
-import io.taanielo.jmud.core.bank.BankService;
-import io.taanielo.jmud.core.bank.repository.json.JsonBankRepository;
-import io.taanielo.jmud.core.shop.ShopRepository;
-import io.taanielo.jmud.core.shop.ShopRepositoryException;
-import io.taanielo.jmud.core.shop.ShopService;
-import io.taanielo.jmud.core.shop.repository.json.JsonShopRepository;
+import io.taanielo.jmud.core.persistence.PersistenceQueue;
 import io.taanielo.jmud.core.player.DeathSettings;
 import io.taanielo.jmud.core.player.EncumbranceService;
 import io.taanielo.jmud.core.player.JsonPlayerRepository;
 import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.quest.QuestKillService;
+import io.taanielo.jmud.core.quest.QuestRepository;
+import io.taanielo.jmud.core.quest.QuestRepositoryException;
+import io.taanielo.jmud.core.quest.repository.json.JsonQuestRepository;
+import io.taanielo.jmud.core.shop.ShopRepository;
+import io.taanielo.jmud.core.shop.ShopRepositoryException;
+import io.taanielo.jmud.core.shop.ShopService;
+import io.taanielo.jmud.core.shop.repository.json.JsonShopRepository;
 import io.taanielo.jmud.core.tick.FixedRateTickScheduler;
 import io.taanielo.jmud.core.tick.TickClock;
 import io.taanielo.jmud.core.tick.TickRegistry;
@@ -73,6 +74,7 @@ public record GameContext(
     AuthenticationPolicy authenticationPolicy,
     AuthenticationLimiter authenticationLimiter,
     PlayerRepository playerRepository,
+    PersistenceQueue persistenceQueue,
     RoomRepository roomRepository,
     RoomService roomService,
     TickRegistry tickRegistry,
@@ -121,6 +123,7 @@ public record GameContext(
 
         AbilityRegistry abilityRegistry = loadAbilities();
         AuditService auditService = AuditService.create(tickClock::currentTick);
+        PersistenceQueue persistenceQueue = new PersistenceQueue(playerRepository, auditService);
 
         EffectRepository effectRepository = createEffectRepository();
         EffectEngine effectEngine = new EffectEngine(effectRepository);
@@ -140,9 +143,8 @@ public record GameContext(
         SocketCommandRegistry commandRegistry = SocketCommandRegistry.createDefault(equipmentArmorResolver, raceArmorBonusResolver);
 
         PlayerEventBus playerEventBus = new PlayerEventBus();
-        MobRegistry mobRegistry = createMobRegistry(playerEventBus, roomService, playerRepository);
+        MobRegistry mobRegistry = createMobRegistry(playerEventBus, roomService, playerRepository, persistenceQueue);
         if (mobRegistry != null) {
-            mobRegistry.setAuditService(auditService);
             mobRegistry.init();
             tickRegistry.register(mobRegistry);
         }
@@ -165,6 +167,7 @@ public record GameContext(
             authenticationPolicy,
             authenticationLimiter,
             playerRepository,
+            persistenceQueue,
             roomRepository,
             roomService,
             tickRegistry,
@@ -211,13 +214,14 @@ public record GameContext(
     private static MobRegistry createMobRegistry(
         PlayerEventBus playerEventBus,
         RoomService roomService,
-        PlayerRepository playerRepository
+        PlayerRepository playerRepository,
+        PersistenceQueue persistenceQueue
     ) {
         try {
             JsonMobTemplateRepository templateRepo = new JsonMobTemplateRepository();
             ItemRepository itemRepo = new JsonItemRepository();
             JsonAttackRepository attackRepo = new JsonAttackRepository();
-            return new MobRegistry(templateRepo, itemRepo, attackRepo, roomService, playerRepository, playerEventBus);
+            return new MobRegistry(templateRepo, itemRepo, attackRepo, roomService, playerRepository, persistenceQueue, playerEventBus);
         } catch (RepositoryException e) {
             throw new IllegalStateException("Failed to initialize mob registry: " + e.getMessage(), e);
         }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/PlayerSession.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/PlayerSession.java
@@ -1,5 +1,6 @@
 package io.taanielo.jmud.core.server.socket;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -21,16 +22,15 @@ import io.taanielo.jmud.core.healing.PlayerHealingTicker;
 import io.taanielo.jmud.core.output.OutputStyleSettings;
 import io.taanielo.jmud.core.output.TextStyler;
 import io.taanielo.jmud.core.output.TextStylers;
+import io.taanielo.jmud.core.persistence.PersistenceQueue;
 import io.taanielo.jmud.core.player.DeathSettings;
 import io.taanielo.jmud.core.player.Player;
-import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.player.PlayerRespawnTicker;
 import io.taanielo.jmud.core.player.RestingTicker;
 import io.taanielo.jmud.core.tick.TickRegistry;
 import io.taanielo.jmud.core.tick.TickSubscription;
 import io.taanielo.jmud.core.tick.system.CooldownSystem;
 import io.taanielo.jmud.core.world.RoomService;
-import io.taanielo.jmud.core.world.repository.RepositoryException;
 
 /**
  * Manages the lifecycle of a connected player within a single session.
@@ -42,8 +42,10 @@ import io.taanielo.jmud.core.world.repository.RepositoryException;
 @Slf4j
 public class PlayerSession {
 
+    private static final Duration DISCONNECT_FLUSH_TIMEOUT = Duration.ofSeconds(5);
+
     private final TickRegistry tickRegistry;
-    private final PlayerRepository playerRepository;
+    private final PersistenceQueue persistenceQueue;
     private final RoomService roomService;
     private final PlayerCommandQueue commandQueue = new PlayerCommandQueue();
     private final EffectEngine effectEngine;
@@ -80,7 +82,8 @@ public class PlayerSession {
      * Creates a player session with the given dependencies.
      *
      * @param tickRegistry the tick registry for scheduling tickables
-     * @param playerRepository the player repository for persistence
+     * @param persistenceQueue the write-behind queue used for all player saves, so
+     *                         this session never blocks the tick thread on disk I/O
      * @param roomService the room service for location management
      * @param respawnCallback called when the player respawns after death
      * @param effectEngine effect engine for player effects
@@ -89,7 +92,7 @@ public class PlayerSession {
      */
     public PlayerSession(
         TickRegistry tickRegistry,
-        PlayerRepository playerRepository,
+        PersistenceQueue persistenceQueue,
         RoomService roomService,
         Consumer<Player> respawnCallback,
         EffectEngine effectEngine,
@@ -98,7 +101,7 @@ public class PlayerSession {
         HealingBaseResolver healingBaseResolver
     ) {
         this.tickRegistry = Objects.requireNonNull(tickRegistry, "Tick registry is required");
-        this.playerRepository = Objects.requireNonNull(playerRepository, "Player repository is required");
+        this.persistenceQueue = Objects.requireNonNull(persistenceQueue, "Persistence queue is required");
         this.roomService = Objects.requireNonNull(roomService, "Room service is required");
         this.effectEngine = Objects.requireNonNull(effectEngine, "Effect engine is required");
         this.effectRepository = Objects.requireNonNull(effectRepository, "Effect repository is required");
@@ -188,24 +191,14 @@ public class PlayerSession {
     }
 
     /**
-     * Attempts to persist the given player, logging and notifying the save-failure
-     * handler (if any) on failure rather than propagating the exception.
+     * Hands the given player off to the write-behind persistence queue rather than
+     * saving synchronously (AGENTS.md §5); the queue itself logs and audits any
+     * eventual save failure after its retry.
      *
      * @param playerToSave the player to save
-     * @param context short label describing the call site, used in the log message
-     * @return true if the save succeeded, false otherwise
      */
-    private boolean trySavePlayer(Player playerToSave, String context) {
-        try {
-            playerRepository.savePlayer(playerToSave);
-            return true;
-        } catch (RepositoryException e) {
-            log.error("Failed to save player {} ({})", playerToSave.getUsername(), context, e);
-            if (saveFailureHandler != null) {
-                saveFailureHandler.accept(playerToSave);
-            }
-            return false;
-        }
+    private void enqueueSave(Player playerToSave) {
+        persistenceQueue.enqueueSave(playerToSave);
     }
 
     /**
@@ -214,7 +207,7 @@ public class PlayerSession {
      */
     public void replacePlayer(Player updated) {
         player = updated;
-        trySavePlayer(player, "replacePlayer");
+        enqueueSave(player);
         if (effectsInitialized) {
             clearEffects();
             if (!player.isDead()) {
@@ -318,6 +311,12 @@ public class PlayerSession {
 
     /**
      * Closes the session by unsubscribing all ticks and persisting the player.
+     *
+     * <p>Unlike normal in-play saves, disconnect has no further chance to persist,
+     * so this enqueues the final save and then synchronously {@link
+     * PersistenceQueue#flush(Duration) flushes} the queue (bounded by {@link
+     * #DISCONNECT_FLUSH_TIMEOUT}) before returning, guaranteeing the write has
+     * completed (or definitively failed) by the time the connection is torn down.
      */
     public void close() {
         connected = false;
@@ -334,30 +333,19 @@ public class PlayerSession {
             commandSubscription.unsubscribe();
         }
         if (authenticated && player != null) {
-            // Retry once before giving up: on-disconnect saves have no further chance to persist.
-            boolean saved = trySavePlayerQuietly(player);
-            if (!saved) {
-                saved = trySavePlayerQuietly(player);
-            }
-            if (saved) {
+            long failuresBeforeSave = persistenceQueue.getFailureCount();
+            enqueueSave(player);
+            boolean flushed = persistenceQueue.flush(DISCONNECT_FLUSH_TIMEOUT);
+            boolean saveFailed = persistenceQueue.getFailureCount() > failuresBeforeSave;
+            if (flushed && !saveFailed) {
                 log.info("Player {} data saved on disconnect.", player.getUsername());
             } else {
-                log.error("Failed to save player {} on disconnect after retry.", player.getUsername());
+                log.error("Failed to save player {} on disconnect (flushed={}, failureDetected={}).",
+                    player.getUsername(), flushed, saveFailed);
                 if (saveFailureHandler != null) {
                     saveFailureHandler.accept(player);
                 }
             }
-        }
-    }
-
-    private boolean trySavePlayerQuietly(Player playerToSave) {
-        try {
-            playerRepository.savePlayer(playerToSave);
-            return true;
-        } catch (RepositoryException e) {
-            log.warn("Save attempt failed for player {} on disconnect: {}",
-                playerToSave.getUsername(), e.getMessage());
-            return false;
         }
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinator.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinator.java
@@ -8,14 +8,13 @@ import lombok.extern.slf4j.Slf4j;
 
 import io.taanielo.jmud.core.audit.AuditService;
 import io.taanielo.jmud.core.messaging.SystemNoticeMessage;
+import io.taanielo.jmud.core.persistence.PersistenceQueue;
 import io.taanielo.jmud.core.player.Player;
-import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.server.Client;
 import io.taanielo.jmud.core.server.ClientPool;
 import io.taanielo.jmud.core.server.Server;
 import io.taanielo.jmud.core.tick.FixedRateTickScheduler;
 import io.taanielo.jmud.core.tick.TickRegistry;
-import io.taanielo.jmud.core.world.repository.RepositoryException;
 
 /**
  * Executes the server's orderly shutdown sequence: stop accepting new
@@ -32,12 +31,13 @@ import io.taanielo.jmud.core.world.repository.RepositoryException;
 public class ShutdownCoordinator {
 
     private static final Duration DEFAULT_AUDIT_FLUSH_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration PERSISTENCE_FLUSH_TIMEOUT = Duration.ofSeconds(10);
 
     private final List<Server> servers;
     private final ClientPool clientPool;
     private final FixedRateTickScheduler tickScheduler;
     private final TickRegistry tickRegistry;
-    private final PlayerRepository playerRepository;
+    private final PersistenceQueue persistenceQueue;
     private final AuditService auditService;
     private final Duration auditFlushTimeout;
 
@@ -46,10 +46,10 @@ public class ShutdownCoordinator {
         ClientPool clientPool,
         FixedRateTickScheduler tickScheduler,
         TickRegistry tickRegistry,
-        PlayerRepository playerRepository,
+        PersistenceQueue persistenceQueue,
         AuditService auditService
     ) {
-        this(servers, clientPool, tickScheduler, tickRegistry, playerRepository, auditService, DEFAULT_AUDIT_FLUSH_TIMEOUT);
+        this(servers, clientPool, tickScheduler, tickRegistry, persistenceQueue, auditService, DEFAULT_AUDIT_FLUSH_TIMEOUT);
     }
 
     public ShutdownCoordinator(
@@ -57,7 +57,7 @@ public class ShutdownCoordinator {
         ClientPool clientPool,
         FixedRateTickScheduler tickScheduler,
         TickRegistry tickRegistry,
-        PlayerRepository playerRepository,
+        PersistenceQueue persistenceQueue,
         AuditService auditService,
         Duration auditFlushTimeout
     ) {
@@ -65,7 +65,7 @@ public class ShutdownCoordinator {
         this.clientPool = Objects.requireNonNull(clientPool, "Client pool is required");
         this.tickScheduler = Objects.requireNonNull(tickScheduler, "Tick scheduler is required");
         this.tickRegistry = Objects.requireNonNull(tickRegistry, "Tick registry is required");
-        this.playerRepository = Objects.requireNonNull(playerRepository, "Player repository is required");
+        this.persistenceQueue = Objects.requireNonNull(persistenceQueue, "Persistence queue is required");
         this.auditService = Objects.requireNonNull(auditService, "Audit service is required");
         this.auditFlushTimeout = Objects.requireNonNull(auditFlushTimeout, "Audit flush timeout is required");
     }
@@ -85,6 +85,23 @@ public class ShutdownCoordinator {
         flushAudit();
         tickRegistry.clear();
         log.info("Shutdown sequence complete");
+    }
+
+    private void saveOnlinePlayers() {
+        for (Client client : clientPool.clients()) {
+            client.currentPlayer().ifPresent(this::enqueueSave);
+        }
+        boolean flushed = persistenceQueue.flush(PERSISTENCE_FLUSH_TIMEOUT);
+        if (!flushed) {
+            log.error("Persistence queue did not drain within {} during shutdown; some player saves may be lost",
+                PERSISTENCE_FLUSH_TIMEOUT);
+        }
+        persistenceQueue.close();
+    }
+
+    private void enqueueSave(Player player) {
+        persistenceQueue.enqueueSave(player);
+        log.info("Enqueued save for player {} during shutdown", player.getUsername());
     }
 
     private void stopAccepting() {
@@ -110,21 +127,6 @@ public class ShutdownCoordinator {
 
     private void stopTickScheduler() {
         tickScheduler.stop();
-    }
-
-    private void saveOnlinePlayers() {
-        for (Client client : clientPool.clients()) {
-            client.currentPlayer().ifPresent(this::saveOrLog);
-        }
-    }
-
-    private void saveOrLog(Player player) {
-        try {
-            playerRepository.savePlayer(player);
-            log.info("Saved player {} during shutdown", player.getUsername());
-        } catch (RepositoryException e) {
-            log.error("Failed to save player {} during shutdown", player.getUsername(), e);
-        }
     }
 
     private void flushAudit() {

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -21,14 +21,6 @@ import io.taanielo.jmud.core.ability.AbilityId;
 import io.taanielo.jmud.core.ability.AbilityMatch;
 import io.taanielo.jmud.core.ability.AbilityRegistry;
 import io.taanielo.jmud.core.ability.AbilityTargetResolver;
-import io.taanielo.jmud.core.character.ClassDefinition;
-import io.taanielo.jmud.core.character.ClassId;
-import io.taanielo.jmud.core.character.RaceId;
-import io.taanielo.jmud.core.creation.CharacterCreationException;
-import io.taanielo.jmud.core.creation.CharacterCreationService;
-import io.taanielo.jmud.core.creation.CharacterCreationState;
-import io.taanielo.jmud.core.creation.CharacterCreationState.ChoosingClass;
-import io.taanielo.jmud.core.creation.CharacterCreationState.ChoosingRace;
 import io.taanielo.jmud.core.action.GameActionResult;
 import io.taanielo.jmud.core.action.GameActionService;
 import io.taanielo.jmud.core.action.GameMessage;
@@ -38,6 +30,14 @@ import io.taanielo.jmud.core.audit.AuditSubject;
 import io.taanielo.jmud.core.authentication.AuthenticationService;
 import io.taanielo.jmud.core.authentication.User;
 import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.bank.BankTransactionResult;
+import io.taanielo.jmud.core.character.ClassDefinition;
+import io.taanielo.jmud.core.character.RaceId;
+import io.taanielo.jmud.core.creation.CharacterCreationException;
+import io.taanielo.jmud.core.creation.CharacterCreationService;
+import io.taanielo.jmud.core.creation.CharacterCreationState;
+import io.taanielo.jmud.core.creation.CharacterCreationState.ChoosingClass;
+import io.taanielo.jmud.core.creation.CharacterCreationState.ChoosingRace;
 import io.taanielo.jmud.core.effects.EffectMessageSink;
 import io.taanielo.jmud.core.messaging.Message;
 import io.taanielo.jmud.core.messaging.UserSayMessage;
@@ -45,29 +45,25 @@ import io.taanielo.jmud.core.messaging.WelcomeBannerMessage;
 import io.taanielo.jmud.core.messaging.WelcomeMessage;
 import io.taanielo.jmud.core.output.OutputStyleSettings;
 import io.taanielo.jmud.core.output.TextStylers;
+import io.taanielo.jmud.core.party.Party;
+import io.taanielo.jmud.core.party.PartyService;
+import io.taanielo.jmud.core.persistence.PersistenceQueue;
 import io.taanielo.jmud.core.player.EncumbranceService;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.player.RestSettings;
 import io.taanielo.jmud.core.player.RestingTicker;
-import io.taanielo.jmud.core.world.repository.RepositoryException;
 import io.taanielo.jmud.core.prompt.PromptRenderer;
 import io.taanielo.jmud.core.prompt.PromptSettings;
+import io.taanielo.jmud.core.quest.ActiveQuest;
+import io.taanielo.jmud.core.quest.QuestDeliveryService;
+import io.taanielo.jmud.core.quest.QuestRepository;
+import io.taanielo.jmud.core.quest.QuestRepositoryException;
+import io.taanielo.jmud.core.quest.QuestTemplate;
 import io.taanielo.jmud.core.server.Client;
 import io.taanielo.jmud.core.server.ClientPool;
 import io.taanielo.jmud.core.server.connection.ClientConnection;
 import io.taanielo.jmud.core.server.connection.TransportSecurity;
-import io.taanielo.jmud.core.party.Party;
-import io.taanielo.jmud.core.party.PartyService;
-import io.taanielo.jmud.core.quest.ActiveQuest;
-import io.taanielo.jmud.core.quest.QuestDeliveryService;
-import io.taanielo.jmud.core.quest.QuestKillService;
-import io.taanielo.jmud.core.quest.QuestRepository;
-import io.taanielo.jmud.core.quest.QuestRepositoryException;
-import io.taanielo.jmud.core.quest.QuestTemplate;
-import io.taanielo.jmud.core.bank.Bank;
-import io.taanielo.jmud.core.bank.BankTransactionResult;
-import io.taanielo.jmud.core.shop.Shop;
 import io.taanielo.jmud.core.shop.ShopTransactionResult;
 import io.taanielo.jmud.core.world.Direction;
 import io.taanielo.jmud.core.world.Item;
@@ -85,6 +81,7 @@ public class SocketClient implements Client {
     private final GameActionService gameActionService;
     private final AuthenticationService authenticationService;
     private final PlayerRepository playerRepository;
+    private final PersistenceQueue persistenceQueue;
     private final RoomService roomService;
     private final EncumbranceService encumbranceService;
     private final ClientPool clientPool;
@@ -117,6 +114,7 @@ public class SocketClient implements Client {
         this.connection = Objects.requireNonNull(connection, "Connection is required");
         this.authenticationService = Objects.requireNonNull(authenticationService, "Authentication service is required");
         this.playerRepository = context.playerRepository();
+        this.persistenceQueue = context.persistenceQueue();
         this.roomService = context.roomService();
         this.encumbranceService = context.encumbranceService();
         this.clientPool = clientPool;
@@ -127,7 +125,7 @@ public class SocketClient implements Client {
 
         this.session = new PlayerSession(
             context.tickRegistry(),
-            this.playerRepository,
+            this.persistenceQueue,
             this.roomService,
             this::applyRespawnUpdate,
             context.effectEngine(),
@@ -738,26 +736,23 @@ public class SocketClient implements Client {
     // ── Persistence ─────────────────────────────────────────────────────
 
     /**
-     * Saves the given player, warning the player and emitting an audit event
-     * on failure instead of letting the persistence exception escape.
+     * Hands the given player off to the write-behind persistence queue rather than
+     * saving synchronously on this (tick) thread (AGENTS.md §5). Failures are logged
+     * and audited by the queue itself after its retry; there is no more a way to warn
+     * the player synchronously about a failed save from this call site.
      *
      * @param playerToSave the player to save
      */
     private void saveOrWarn(Player playerToSave) {
-        try {
-            playerRepository.savePlayer(playerToSave);
-        } catch (RepositoryException e) {
-            handleSaveFailure(playerToSave);
-        }
+        persistenceQueue.enqueueSave(playerToSave);
     }
 
     /**
-     * Handles a failed player save: logs the failure, warns the player, and
-     * emits an audit event. Passed to {@link PlayerSession} as its save-failure hook
-     * so saves triggered internally by the session (e.g. {@code replacePlayer}) are
-     * surfaced the same way as saves performed directly by this class.
+     * Handles a failed flush of pending saves on disconnect: logs the failure, warns
+     * the player, and emits an audit event. Passed to {@link PlayerSession} as its
+     * save-failure hook.
      *
-     * @param player the player whose save failed
+     * @param player the player whose save failed to flush before disconnect
      */
     private void handleSaveFailure(Player player) {
         log.error("Player save failed for {}; warning player", player.getUsername());

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryAggressiveMobTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryAggressiveMobTest.java
@@ -3,7 +3,6 @@ package io.taanielo.jmud.core.mob;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -11,7 +10,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.jupiter.api.Test;
 
-import io.taanielo.jmud.core.action.GameActionResult;
 import io.taanielo.jmud.core.action.PlayerEventBus;
 import io.taanielo.jmud.core.authentication.Password;
 import io.taanielo.jmud.core.authentication.User;
@@ -79,7 +77,7 @@ class MobRegistryAggressiveMobTest {
         PlayerEventBus bus = new PlayerEventBus();
 
         MobRegistry registry = new MobRegistry(
-            templateRepo, itemRepo, attackRepo, roomService, playerRepo, bus);
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo, MobRegistryTestSupport.persistenceQueueFor(playerRepo), bus);
         registry.init();
         return registry;
     }

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryFleeCombatTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryFleeCombatTest.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.jupiter.api.Test;
 
-import io.taanielo.jmud.core.action.GameActionResult;
 import io.taanielo.jmud.core.action.PlayerEventBus;
 import io.taanielo.jmud.core.authentication.Password;
 import io.taanielo.jmud.core.authentication.User;
@@ -22,7 +21,6 @@ import io.taanielo.jmud.core.combat.repository.AttackRepository;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.world.Item;
-import io.taanielo.jmud.core.world.ItemAttributes;
 import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.Room;
 import io.taanielo.jmud.core.world.RoomId;
@@ -75,7 +73,7 @@ class MobRegistryFleeCombatTest {
         PlayerEventBus bus = new PlayerEventBus();
 
         MobRegistry registry = new MobRegistry(
-            templateRepo, itemRepo, attackRepo, roomService, playerRepo, bus);
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo, MobRegistryTestSupport.persistenceQueueFor(playerRepo), bus);
         registry.init();
         return registry;
     }

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryGoldDropTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryGoldDropTest.java
@@ -3,6 +3,7 @@ package io.taanielo.jmud.core.mob;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -21,10 +22,10 @@ import io.taanielo.jmud.core.combat.AttackDefinition;
 import io.taanielo.jmud.core.combat.AttackId;
 import io.taanielo.jmud.core.combat.CombatSettings;
 import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.persistence.PersistenceQueue;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.world.Item;
-import io.taanielo.jmud.core.world.ItemAttributes;
 import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.Room;
 import io.taanielo.jmud.core.world.RoomId;
@@ -96,7 +97,8 @@ class MobRegistryGoldDropTest {
         MobTemplate template,
         Player attacker,
         StubPlayerRepository playerRepo,
-        List<GameActionResult> captured
+        List<GameActionResult> captured,
+        PersistenceQueue persistenceQueue
     ) {
         MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
         AttackRepository attackRepo = new StubAttackRepository(Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));
@@ -109,7 +111,7 @@ class MobRegistryGoldDropTest {
         bus.register(attacker.getUsername(), captured::add);
 
         MobRegistry registry = new MobRegistry(
-            templateRepo, itemRepo, attackRepo, roomService, playerRepo, bus);
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo, persistenceQueue, bus);
         registry.init();
         return registry;
     }
@@ -127,8 +129,9 @@ class MobRegistryGoldDropTest {
         MobTemplate template = templateWithFixedGoldDrop(1); // 1 HP → one-shot kill
 
         StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        PersistenceQueue persistenceQueue = MobRegistryTestSupport.persistenceQueueFor(playerRepo);
         List<GameActionResult> captured = new ArrayList<>();
-        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured);
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured, persistenceQueue);
 
         GameActionResult result = registry.processPlayerAttack(attacker, "Goblin", ROOM_ID);
 
@@ -140,6 +143,8 @@ class MobRegistryGoldDropTest {
             texts.stream().anyMatch(t -> t.contains("gold coin")),
             "Expected a gold drop message but got: " + texts);
 
+        assertTrue(persistenceQueue.flush(Duration.ofSeconds(2)));
+        persistenceQueue.close();
         Player saved = playerRepo.load(attacker.getUsername());
         assertTrue(saved.getGold() > 0,
             "Expected saved player to have gold > 0, got " + saved.getGold());
@@ -156,8 +161,9 @@ class MobRegistryGoldDropTest {
         MobTemplate template = templateWithNoGoldDrop(1);
 
         StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        PersistenceQueue persistenceQueue = MobRegistryTestSupport.persistenceQueueFor(playerRepo);
         List<GameActionResult> captured = new ArrayList<>();
-        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured);
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured, persistenceQueue);
 
         GameActionResult result = registry.processPlayerAttack(attacker, "Rat", ROOM_ID);
 
@@ -169,6 +175,8 @@ class MobRegistryGoldDropTest {
             texts.stream().noneMatch(t -> t.contains("gold coin")),
             "Expected no gold message for mob with no gold drop, but got: " + texts);
 
+        assertTrue(persistenceQueue.flush(Duration.ofSeconds(2)));
+        persistenceQueue.close();
         Player saved = playerRepo.load(attacker.getUsername());
         assertEquals(0, saved.getGold(), "Expected 0 gold for mob with no gold drop");
     }
@@ -185,8 +193,9 @@ class MobRegistryGoldDropTest {
         MobTemplate template = templateWithFixedGoldDrop(2);
 
         StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        PersistenceQueue persistenceQueue = MobRegistryTestSupport.persistenceQueueFor(playerRepo);
         List<GameActionResult> captured = new ArrayList<>();
-        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured);
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured, persistenceQueue);
 
         // First hit — mob survives, combat is registered.
         registry.processPlayerAttack(attacker, "Goblin", ROOM_ID);
@@ -204,6 +213,8 @@ class MobRegistryGoldDropTest {
             allTexts.stream().anyMatch(t -> t.contains("gold coin")),
             "Expected gold drop message on tick kill, but got: " + allTexts);
 
+        assertTrue(persistenceQueue.flush(Duration.ofSeconds(2)));
+        persistenceQueue.close();
         Player saved = playerRepo.load(attacker.getUsername());
         assertTrue(saved.getGold() > 0,
             "Expected saved player to have gold after tick kill, got " + saved.getGold());

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryKillTrackingTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryKillTrackingTest.java
@@ -1,7 +1,9 @@
 package io.taanielo.jmud.core.mob;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +21,7 @@ import io.taanielo.jmud.core.combat.AttackDefinition;
 import io.taanielo.jmud.core.combat.AttackId;
 import io.taanielo.jmud.core.combat.CombatSettings;
 import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.persistence.PersistenceQueue;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.world.Item;
@@ -72,7 +75,8 @@ class MobRegistryKillTrackingTest {
         MobTemplate template,
         Player attacker,
         StubPlayerRepository playerRepo,
-        List<GameActionResult> captured
+        List<GameActionResult> captured,
+        PersistenceQueue persistenceQueue
     ) {
         MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
         AttackRepository attackRepo = new StubAttackRepository(Map.of(DEFAULT_ATTACK, ONE_DMG_ATTACK));
@@ -85,7 +89,7 @@ class MobRegistryKillTrackingTest {
         bus.register(attacker.getUsername(), captured::add);
 
         MobRegistry registry = new MobRegistry(
-            templateRepo, itemRepo, attackRepo, roomService, playerRepo, bus);
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo, persistenceQueue, bus);
         registry.init();
         return registry;
     }
@@ -103,10 +107,15 @@ class MobRegistryKillTrackingTest {
 
         MobTemplate template = templateWithHp(1); // 1 HP → one-shot
         StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
-        MobRegistry registry = buildRegistry(template, attacker, playerRepo, new ArrayList<>());
+        PersistenceQueue persistenceQueue = MobRegistryTestSupport.persistenceQueueFor(playerRepo);
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, new ArrayList<>(), persistenceQueue);
 
         registry.processPlayerAttack(attacker, "Rat", ROOM_ID);
 
+        // Saves are write-behind (issue #179): wait for the queue to drain before
+        // reading back the persisted state.
+        assertTrue(persistenceQueue.flush(Duration.ofSeconds(2)));
+        persistenceQueue.close();
         Player saved = playerRepo.load(attacker.getUsername());
         assertEquals(1L, saved.getTotalKills(),
             "totalKills should be 1 after one kill via processPlayerAttack");
@@ -121,23 +130,29 @@ class MobRegistryKillTrackingTest {
 
         // Use two separate registries / mob instances to simulate two distinct kills.
         StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        PersistenceQueue persistenceQueue = MobRegistryTestSupport.persistenceQueueFor(playerRepo);
         List<GameActionResult> captured = new ArrayList<>();
 
         MobTemplate template = templateWithHp(1);
-        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured);
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured, persistenceQueue);
 
         registry.processPlayerAttack(attacker, "Rat", ROOM_ID);
 
         // Reload the saved state and simulate a second kill.
+        assertTrue(persistenceQueue.flush(Duration.ofSeconds(2)));
+        persistenceQueue.close();
         Player afterFirst = playerRepo.load(attacker.getUsername());
         assertEquals(1L, afterFirst.getTotalKills());
 
         // The second kill reuses the same registry — mob respawns after scheduleRespawn,
         // so we rebuild to get a fresh instance.
         StubPlayerRepository playerRepo2 = new StubPlayerRepository(afterFirst);
-        MobRegistry registry2 = buildRegistry(template, afterFirst, playerRepo2, new ArrayList<>());
+        PersistenceQueue persistenceQueue2 = MobRegistryTestSupport.persistenceQueueFor(playerRepo2);
+        MobRegistry registry2 = buildRegistry(template, afterFirst, playerRepo2, new ArrayList<>(), persistenceQueue2);
         registry2.processPlayerAttack(afterFirst, "Rat", ROOM_ID);
 
+        assertTrue(persistenceQueue2.flush(Duration.ofSeconds(2)));
+        persistenceQueue2.close();
         Player afterSecond = playerRepo2.load(afterFirst.getUsername());
         assertEquals(2L, afterSecond.getTotalKills(),
             "totalKills should be 2 after two kills");
@@ -154,8 +169,9 @@ class MobRegistryKillTrackingTest {
         // 2 HP: first attack leaves 1 HP, next tick delivers the killing blow.
         MobTemplate template = templateWithHp(2);
         StubPlayerRepository playerRepo = new StubPlayerRepository(attacker);
+        PersistenceQueue persistenceQueue = MobRegistryTestSupport.persistenceQueueFor(playerRepo);
         List<GameActionResult> captured = new ArrayList<>();
-        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured);
+        MobRegistry registry = buildRegistry(template, attacker, playerRepo, captured, persistenceQueue);
 
         // First hit — mob survives, combat registered.
         registry.processPlayerAttack(attacker, "Rat", ROOM_ID);
@@ -164,6 +180,8 @@ class MobRegistryKillTrackingTest {
         // Tick — killing blow via runPlayerCombat.
         registry.tick();
 
+        assertTrue(persistenceQueue.flush(Duration.ofSeconds(2)));
+        persistenceQueue.close();
         Player saved = playerRepo.load(attacker.getUsername());
         assertEquals(1L, saved.getTotalKills(),
             "totalKills should be 1 after a tick kill via runPlayerCombat");

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryLootAnnouncementTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryLootAnnouncementTest.java
@@ -112,7 +112,7 @@ class MobRegistryLootAnnouncementTest {
         bus.register(attacker.getUsername(), captured::add);
 
         MobRegistry registry = new MobRegistry(
-            templateRepo, itemRepo, attackRepo, roomService, playerRepo, bus);
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo, MobRegistryTestSupport.persistenceQueueFor(playerRepo), bus);
         registry.init();
         return registry;
     }
@@ -211,7 +211,7 @@ class MobRegistryLootAnnouncementTest {
 
         MobRegistry registry = new MobRegistry(
             new StubMobTemplateRepository(List.of(template)),
-            itemRepo, attackRepo, roomService, playerRepo, bus);
+            itemRepo, attackRepo, roomService, playerRepo, MobRegistryTestSupport.persistenceQueueFor(playerRepo), bus);
         registry.init();
 
         GameActionResult result = registry.processPlayerAttack(

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryTestSupport.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryTestSupport.java
@@ -1,0 +1,31 @@
+package io.taanielo.jmud.core.mob;
+
+import java.time.Clock;
+
+import io.taanielo.jmud.core.audit.AuditEntry;
+import io.taanielo.jmud.core.audit.AuditService;
+import io.taanielo.jmud.core.audit.AuditSink;
+import io.taanielo.jmud.core.persistence.PersistenceQueue;
+import io.taanielo.jmud.core.player.PlayerRepository;
+
+/**
+ * Shared test helper for building a {@link PersistenceQueue} backed by a fake
+ * {@link PlayerRepository}, so {@code MobRegistry} tests (which construct
+ * {@code MobRegistry} directly rather than via {@code GameContext}) don't each
+ * repeat the same audit/queue boilerplate.
+ */
+final class MobRegistryTestSupport {
+
+    private MobRegistryTestSupport() {
+    }
+
+    static PersistenceQueue persistenceQueueFor(PlayerRepository playerRepository) {
+        AuditSink noOpSink = new AuditSink() {
+            @Override
+            public void write(AuditEntry entry) {
+            }
+        };
+        AuditService auditService = new AuditService(noOpSink, Clock.systemUTC(), () -> 0L, () -> "test-correlation");
+        return new PersistenceQueue(playerRepository, auditService);
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryWanderTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryWanderTest.java
@@ -1,7 +1,6 @@
 package io.taanielo.jmud.core.mob;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.List;
 import java.util.Map;
@@ -14,10 +13,10 @@ import io.taanielo.jmud.core.action.PlayerEventBus;
 import io.taanielo.jmud.core.authentication.Password;
 import io.taanielo.jmud.core.authentication.User;
 import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.combat.AttackDefinition;
 import io.taanielo.jmud.core.combat.AttackId;
 import io.taanielo.jmud.core.combat.CombatSettings;
 import io.taanielo.jmud.core.combat.repository.AttackRepository;
-import io.taanielo.jmud.core.combat.AttackDefinition;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.world.Direction;
@@ -95,7 +94,7 @@ class MobRegistryWanderTest {
         PlayerRepository playerRepo = new StubPlayerRepository();
         PlayerEventBus bus = new PlayerEventBus();
         MobRegistry registry = new MobRegistry(
-            templateRepo, itemRepo, attackRepo, roomService, playerRepo, bus);
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo, MobRegistryTestSupport.persistenceQueueFor(playerRepo), bus);
         registry.init();
         return registry;
     }

--- a/src/test/java/io/taanielo/jmud/core/persistence/PersistenceQueueTest.java
+++ b/src/test/java/io/taanielo/jmud/core/persistence/PersistenceQueueTest.java
@@ -1,0 +1,202 @@
+package io.taanielo.jmud.core.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.audit.AuditEntry;
+import io.taanielo.jmud.core.audit.AuditService;
+import io.taanielo.jmud.core.audit.AuditSink;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.player.PlayerVitals;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+
+/**
+ * Verifies the write-behind behaviour of {@link PersistenceQueue}: coalescing of
+ * bursty saves, synchronous draining via {@link PersistenceQueue#flush}, and the
+ * retry-then-count-failure path (AGENTS.md §5, §10).
+ */
+class PersistenceQueueTest {
+
+    private PersistenceQueue queue;
+
+    @AfterEach
+    void tearDown() {
+        if (queue != null) {
+            queue.close();
+        }
+    }
+
+    private static Player playerWithGold(int gold) {
+        PlayerVitals vitals = new PlayerVitals(20, 20, 10, 10, 10, 10);
+        User user = User.of(Username.of("sparky"), Password.hash("pw", 1000));
+        return new Player(user, 1, 0, vitals, List.of(), "prompt", false, List.of(), null, null)
+            .withGold(gold);
+    }
+
+    private static AuditService noOpAuditService() {
+        AuditSink sink = new AuditSink() {
+            @Override
+            public void write(AuditEntry entry) {
+            }
+        };
+        return new AuditService(sink, Clock.systemUTC(), () -> 0L, () -> "correlation");
+    }
+
+    @Test
+    void burstOfSavesForSamePlayerCoalescesToLatestState() throws InterruptedException {
+        CountDownLatch firstSaveStarted = new CountDownLatch(1);
+        CountDownLatch releaseFirstSave = new CountDownLatch(1);
+        AtomicInteger callCount = new AtomicInteger();
+        List<Player> saved = new CopyOnWriteArrayList<>();
+
+        PlayerRepository repository = new PlayerRepository() {
+            @Override
+            public void savePlayer(Player player) throws RepositoryException {
+                int callNumber = callCount.incrementAndGet();
+                if (callNumber == 1) {
+                    firstSaveStarted.countDown();
+                    await(releaseFirstSave);
+                }
+                saved.add(player);
+            }
+
+            @Override
+            public Optional<Player> loadPlayer(Username username) {
+                return Optional.empty();
+            }
+        };
+
+        queue = new PersistenceQueue(repository, noOpAuditService());
+
+        // First save starts immediately and blocks "mid-write" so subsequent saves for
+        // the same player enqueue while it is in flight.
+        queue.enqueueSave(playerWithGold(0));
+        assertTrue(firstSaveStarted.await(2, TimeUnit.SECONDS), "first save should have started");
+
+        for (int i = 1; i <= 20; i++) {
+            queue.enqueueSave(playerWithGold(i));
+        }
+
+        releaseFirstSave.countDown();
+
+        assertTrue(queue.flush(Duration.ofSeconds(5)), "flush should drain the queue");
+
+        // The in-flight first write plus one coalesced write of the latest state.
+        assertEquals(2, saved.size(), "burst of saves should collapse to at most 2 writes");
+        assertEquals(0, saved.get(0).getGold(), "first (in-flight) write is the initial snapshot");
+        assertEquals(20, saved.get(1).getGold(), "second write carries the latest coalesced state");
+    }
+
+    @Test
+    void flushWaitsForPendingWorkThenReturnsTrue() {
+        List<Player> saved = new CopyOnWriteArrayList<>();
+        PlayerRepository repository = new PlayerRepository() {
+            @Override
+            public void savePlayer(Player player) throws RepositoryException {
+                saved.add(player);
+            }
+
+            @Override
+            public Optional<Player> loadPlayer(Username username) {
+                return Optional.empty();
+            }
+        };
+        queue = new PersistenceQueue(repository, noOpAuditService());
+
+        queue.enqueueSave(playerWithGold(1));
+
+        assertTrue(queue.flush(Duration.ofSeconds(2)));
+        assertEquals(1, saved.size());
+        assertEquals(1, saved.get(0).getGold());
+    }
+
+    @Test
+    void writeFailureRetriesOnceThenIncrementsFailureCounter() {
+        AtomicInteger callCount = new AtomicInteger();
+        PlayerRepository repository = new PlayerRepository() {
+            @Override
+            public void savePlayer(Player player) throws RepositoryException {
+                callCount.incrementAndGet();
+                throw new RepositoryException("simulated failure");
+            }
+
+            @Override
+            public Optional<Player> loadPlayer(Username username) {
+                return Optional.empty();
+            }
+        };
+        queue = new PersistenceQueue(repository, noOpAuditService());
+
+        queue.enqueueSave(playerWithGold(1));
+
+        assertTrue(queue.flush(Duration.ofSeconds(3)));
+        assertEquals(2, callCount.get(), "should attempt an initial save plus one retry");
+        assertEquals(1, queue.getFailureCount());
+    }
+
+    @Test
+    void concurrentEnqueueDuringFlushDoesNotLoseNewestSnapshot() throws InterruptedException {
+        List<Player> saved = new CopyOnWriteArrayList<>();
+        CountDownLatch firstSaveStarted = new CountDownLatch(1);
+        CountDownLatch releaseFirstSave = new CountDownLatch(1);
+        AtomicInteger callCount = new AtomicInteger();
+
+        PlayerRepository repository = new PlayerRepository() {
+            @Override
+            public void savePlayer(Player player) throws RepositoryException {
+                if (callCount.incrementAndGet() == 1) {
+                    firstSaveStarted.countDown();
+                    await(releaseFirstSave);
+                }
+                saved.add(player);
+            }
+
+            @Override
+            public Optional<Player> loadPlayer(Username username) {
+                return Optional.empty();
+            }
+        };
+        queue = new PersistenceQueue(repository, noOpAuditService());
+
+        queue.enqueueSave(playerWithGold(0));
+        assertTrue(firstSaveStarted.await(2, TimeUnit.SECONDS));
+
+        Thread flushingThread = Thread.ofVirtual().start(() -> queue.flush(Duration.ofSeconds(5)));
+
+        queue.enqueueSave(playerWithGold(1));
+        queue.enqueueSave(playerWithGold(2));
+        queue.enqueueSave(playerWithGold(42));
+
+        releaseFirstSave.countDown();
+        flushingThread.join(Duration.ofSeconds(5).toMillis());
+
+        assertTrue(queue.flush(Duration.ofSeconds(5)));
+        assertEquals(42, saved.get(saved.size() - 1).getGold(), "the newest snapshot must be the last one written");
+        assertTrue(Set.of(2, 3).contains(saved.size()), "expected 2-3 writes, got " + saved.size());
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/PlayerSessionSaveFailureTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/PlayerSessionSaveFailureTest.java
@@ -3,13 +3,18 @@ package io.taanielo.jmud.core.server.socket;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.taanielo.jmud.core.audit.AuditEntry;
+import io.taanielo.jmud.core.audit.AuditService;
+import io.taanielo.jmud.core.audit.AuditSink;
 import io.taanielo.jmud.core.authentication.Password;
 import io.taanielo.jmud.core.authentication.User;
 import io.taanielo.jmud.core.authentication.Username;
@@ -28,6 +33,7 @@ import io.taanielo.jmud.core.effects.EffectRepository;
 import io.taanielo.jmud.core.effects.EffectRepositoryException;
 import io.taanielo.jmud.core.healing.HealingBaseResolver;
 import io.taanielo.jmud.core.healing.HealingEngine;
+import io.taanielo.jmud.core.persistence.PersistenceQueue;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.tick.TickRegistry;
@@ -40,11 +46,31 @@ import io.taanielo.jmud.core.world.repository.RepositoryException;
  * Verifies that {@link PlayerSession} surfaces player-save failures via its
  * save-failure hook, rather than silently swallowing them, satisfying the
  * "player warning + audit" acceptance criterion from a caller's perspective
- * (see issue #169).
+ * (see issue #169), now that saves are routed through the write-behind
+ * {@link PersistenceQueue} (issue #179).
  */
 class PlayerSessionSaveFailureTest {
 
+    private PersistenceQueue persistenceQueue;
+
+    @AfterEach
+    void tearDown() {
+        if (persistenceQueue != null) {
+            persistenceQueue.close();
+        }
+    }
+
+    private static AuditService noOpAuditService() {
+        AuditSink sink = new AuditSink() {
+            @Override
+            public void write(AuditEntry entry) {
+            }
+        };
+        return new AuditService(sink, Clock.systemUTC(), () -> 0L, () -> "correlation");
+    }
+
     private PlayerSession newSession(PlayerRepository playerRepository) {
+        this.persistenceQueue = new PersistenceQueue(playerRepository, noOpAuditService());
         RoomService roomService = new RoomService(new InMemoryRoomRepository(), RoomId.of("training-yard"));
         EffectRepository effectRepository = new EffectRepository() {
             @Override
@@ -80,7 +106,7 @@ class PlayerSessionSaveFailureTest {
 
         return new PlayerSession(
             new TickRegistry(),
-            playerRepository,
+            persistenceQueue,
             roomService,
             updated -> { },
             effectEngine,
@@ -112,17 +138,19 @@ class PlayerSessionSaveFailureTest {
     }
 
     @Test
-    void replacePlayerNotifiesSaveFailureHandlerWhenSaveFails() {
+    void replacePlayerEnqueuesSaveThatIsEventuallyRetriedAndCounted() {
         FailingPlayerRepository repository = new FailingPlayerRepository();
         PlayerSession session = newSession(repository);
-        List<Player> notifiedFailures = new ArrayList<>();
-        session.setSaveFailureHandler(notifiedFailures::add);
 
         Player player = newPlayer("sparky");
         session.replacePlayer(player);
 
-        assertEquals(1, notifiedFailures.size(), "Caller must be notified so it can warn the player");
-        assertEquals(player.getUsername(), notifiedFailures.get(0).getUsername());
+        // Saves are now write-behind (issue #179): replacePlayer only enqueues, it does
+        // not block or synchronously invoke the save-failure handler. The eventual
+        // failure (after the queue's single retry) is still observable via the queue.
+        assertTrue(persistenceQueue.flush(java.time.Duration.ofSeconds(3)), "queue should drain (even a failed save is removed from the queue)");
+        assertEquals(2, repository.saveAttempts.get(), "the queue must retry once before giving up");
+        assertEquals(1, persistenceQueue.getFailureCount());
     }
 
     @Test

--- a/src/test/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinatorTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinatorTest.java
@@ -18,6 +18,7 @@ import io.taanielo.jmud.core.authentication.Password;
 import io.taanielo.jmud.core.authentication.User;
 import io.taanielo.jmud.core.authentication.Username;
 import io.taanielo.jmud.core.messaging.Message;
+import io.taanielo.jmud.core.persistence.PersistenceQueue;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerRepository;
 import io.taanielo.jmud.core.server.Client;
@@ -75,9 +76,10 @@ class ShutdownCoordinatorTest {
                 super.shutdown(timeout);
             }
         };
+        PersistenceQueue persistenceQueue = new PersistenceQueue(playerRepository, auditService);
 
         ShutdownCoordinator coordinator = new ShutdownCoordinator(
-            List.of(server), clientPool, tickScheduler, tickRegistry, playerRepository, auditService, Duration.ofMillis(200)
+            List.of(server), clientPool, tickScheduler, tickRegistry, persistenceQueue, auditService, Duration.ofMillis(200)
         );
 
         coordinator.shutdown();
@@ -130,9 +132,10 @@ class ShutdownCoordinatorTest {
             public void write(AuditEntry entry) {
             }
         }, java.time.Clock.systemUTC(), () -> 0L, () -> "corr");
+        PersistenceQueue persistenceQueue = new PersistenceQueue(playerRepository, auditService);
 
         ShutdownCoordinator coordinator = new ShutdownCoordinator(
-            List.of(), clientPool, tickScheduler, tickRegistry, playerRepository, auditService, Duration.ofMillis(200)
+            List.of(), clientPool, tickScheduler, tickRegistry, persistenceQueue, auditService, Duration.ofMillis(200)
         );
 
         coordinator.shutdown();


### PR DESCRIPTION
Closes #179

## Summary

- New `io.taanielo.jmud.core.persistence.PersistenceQueue`: a coalescing write-behind queue backed by a latest-snapshot-per-username map plus a dirty-username blocking queue. A single dedicated virtual thread drains it and calls `playerRepository.savePlayer(...)`. Public API is `enqueueSave(...)`, `flush(Duration)`, `close()`. Failed writes get a single retry with a 200ms backoff; a final failure increments a failure counter and emits an audit event instead of throwing back into caller code.

- **Snapshot safety**: while implementing the queue we found `PlayerCombatState.effects()` is genuinely mutable — tick-down, refresh, and stacking all happen in place on the live `EffectInstance` list. Since the writer thread runs concurrently with the tick thread, it must never see live game state. Added `EffectInstance#copy()` and `Player#snapshotForPersistence()` so every enqueued save is a defensive deep copy taken at enqueue time, not a live reference.

- **Wiring**: `GameContext` (the composition root) constructs the single `PersistenceQueue` instance. All tick/command-path call sites that used to call `playerRepository.savePlayer(...)` directly (`SocketClient`, `PlayerSession`, `MobRegistry`) now call `persistenceQueue.enqueueSave(...)`. `PlayerSession.close()` (QUIT/disconnect) and `ShutdownCoordinator.saveOnlinePlayers()` enqueue and then `flush()` before proceeding; shutdown additionally closes the queue afterward.

- **Tests**: new `PersistenceQueueTest` covers coalescing of repeated saves for the same player, flush-drains-queue behavior, retry-then-failure-counter behavior, and concurrent enqueue-during-flush. Updated `PlayerSessionSaveFailureTest`, `ShutdownCoordinatorTest`, and the `MobRegistry*Test` suite for the now-asynchronous save path.

## Known deviation

`flush()` only reports whether the queue drained, not whether the underlying save ultimately succeeded — a save that fails even after its retry is still removed from the queue once the writer gives up on it. To avoid silently swallowing real save failures on the player-facing path, `PlayerSession.close()` additionally compares `getFailureCount()` before/after the flush so it can still surface a save failure warning to the disconnecting player.

## Test plan

- [x] `./gradlew check` (including ArchUnit) — verified green independently
- [x] `scripts/smoke-test.sh` end-to-end telnet smoke test — verified green independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)