### PR TITLE
feat(messaging): add room/player-scoped messaging to MessageBroadcaster

### DIFF
--- a/src/main/java/io/taanielo/jmud/Main.java
+++ b/src/main/java/io/taanielo/jmud/Main.java
@@ -24,7 +24,7 @@ public class Main {
         String sshHost = resolveHost(args, "--ssh-host", "JMUD_SSH_HOST", "0.0.0.0");
         int sshPort = resolvePort(args, "--ssh-port", "JMUD_SSH_PORT", 2222);
         ClientPool clientPool = new DefaultClientPool();
-        GameContext context = GameContext.create();
+        GameContext context = GameContext.create(clientPool);
         context.tickScheduler().start();
 
         Server telnetServer = telnetEnabled ? new SocketServer(telnetHost, telnetPort, context, clientPool) : null;

--- a/src/main/java/io/taanielo/jmud/core/messaging/MessageBroadcaster.java
+++ b/src/main/java/io/taanielo/jmud/core/messaging/MessageBroadcaster.java
@@ -1,7 +1,46 @@
 package io.taanielo.jmud.core.messaging;
 
-import io.taanielo.jmud.core.server.Client;
+import java.util.Set;
 
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.world.RoomId;
+
+/**
+ * Scoped message delivery service: player-, room-, and server-wide broadcast.
+ *
+ * <p>This is the only sanctioned fan-out mechanism for delivering {@link Message}s to
+ * connected clients (AGENTS.md §3.3); adapters (e.g. the socket layer) must route all
+ * multi-recipient delivery through here instead of hand-rolling loops over connected
+ * clients.
+ */
 public interface MessageBroadcaster {
-    void broadcast(Client client, Message message);
+
+    /**
+     * Delivers a message to a single online player, identified by username.
+     *
+     * <p>This is a no-op (and does not throw) when the target player is not currently
+     * connected.
+     *
+     * @param target  the recipient's username
+     * @param message the message to deliver
+     */
+    void sendToPlayer(Username target, Message message);
+
+    /**
+     * Delivers a message to every online player currently located in the given room.
+     *
+     * @param room    the room whose occupants should receive the message
+     * @param message the message to deliver
+     * @param exclude usernames to skip even if present in the room (e.g. the speaker);
+     *                may be empty, never {@code null}
+     */
+    void broadcastToRoom(RoomId room, Message message, Set<Username> exclude);
+
+    /**
+     * Delivers a message to every online player, regardless of location.
+     *
+     * @param message the message to deliver
+     * @param exclude usernames to skip (e.g. the sender); may be empty, never {@code null}
+     */
+    void broadcastGlobal(Message message, Set<Username> exclude);
 }

--- a/src/main/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImpl.java
+++ b/src/main/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImpl.java
@@ -1,21 +1,80 @@
 package io.taanielo.jmud.core.messaging;
 
-import static java.util.function.Predicate.not;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.server.Client;
 import io.taanielo.jmud.core.server.ClientPool;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
 
+/**
+ * Default {@link MessageBroadcaster}: resolves recipients via the {@link ClientPool} (for the
+ * connected-clients snapshot) and {@link RoomService} (for room occupancy), and never depends on
+ * any concrete transport type. Constructed only by the composition root (AGENTS.md §3.3).
+ *
+ * <p>Safe to call from both reader threads (e.g. during login) and the tick thread: the backing
+ * {@link ClientPool#clients()} snapshot is an immutable {@link java.util.List} copy, so no locking
+ * is required here (AGENTS.md §5).
+ */
 public class MessageBroadcasterImpl implements MessageBroadcaster {
-    private final ClientPool clientPool;
 
-    public MessageBroadcasterImpl(ClientPool clientPool) {
-        this.clientPool = clientPool;
+    private final ClientPool clientPool;
+    private final RoomService roomService;
+
+    /**
+     * Creates a broadcaster backed by the given client pool and room service.
+     *
+     * @param clientPool  provides the current snapshot of connected clients
+     * @param roomService  provides room occupancy lookups
+     */
+    public MessageBroadcasterImpl(ClientPool clientPool, RoomService roomService) {
+        this.clientPool = Objects.requireNonNull(clientPool, "Client pool is required");
+        this.roomService = Objects.requireNonNull(roomService, "Room service is required");
     }
 
     @Override
-    public void broadcast(Client client, Message message) {
-        clientPool.clients().stream()
-                .filter(not(c -> c.equals(client)))
-                .forEach(c -> c.sendMessage(message));
+    public void sendToPlayer(Username target, Message message) {
+        Objects.requireNonNull(target, "Target username is required");
+        Objects.requireNonNull(message, "Message is required");
+        findClient(target).ifPresent(client -> client.sendMessage(message));
+    }
+
+    @Override
+    public void broadcastToRoom(RoomId room, Message message, Set<Username> exclude) {
+        Objects.requireNonNull(room, "Room id is required");
+        Objects.requireNonNull(message, "Message is required");
+        Set<Username> excluded = exclude == null ? Set.of() : exclude;
+        List<Username> occupants = roomService.getPlayersInRoom(room);
+        for (Username occupant : occupants) {
+            if (excluded.contains(occupant)) {
+                continue;
+            }
+            findClient(occupant).ifPresent(client -> client.sendMessage(message));
+        }
+    }
+
+    @Override
+    public void broadcastGlobal(Message message, Set<Username> exclude) {
+        Objects.requireNonNull(message, "Message is required");
+        Set<Username> excluded = exclude == null ? Set.of() : exclude;
+        for (Client client : clientPool.clients()) {
+            client.currentPlayer()
+                .map(Player::getUsername)
+                .filter(username -> !excluded.contains(username))
+                .ifPresent(ignored -> client.sendMessage(message));
+        }
+    }
+
+    private Optional<Client> findClient(Username username) {
+        return clientPool.clients().stream()
+            .filter(client -> client.currentPlayer()
+                .map(player -> player.getUsername().equals(username))
+                .orElse(false))
+            .findFirst();
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/messaging/PlainTextMessage.java
+++ b/src/main/java/io/taanielo/jmud/core/messaging/PlainTextMessage.java
@@ -1,0 +1,22 @@
+package io.taanielo.jmud.core.messaging;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A single line of unstyled text, e.g. chat/emote output routed through
+ * {@link MessageBroadcaster}. Unlike {@link SystemNoticeMessage}, it does not
+ * prepend a blank line, so it matches the plain {@code writeLine} behaviour
+ * previously hand-rolled by socket adapters for say/tell/gossip/emote.
+ */
+public record PlainTextMessage(String text) implements Message {
+
+    public PlainTextMessage {
+        Objects.requireNonNull(text, "Text is required");
+    }
+
+    @Override
+    public void send(MessageWriter messageWriter) throws IOException {
+        messageWriter.writeLine(text);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GameContext.java
@@ -38,6 +38,8 @@ import io.taanielo.jmud.core.effects.EffectRepositoryException;
 import io.taanielo.jmud.core.effects.repository.json.JsonEffectRepository;
 import io.taanielo.jmud.core.healing.HealingBaseResolver;
 import io.taanielo.jmud.core.healing.HealingEngine;
+import io.taanielo.jmud.core.messaging.MessageBroadcaster;
+import io.taanielo.jmud.core.messaging.MessageBroadcasterImpl;
 import io.taanielo.jmud.core.mob.MobRegistry;
 import io.taanielo.jmud.core.mob.repository.json.JsonMobTemplateRepository;
 import io.taanielo.jmud.core.party.PartyService;
@@ -50,6 +52,7 @@ import io.taanielo.jmud.core.quest.QuestKillService;
 import io.taanielo.jmud.core.quest.QuestRepository;
 import io.taanielo.jmud.core.quest.QuestRepositoryException;
 import io.taanielo.jmud.core.quest.repository.json.JsonQuestRepository;
+import io.taanielo.jmud.core.server.ClientPool;
 import io.taanielo.jmud.core.shop.ShopRepository;
 import io.taanielo.jmud.core.shop.ShopRepositoryException;
 import io.taanielo.jmud.core.shop.ShopService;
@@ -97,13 +100,17 @@ public record GameContext(
     ShopService shopService,
     QuestRepository questRepository,
     PartyService partyService,
-    BankService bankService
+    BankService bankService,
+    MessageBroadcaster messageBroadcaster
 ) {
 
     /**
      * Builds a fully wired context for the socket server.
+     *
+     * @param clientPool the pool of connected clients, used to wire {@link MessageBroadcaster}
+     *                    without transport adapters ever constructing it themselves
      */
-    public static GameContext create() {
+    public static GameContext create(ClientPool clientPool) {
         GameConfig config = GameConfig.load();
         UserRegistry userRegistry = createUserRegistry();
         AuthenticationPolicy authenticationPolicy = AuthenticationPolicy.fromConfig(config);
@@ -162,6 +169,8 @@ public record GameContext(
             mobRegistry.setPartyService(partyService);
         }
 
+        MessageBroadcaster messageBroadcaster = new MessageBroadcasterImpl(clientPool, roomService);
+
         return new GameContext(
             userRegistry,
             authenticationPolicy,
@@ -190,7 +199,8 @@ public record GameContext(
             shopService,
             questRepository,
             partyService,
-            bankService
+            bankService,
+            messageBroadcaster
         );
     }
 

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -4,11 +4,13 @@ import java.io.IOException;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -40,6 +42,7 @@ import io.taanielo.jmud.core.creation.CharacterCreationState.ChoosingClass;
 import io.taanielo.jmud.core.creation.CharacterCreationState.ChoosingRace;
 import io.taanielo.jmud.core.effects.EffectMessageSink;
 import io.taanielo.jmud.core.messaging.Message;
+import io.taanielo.jmud.core.messaging.PlainTextMessage;
 import io.taanielo.jmud.core.messaging.UserSayMessage;
 import io.taanielo.jmud.core.messaging.WelcomeBannerMessage;
 import io.taanielo.jmud.core.messaging.WelcomeMessage;
@@ -680,14 +683,7 @@ public class SocketClient implements Client {
         if (message == null || message.isBlank()) {
             return;
         }
-        for (Client client : clientPool.clients()) {
-            if (client instanceof SocketClient socketClient) {
-                if (socketClient.isAuthenticatedUser(username)) {
-                    socketClient.connection.writeLine(message);
-                    return;
-                }
-            }
-        }
+        context.messageBroadcaster().sendToPlayer(username, new PlainTextMessage(message));
     }
 
     private void sendToRoom(Player source, Player target, String message) {
@@ -698,15 +694,8 @@ public class SocketClient implements Client {
         if (message == null || message.isBlank() || room == null) {
             return;
         }
-        if (room.getOccupants().isEmpty()) {
-            return;
-        }
-        for (Username occupant : room.getOccupants()) {
-            if (exclude != null && occupant.equals(exclude)) {
-                continue;
-            }
-            sendToUsername(occupant, message);
-        }
+        Set<Username> excludeSet = exclude == null ? Set.of() : Set.of(exclude);
+        context.messageBroadcaster().broadcastToRoom(room.getId(), new PlainTextMessage(message), excludeSet);
     }
 
     private void deliverRoomMessage(Username sourceExclude, Username targetExclude, String message) {
@@ -719,18 +708,18 @@ public class SocketClient implements Client {
         if (lookupUser == null) {
             return;
         }
-        RoomService.LookResult look = roomService.look(lookupUser);
-        Room room = look.room();
-        if (room == null || room.getOccupants().isEmpty()) {
+        Optional<RoomId> roomIdOpt = roomService.findPlayerLocation(lookupUser);
+        if (roomIdOpt.isEmpty()) {
             return;
         }
-        for (Username occupant : room.getOccupants()) {
-            if ((sourceExclude != null && occupant.equals(sourceExclude))
-                || (targetExclude != null && occupant.equals(targetExclude))) {
-                continue;
-            }
-            sendToUsername(occupant, message);
+        Set<Username> excludeSet = new HashSet<>();
+        if (sourceExclude != null) {
+            excludeSet.add(sourceExclude);
         }
+        if (targetExclude != null) {
+            excludeSet.add(targetExclude);
+        }
+        context.messageBroadcaster().broadcastToRoom(roomIdOpt.get(), new PlainTextMessage(message), excludeSet);
     }
 
     // ── Persistence ─────────────────────────────────────────────────────
@@ -1322,21 +1311,11 @@ public class SocketClient implements Client {
 
         @Override
         public void gossip(String senderName, String message) {
-            for (Client client : clientPool.clients()) {
-                if (client instanceof SocketClient socketClient) {
-                    Optional<Username> usernameOpt = socketClient.authenticatedUsername();
-                    if (usernameOpt.isEmpty()) {
-                        continue;
-                    }
-                    Username recipient = usernameOpt.get();
-                    // Skip the sender — they already see "You gossip: ..." from GossipCommand.
-                    if (recipient.equals(Username.of(senderName))) {
-                        continue;
-                    }
-                    socketClient.connection.writeLine(senderName + " gossips: " + message);
-                    socketClient.sendPrompt();
-                }
-            }
+            // Skip the sender — they already see "You gossip: ..." from GossipCommand.
+            context.messageBroadcaster().broadcastGlobal(
+                new PlainTextMessage(senderName + " gossips: " + message),
+                Set.of(Username.of(senderName))
+            );
         }
 
         @Override

--- a/src/test/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImplTest.java
+++ b/src/test/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImplTest.java
@@ -1,0 +1,218 @@
+package io.taanielo.jmud.core.messaging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.server.ClientPool;
+import io.taanielo.jmud.core.world.Direction;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Unit tests for {@link MessageBroadcasterImpl} covering player, room, and global scoping,
+ * plus exclusion sets and the offline-recipient no-op case.
+ */
+class MessageBroadcasterImplTest {
+
+    private static final RoomId ROOM_ONE = RoomId.of("room-one");
+    private static final RoomId ROOM_TWO = RoomId.of("room-two");
+
+    @Test
+    void sendToPlayerDeliversOnlyToTargetClient() {
+        FakeClient alice = fakeClient("Alice");
+        FakeClient bob = fakeClient("Bob");
+        MessageBroadcaster broadcaster = broadcaster(List.of(alice, bob), twoRoomService());
+
+        Message message = new PlainTextMessage("hello");
+        broadcaster.sendToPlayer(Username.of("Bob"), message);
+
+        assertTrue(alice.received.isEmpty(), "Only the target should receive the message");
+        assertEquals(List.of(message), bob.received);
+    }
+
+    @Test
+    void sendToPlayerToOfflinePlayerIsCleanNoOp() {
+        FakeClient alice = fakeClient("Alice");
+        MessageBroadcaster broadcaster = broadcaster(List.of(alice), twoRoomService());
+
+        broadcaster.sendToPlayer(Username.of("Ghost"), new PlainTextMessage("hello?"));
+
+        assertTrue(alice.received.isEmpty(), "No connected client should receive anything");
+    }
+
+    @Test
+    void broadcastToRoomReachesOnlyRoomOccupants() {
+        RoomService roomService = twoRoomService();
+        FakeClient alice = fakeClient("Alice");
+        FakeClient bob = fakeClient("Bob");
+        FakeClient carol = fakeClient("Carol");
+        roomService.ensurePlayerLocation(alice.player.getUsername());
+        roomService.ensurePlayerLocation(bob.player.getUsername());
+        roomService.ensurePlayerLocation(carol.player.getUsername());
+        roomService.move(carol.player.getUsername(), Direction.NORTH);
+        MessageBroadcaster broadcaster = broadcaster(List.of(alice, bob, carol), roomService);
+
+        Message message = new PlainTextMessage("Alice says hi");
+        broadcaster.broadcastToRoom(ROOM_ONE, message, Set.of());
+
+        assertEquals(List.of(message), alice.received);
+        assertEquals(List.of(message), bob.received);
+        assertTrue(carol.received.isEmpty(), "Occupant of a different room must not receive the message");
+    }
+
+    @Test
+    void broadcastToRoomHonoursExclusions() {
+        RoomService roomService = twoRoomService();
+        FakeClient alice = fakeClient("Alice");
+        FakeClient bob = fakeClient("Bob");
+        roomService.ensurePlayerLocation(alice.player.getUsername());
+        roomService.ensurePlayerLocation(bob.player.getUsername());
+        MessageBroadcaster broadcaster = broadcaster(List.of(alice, bob), roomService);
+
+        Message message = new PlainTextMessage("Alice says hi");
+        broadcaster.broadcastToRoom(ROOM_ONE, message, Set.of(Username.of("Alice")));
+
+        assertTrue(alice.received.isEmpty(), "Excluded speaker must not receive the room broadcast");
+        assertEquals(List.of(message), bob.received);
+    }
+
+    @Test
+    void broadcastGlobalReachesEveryoneMinusExclusions() {
+        FakeClient alice = fakeClient("Alice");
+        FakeClient bob = fakeClient("Bob");
+        FakeClient carol = fakeClient("Carol");
+        MessageBroadcaster broadcaster = broadcaster(List.of(alice, bob, carol), twoRoomService());
+
+        Message message = new PlainTextMessage("Alice gossips: hi everyone");
+        broadcaster.broadcastGlobal(message, Set.of(Username.of("Alice")));
+
+        assertTrue(alice.received.isEmpty(), "Sender should be excluded from the global broadcast");
+        assertEquals(List.of(message), bob.received);
+        assertEquals(List.of(message), carol.received);
+    }
+
+    // --- helpers ---
+
+    private static MessageBroadcaster broadcaster(List<Client> clients, RoomService roomService) {
+        ClientPool pool = new FakeClientPool(clients);
+        return new MessageBroadcasterImpl(pool, roomService);
+    }
+
+    /** Two adjacent rooms (ROOM_ONE --north--> ROOM_TWO), starting room is ROOM_ONE. */
+    private static RoomService twoRoomService() {
+        Room roomOne = new Room(
+            ROOM_ONE,
+            "Room One",
+            "The first room.",
+            Map.of(Direction.NORTH, ROOM_TWO),
+            List.of(),
+            List.of()
+        );
+        Room roomTwo = new Room(
+            ROOM_TWO,
+            "Room Two",
+            "The second room.",
+            Map.of(Direction.SOUTH, ROOM_ONE),
+            List.of(),
+            List.of()
+        );
+        RoomRepository repository = new InMemoryRoomRepository(Map.of(ROOM_ONE, roomOne, ROOM_TWO, roomTwo));
+        return new RoomService(repository, ROOM_ONE);
+    }
+
+    private static FakeClient fakeClient(String username) {
+        User user = User.of(Username.of(username), Password.hash("secret"));
+        Player player = Player.of(user, "%h/%H hp>");
+        return new FakeClient(player);
+    }
+
+    private static final class FakeClient implements Client {
+        private final Player player;
+        private final List<Message> received = new ArrayList<>();
+
+        private FakeClient(Player player) {
+            this.player = player;
+        }
+
+        @Override
+        public void sendMessage(Message message) {
+            received.add(message);
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public Optional<Player> currentPlayer() {
+            return Optional.of(player);
+        }
+
+        @Override
+        public void run() {
+        }
+    }
+
+    private static final class FakeClientPool implements ClientPool {
+        private final List<Client> clients;
+
+        private FakeClientPool(List<Client> clients) {
+            this.clients = new CopyOnWriteArrayList<>(clients);
+        }
+
+        @Override
+        public void add(Client client) {
+            clients.add(client);
+        }
+
+        @Override
+        public void remove(Client client) {
+            clients.remove(client);
+        }
+
+        @Override
+        public int getNextId() {
+            return clients.size();
+        }
+
+        @Override
+        public List<Client> clients() {
+            return List.copyOf(clients);
+        }
+    }
+
+    private static final class InMemoryRoomRepository implements RoomRepository {
+        private final Map<RoomId, Room> rooms;
+
+        private InMemoryRoomRepository(Map<RoomId, Room> rooms) {
+            this.rooms = rooms;
+        }
+
+        @Override
+        public void save(Room room) throws RepositoryException {
+            // not needed for these tests
+        }
+
+        @Override
+        public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return Optional.ofNullable(rooms.get(id));
+        }
+    }
+}


### PR DESCRIPTION
Closes #180

## Summary

Redesigns `MessageBroadcaster` to support room- and player-scoped message delivery, replacing hand-rolled fan-out loops in `SocketClient` with a proper broadcaster abstraction.

- `MessageBroadcaster` redesigned with `sendToPlayer(Username, Message)`, `broadcastToRoom(RoomId, Message, Set<Username> exclude)`, `broadcastGlobal(Message, Set<Username> exclude)`.
- New `MessageBroadcasterImpl` backed by `ClientPool` (player lookup) and `RoomService.getPlayersInRoom` (room occupancy).
- New `PlainTextMessage` for unstyled chat/emote text, preserving prior no-styling behavior exactly.
- `GameContext` composition root now takes `ClientPool` and constructs the broadcaster; `Main.java` updated accordingly.
- `SocketClient`'s hand-rolled fan-out (`sendToUsername`, `deliverRoomMessage`, `gossip`) now delegates to the broadcaster — no fan-out loops remain there for message delivery.
- New `MessageBroadcasterImplTest` covering room/player/global scoping, exclusions, and offline-player no-op.

Notes:
- `MessageBroadcaster` was previously unwired dead code, so no construction-cycle workaround was needed.
- `scripts/smoke-test.sh` doesn't cover chat commands, so this was verified manually via a two-client telnet session instead — both SAY (room-scoped) and GOSSIP (global, sender-excluded) confirmed correct, with no duplication.

## Test plan
- [x] `./gradlew check` green
- [x] Manual two-client telnet session: SAY delivers only to same room, GOSSIP delivers globally excluding sender, no duplicate messages
- [x] New unit tests for `MessageBroadcasterImpl`