### PR TITLE
refactor(world): split RoomService into location, rendering, and item services

### DIFF
--- a/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
@@ -65,7 +65,10 @@ import io.taanielo.jmud.core.tick.FixedRateTickScheduler;
 import io.taanielo.jmud.core.tick.TickClock;
 import io.taanielo.jmud.core.tick.TickRegistry;
 import io.taanielo.jmud.core.world.CorpseDecayTicker;
+import io.taanielo.jmud.core.world.PlayerLocationService;
 import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomItemService;
+import io.taanielo.jmud.core.world.RoomRenderer;
 import io.taanielo.jmud.core.world.RoomService;
 import io.taanielo.jmud.core.world.repository.ItemRepository;
 import io.taanielo.jmud.core.world.repository.RepositoryException;
@@ -131,13 +134,17 @@ public record GameContext(
         JsonClassRepository classRepository = createClassRepository();
 
         RoomRepository roomRepository = createRoomRepository(itemRepository);
-        RoomService roomService = new RoomService(roomRepository, RoomId.of("training-yard"));
+        RoomItemService roomItemService = new RoomItemService();
+        PlayerLocationService playerLocationService =
+            new PlayerLocationService(roomRepository, RoomId.of("training-yard"));
+        RoomService roomService = new RoomService(
+            playerLocationService, roomItemService, new RoomRenderer(), roomRepository);
 
         TickRegistry tickRegistry = new TickRegistry();
         TickClock tickClock = new TickClock();
         tickRegistry.register(tickClock);
         tickRegistry.register(new CorpseDecayTicker(
-            roomService,
+            roomItemService,
             java.time.Duration.ofSeconds(DeathSettings.corpseDecaySeconds())
         ));
         FixedRateTickScheduler tickScheduler = new FixedRateTickScheduler(tickRegistry);

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
@@ -56,6 +56,7 @@ import io.taanielo.jmud.core.server.ClientPool;
 import io.taanielo.jmud.core.server.connection.ClientConnection;
 import io.taanielo.jmud.core.shop.ShopTransactionResult;
 import io.taanielo.jmud.core.world.Direction;
+import io.taanielo.jmud.core.world.DoorActionResult;
 import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.Room;
@@ -1327,7 +1328,7 @@ class SocketCommandContextImpl implements SocketCommandContext {
             return;
         }
         Player player = session.getPlayer();
-        RoomService.DoorActionResult result = roomService.lock(
+        DoorActionResult result = roomService.lock(
             player.getUsername(), direction, player.getInventory());
         if (result.roomMessage() != null) {
             deliverRoomMessage(player.getUsername(), null, result.roomMessage());
@@ -1342,7 +1343,7 @@ class SocketCommandContextImpl implements SocketCommandContext {
             return;
         }
         Player player = session.getPlayer();
-        RoomService.DoorActionResult result = roomService.unlock(
+        DoorActionResult result = roomService.unlock(
             player.getUsername(), direction, player.getInventory());
         if (result.roomMessage() != null) {
             deliverRoomMessage(player.getUsername(), null, result.roomMessage());

--- a/src/main/java/io/taanielo/jmud/core/world/CorpseDecayTicker.java
+++ b/src/main/java/io/taanielo/jmud/core/world/CorpseDecayTicker.java
@@ -8,23 +8,23 @@ import io.taanielo.jmud.core.tick.Tickable;
 /**
  * Per-tick service that removes expired player corpses from the world.
  *
- * <p>On each tick, any corpse tracked by {@link RoomService} that is older than
- * the configured {@code decayAfter} duration is removed from its room.
+ * <p>On each tick, any corpse tracked by {@link RoomItemService} that is older than the
+ * configured {@code decayAfter} duration is removed from its room.
  */
 public class CorpseDecayTicker implements Tickable {
 
-    private final RoomService roomService;
+    private final RoomItemService roomItemService;
     private final Duration decayAfter;
 
     /**
      * Creates a corpse decay ticker.
      *
-     * @param roomService the room service used to remove decayed corpse items
-     * @param decayAfter  how long after creation a corpse persists before decaying;
-     *                    must be positive
+     * @param roomItemService the item service used to remove decayed corpse items
+     * @param decayAfter      how long after creation a corpse persists before decaying;
+     *                        must be positive
      */
-    public CorpseDecayTicker(RoomService roomService, Duration decayAfter) {
-        this.roomService = Objects.requireNonNull(roomService, "Room service is required");
+    public CorpseDecayTicker(RoomItemService roomItemService, Duration decayAfter) {
+        this.roomItemService = Objects.requireNonNull(roomItemService, "Room item service is required");
         this.decayAfter = Objects.requireNonNull(decayAfter, "Decay duration is required");
         if (decayAfter.isNegative() || decayAfter.isZero()) {
             throw new IllegalArgumentException("Decay duration must be positive");
@@ -36,6 +36,6 @@ public class CorpseDecayTicker implements Tickable {
      */
     @Override
     public void tick() {
-        roomService.removeExpiredCorpses(decayAfter);
+        roomItemService.removeExpiredCorpses(decayAfter);
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/DoorActionResult.java
+++ b/src/main/java/io/taanielo/jmud/core/world/DoorActionResult.java
@@ -1,0 +1,13 @@
+package io.taanielo.jmud.core.world;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Result of a lock or unlock door action.
+ *
+ * @param success       whether the action was performed
+ * @param playerMessage message shown to the acting player
+ * @param roomMessage   message broadcast to other room occupants, or {@code null} on failure
+ */
+public record DoorActionResult(boolean success, String playerMessage, @Nullable String roomMessage) {
+}

--- a/src/main/java/io/taanielo/jmud/core/world/PlayerLocationService.java
+++ b/src/main/java/io/taanielo/jmud/core/world/PlayerLocationService.java
@@ -1,0 +1,327 @@
+package io.taanielo.jmud.core.world;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jspecify.annotations.Nullable;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Domain service that owns the player-location map, movement validation, and door lock state.
+ *
+ * <p>Movement includes exit existence checks, locked-door enforcement, and bi-directional lock
+ * propagation. Lock state is seeded lazily from room data and maintained in memory for the
+ * duration of the server session.
+ *
+ * <p>All mutation happens on the tick thread (AGENTS.md §5).
+ */
+public class PlayerLocationService {
+
+    private final RoomRepository roomRepository;
+    private final RoomId startingRoomId;
+    private final ConcurrentHashMap<Username, RoomId> playerLocations = new ConcurrentHashMap<>();
+    /**
+     * Runtime locked-exit state: maps each room id to the set of directions that are currently
+     * locked. Seeded lazily from each room's {@link Room#getLockedExits()} on first access.
+     */
+    private final ConcurrentHashMap<RoomId, Set<Direction>> runtimeLockedExits = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a player location service.
+     *
+     * @param roomRepository the room data store used to validate exits and key requirements
+     * @param startingRoomId the room that new or respawning players are placed into
+     */
+    public PlayerLocationService(RoomRepository roomRepository, RoomId startingRoomId) {
+        this.roomRepository = Objects.requireNonNull(roomRepository, "Room repository is required");
+        this.startingRoomId = Objects.requireNonNull(startingRoomId, "Starting room id is required");
+    }
+
+    /**
+     * Returns all player usernames currently in the given room.
+     *
+     * @param roomId the room to query
+     * @return an unmodifiable list of occupant usernames
+     */
+    public List<Username> getPlayersInRoom(RoomId roomId) {
+        Objects.requireNonNull(roomId, "Room id is required");
+        return playerLocations.entrySet().stream()
+            .filter(e -> e.getValue().equals(roomId))
+            .map(Map.Entry::getKey)
+            .toList();
+    }
+
+    /**
+     * Ensures the player has a location, defaulting to the starting room if absent.
+     *
+     * @param username the player
+     * @return the player's current (or newly assigned) room id
+     */
+    public RoomId ensurePlayerLocation(Username username) {
+        Objects.requireNonNull(username, "Username is required");
+        return playerLocations.computeIfAbsent(username, ignored -> startingRoomId);
+    }
+
+    /**
+     * Returns the player's current room id, if tracked.
+     *
+     * @param username the player
+     * @return the room id, or empty if the player has no location
+     */
+    public Optional<RoomId> findPlayerLocation(Username username) {
+        Objects.requireNonNull(username, "Username is required");
+        return Optional.ofNullable(playerLocations.get(username));
+    }
+
+    /**
+     * Removes the player from the location map (used on death or disconnect).
+     *
+     * @param username the player to remove
+     */
+    public void clearPlayerLocation(Username username) {
+        Objects.requireNonNull(username, "Username is required");
+        playerLocations.remove(username);
+    }
+
+    /**
+     * Moves the player to the starting (respawn) room.
+     *
+     * @param username the player to respawn
+     * @return the starting room id
+     */
+    public RoomId respawnPlayer(Username username) {
+        Objects.requireNonNull(username, "Username is required");
+        playerLocations.put(username, startingRoomId);
+        return startingRoomId;
+    }
+
+    /**
+     * Returns the exit map for the given room, or an empty map if the room cannot be found.
+     *
+     * <p>Used by mob AI to enumerate candidate wander destinations.
+     *
+     * @param roomId the room to query
+     * @return an unmodifiable map of direction to neighbouring room id
+     */
+    public Map<Direction, RoomId> getExits(RoomId roomId) {
+        Objects.requireNonNull(roomId, "Room id is required");
+        return findRoom(roomId).map(Room::getExits).orElse(Map.of());
+    }
+
+    /**
+     * Returns the set of currently locked exit directions for the given room.
+     *
+     * <p>The set is lazily seeded from the room's static locked-exit configuration on first call.
+     *
+     * @param roomId the room to query
+     * @return the mutable set of locked directions (may be empty, never null)
+     */
+    public Set<Direction> getLockedExits(RoomId roomId) {
+        Objects.requireNonNull(roomId, "Room id is required");
+        return ensureLockedState(roomId);
+    }
+
+    /**
+     * Returns {@code true} if the exit in the given direction is currently locked.
+     *
+     * @param roomId    the room containing the exit
+     * @param direction the exit direction to test
+     * @return {@code true} if locked
+     */
+    public boolean isExitLocked(RoomId roomId, Direction direction) {
+        Objects.requireNonNull(roomId, "Room id is required");
+        Objects.requireNonNull(direction, "Direction is required");
+        return ensureLockedState(roomId).contains(direction);
+    }
+
+    /**
+     * Returns the room currently occupied by the player, loading it from the repository.
+     *
+     * <p>Ensures the player has a location (assigns starting room if absent) before resolving.
+     *
+     * @param username the player
+     * @return the loaded room, or empty if not found
+     */
+    public Optional<Room> loadRoomForPlayer(Username username) {
+        Objects.requireNonNull(username, "Username is required");
+        RoomId roomId = ensurePlayerLocation(username);
+        return findRoom(roomId);
+    }
+
+    /**
+     * Attempts to move the player in the given direction.
+     *
+     * <p>On success, updates {@code playerLocations} and returns the destination room. On failure,
+     * returns the reason message and the player's current room (may be {@code null} if the world
+     * has no rooms).
+     *
+     * @param username  the player to move
+     * @param direction the direction to move in
+     * @return a {@link MoveAttempt} describing the outcome
+     */
+    public MoveAttempt attemptMove(Username username, Direction direction) {
+        Objects.requireNonNull(username, "Username is required");
+        Objects.requireNonNull(direction, "Direction is required");
+        Room room = loadRoomForPlayer(username).orElse(null);
+        if (room == null) {
+            return new MoveAttempt.Failed("You cannot move yet. The world has no rooms.", null);
+        }
+        RoomId destinationId = room.getExits().get(direction);
+        if (destinationId == null) {
+            return new MoveAttempt.Failed("You cannot go " + direction.label() + ".", room);
+        }
+        if (isExitLocked(room.getId(), direction)) {
+            return new MoveAttempt.Failed("The door to the " + direction.label() + " is locked.", room);
+        }
+        Room destination = findRoom(destinationId).orElse(null);
+        if (destination == null) {
+            return new MoveAttempt.Failed("The way " + direction.label() + " is blocked.", room);
+        }
+        playerLocations.put(username, destinationId);
+        return new MoveAttempt.Succeeded(destination);
+    }
+
+    /**
+     * The outcome of a {@link #attemptMove(Username, Direction)} call.
+     */
+    public sealed interface MoveAttempt permits MoveAttempt.Failed, MoveAttempt.Succeeded {
+
+        /**
+         * Movement was not possible; {@link #currentRoom()} is the room the player remains in
+         * (may be {@code null} if the world has no rooms at all).
+         */
+        record Failed(String reason, @Nullable Room currentRoom) implements MoveAttempt {}
+
+        /** Movement succeeded; the player is now in {@link #destination()}. */
+        record Succeeded(Room destination) implements MoveAttempt {}
+    }
+
+    /**
+     * Attempts to unlock the exit in the given direction from the player's current room.
+     *
+     * <p>Succeeds when the exit is declared lockable in room data, is currently locked, and the
+     * player's inventory contains the required key item. On success, bi-directionally propagates
+     * the state change to the destination room's reverse exit (if also lockable).
+     *
+     * @param username  the acting player
+     * @param direction the direction of the exit to unlock
+     * @param inventory the player's current inventory (used to check for the required key)
+     * @return the result of the action
+     */
+    public DoorActionResult unlock(Username username, Direction direction, List<Item> inventory) {
+        Objects.requireNonNull(username, "Username is required");
+        Objects.requireNonNull(direction, "Direction is required");
+        Objects.requireNonNull(inventory, "Inventory is required");
+        Room room = loadRoomForPlayer(username).orElse(null);
+        if (room == null) {
+            return new DoorActionResult(false, "You are nowhere.", null);
+        }
+        ItemId requiredKey = room.getLockedExits().get(direction);
+        if (requiredKey == null) {
+            return new DoorActionResult(false, "There is no lockable door to the " + direction.label() + ".", null);
+        }
+        Set<Direction> locked = ensureLockedState(room.getId());
+        if (!locked.contains(direction)) {
+            return new DoorActionResult(false, "The door to the " + direction.label() + " is already unlocked.", null);
+        }
+        if (!hasItem(inventory, requiredKey)) {
+            return new DoorActionResult(false, "You need the right key to unlock this door.", null);
+        }
+        locked.remove(direction);
+        propagateLockState(room, direction, false);
+        String playerMsg = "You unlock the door to the " + direction.label() + ".";
+        String roomMsg = username.getValue() + " unlocks the door to the " + direction.label() + ".";
+        return new DoorActionResult(true, playerMsg, roomMsg);
+    }
+
+    /**
+     * Attempts to lock the exit in the given direction from the player's current room.
+     *
+     * <p>Succeeds when the exit is declared lockable, is currently unlocked, and the player's
+     * inventory contains the required key item. On success, bi-directionally propagates the state
+     * change to the destination room's reverse exit (if also lockable).
+     *
+     * @param username  the acting player
+     * @param direction the direction of the exit to lock
+     * @param inventory the player's current inventory
+     * @return the result of the action
+     */
+    public DoorActionResult lock(Username username, Direction direction, List<Item> inventory) {
+        Objects.requireNonNull(username, "Username is required");
+        Objects.requireNonNull(direction, "Direction is required");
+        Objects.requireNonNull(inventory, "Inventory is required");
+        Room room = loadRoomForPlayer(username).orElse(null);
+        if (room == null) {
+            return new DoorActionResult(false, "You are nowhere.", null);
+        }
+        ItemId requiredKey = room.getLockedExits().get(direction);
+        if (requiredKey == null) {
+            return new DoorActionResult(false, "There is no lockable door to the " + direction.label() + ".", null);
+        }
+        Set<Direction> locked = ensureLockedState(room.getId());
+        if (locked.contains(direction)) {
+            return new DoorActionResult(false, "The door to the " + direction.label() + " is already locked.", null);
+        }
+        if (!hasItem(inventory, requiredKey)) {
+            return new DoorActionResult(false, "You need the right key to lock this door.", null);
+        }
+        locked.add(direction);
+        propagateLockState(room, direction, true);
+        String playerMsg = "You lock the door to the " + direction.label() + ".";
+        String roomMsg = username.getValue() + " locks the door to the " + direction.label() + ".";
+        return new DoorActionResult(true, playerMsg, roomMsg);
+    }
+
+    private Set<Direction> ensureLockedState(RoomId roomId) {
+        return runtimeLockedExits.computeIfAbsent(roomId, id -> {
+            Set<Direction> set = ConcurrentHashMap.newKeySet();
+            findRoom(id).ifPresent(r -> set.addAll(r.getLockedExits().keySet()));
+            return set;
+        });
+    }
+
+    private void propagateLockState(Room room, Direction direction, boolean nowLocked) {
+        RoomId destId = room.getExits().get(direction);
+        if (destId == null) {
+            return;
+        }
+        Room dest = findRoom(destId).orElse(null);
+        if (dest == null) {
+            return;
+        }
+        Direction reverse = direction.opposite();
+        if (!dest.getLockedExits().containsKey(reverse)) {
+            return;
+        }
+        Set<Direction> destLocked = ensureLockedState(destId);
+        if (nowLocked) {
+            destLocked.add(reverse);
+        } else {
+            destLocked.remove(reverse);
+        }
+    }
+
+    private boolean hasItem(List<Item> inventory, ItemId itemId) {
+        for (Item item : inventory) {
+            if (item.getId().equals(itemId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Optional<Room> findRoom(RoomId roomId) {
+        try {
+            return roomRepository.findById(roomId);
+        } catch (RepositoryException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/RoomItemService.java
+++ b/src/main/java/io/taanielo/jmud/core/world/RoomItemService.java
@@ -1,0 +1,201 @@
+package io.taanielo.jmud.core.world;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.jspecify.annotations.Nullable;
+
+import io.taanielo.jmud.core.authentication.Username;
+
+/**
+ * Domain service that owns the transient ground-item and corpse state for all rooms.
+ *
+ * <p>Static items (those defined in room data files) are owned by the repository; this service
+ * owns only runtime-transient items: dropped loot and player corpses spawned on death.
+ *
+ * <p>All mutation happens on the tick thread (AGENTS.md §5).
+ */
+public class RoomItemService {
+
+    private final ConcurrentHashMap<RoomId, List<Item>> transientItems = new ConcurrentHashMap<>();
+    private final ConcurrentLinkedQueue<Corpse> trackedCorpses = new ConcurrentLinkedQueue<>();
+    private final AtomicLong corpseCounter = new AtomicLong();
+
+    /**
+     * Adds a transient item to the specified room.
+     *
+     * @param roomId the room to add the item to
+     * @param item   the item to add
+     */
+    public void addItem(RoomId roomId, Item item) {
+        Objects.requireNonNull(roomId, "Room id is required");
+        Objects.requireNonNull(item, "Item is required");
+        transientItems.compute(roomId, (id, existing) -> {
+            List<Item> items = new ArrayList<>(existing == null ? List.of() : existing);
+            items.add(item);
+            return List.copyOf(items);
+        });
+    }
+
+    /**
+     * Returns the transient items currently in the given room, or an empty list if none.
+     *
+     * @param roomId the room to query
+     * @return an unmodifiable list of transient items
+     */
+    public List<Item> getTransientItems(RoomId roomId) {
+        Objects.requireNonNull(roomId, "Room id is required");
+        List<Item> items = transientItems.get(roomId);
+        return items == null ? List.of() : items;
+    }
+
+    /**
+     * Returns the combined list of static (room-defined) and transient items for the given room.
+     *
+     * @param room the room carrying its static items
+     * @return an unmodifiable merged item list
+     */
+    public List<Item> mergeItems(Room room) {
+        Objects.requireNonNull(room, "Room is required");
+        List<Item> extras = transientItems.get(room.getId());
+        if (extras == null || extras.isEmpty()) {
+            return room.getItems();
+        }
+        List<Item> merged = new ArrayList<>(room.getItems());
+        merged.addAll(extras);
+        return List.copyOf(merged);
+    }
+
+    /**
+     * Spawns a corpse item in the specified room, carrying the given amount of gold.
+     *
+     * <p>The spawned corpse is tracked internally and will be removed after the configured
+     * decay period by {@link #removeExpiredCorpses(Duration)}.
+     *
+     * @param username the player who died
+     * @param roomId   the room where the corpse is placed
+     * @param gold     gold carried by the player at time of death (0 if none)
+     * @return the {@link Corpse} tracking record
+     */
+    public Corpse spawnCorpse(Username username, RoomId roomId, int gold) {
+        Objects.requireNonNull(username, "Username is required");
+        Objects.requireNonNull(roomId, "Room id is required");
+        if (gold < 0) {
+            throw new IllegalArgumentException("Gold must be non-negative");
+        }
+        Item corpseItem = createCorpse(username, gold);
+        addItem(roomId, corpseItem);
+        Corpse corpse = new Corpse(corpseItem.getId(), roomId, username.getValue(), gold, Instant.now());
+        trackedCorpses.add(corpse);
+        return corpse;
+    }
+
+    /**
+     * Removes all tracked corpses that were spawned longer ago than {@code decayAfter}.
+     *
+     * <p>Called by {@link CorpseDecayTicker} on each tick.
+     *
+     * @param decayAfter the maximum age a corpse may be before it is removed
+     */
+    public void removeExpiredCorpses(Duration decayAfter) {
+        Objects.requireNonNull(decayAfter, "Decay duration is required");
+        Instant cutoff = Instant.now().minus(decayAfter);
+        trackedCorpses.removeIf(corpse -> {
+            if (!corpse.spawnedAt().isAfter(cutoff)) {
+                removeTransientItemById(corpse.roomId(), corpse.itemId());
+                return true;
+            }
+            return false;
+        });
+    }
+
+    /**
+     * Attempts to find and remove a transient item from the specified room by name or id prefix.
+     *
+     * @param roomId the room to search
+     * @param input  the name or id prefix to match (case-insensitive)
+     * @return the removed item, or empty if not found
+     */
+    public Optional<Item> takeTransientItem(RoomId roomId, String input) {
+        Objects.requireNonNull(roomId, "Room id is required");
+        if (input == null || input.isBlank()) {
+            return Optional.empty();
+        }
+        List<Item> extras = transientItems.get(roomId);
+        if (extras == null || extras.isEmpty()) {
+            return Optional.empty();
+        }
+        Item match = matchItem(extras, input);
+        if (match == null) {
+            return Optional.empty();
+        }
+        removeTransientItem(roomId, match);
+        return Optional.of(match);
+    }
+
+    /**
+     * Removes a specific transient item from a room by its id.
+     *
+     * @param roomId the room containing the item
+     * @param itemId the id of the item to remove
+     */
+    public void removeTransientItemById(RoomId roomId, ItemId itemId) {
+        transientItems.computeIfPresent(roomId, (id, existing) -> {
+            List<Item> next = new ArrayList<>(existing);
+            next.removeIf(item -> item.getId().equals(itemId));
+            return next.isEmpty() ? null : List.copyOf(next);
+        });
+    }
+
+    private void removeTransientItem(RoomId roomId, Item match) {
+        transientItems.computeIfPresent(roomId, (id, existing) -> {
+            List<Item> next = new ArrayList<>(existing);
+            next.removeIf(item -> item.getId().equals(match.getId()));
+            return next.isEmpty() ? null : List.copyOf(next);
+        });
+    }
+
+    private @Nullable Item matchItem(List<Item> items, String input) {
+        String normalized = input.trim().toLowerCase(Locale.ROOT);
+        for (Item item : items) {
+            String name = item.getName().toLowerCase(Locale.ROOT);
+            if (name.equals(normalized) || name.startsWith(normalized)) {
+                return item;
+            }
+            String id = item.getId().getValue().toLowerCase(Locale.ROOT);
+            if (id.equals(normalized) || id.startsWith(normalized)) {
+                return item;
+            }
+        }
+        return null;
+    }
+
+    private Item createCorpse(Username username, int gold) {
+        String owner = username.getValue();
+        String id = "corpse-" + owner.toLowerCase(Locale.ROOT) + "-" + corpseCounter.incrementAndGet();
+        String description = gold > 0
+            ? "The corpse of " + owner + " lies here, containing "
+                + gold + " gold coin" + (gold == 1 ? "" : "s") + "."
+            : "The corpse of " + owner + " lies here.";
+        return new Item(
+            ItemId.of(id),
+            "the corpse of " + owner,
+            description,
+            ItemAttributes.empty(),
+            List.of(),
+            List.of(),
+            null,
+            0,
+            gold,
+            null
+        );
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/RoomRenderer.java
+++ b/src/main/java/io/taanielo/jmud/core/world/RoomRenderer.java
@@ -1,0 +1,72 @@
+package io.taanielo.jmud.core.world;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.taanielo.jmud.core.authentication.Username;
+
+/**
+ * Stateless service that composes the look description for a room.
+ *
+ * <p>Accepts a fully-populated {@link Room} (with occupants and merged items already embedded)
+ * plus the set of currently locked exits for the room, and returns the rendered output lines.
+ * Contains no mutable state and may be called from any thread.
+ */
+public class RoomRenderer {
+
+    /**
+     * Returns the rendered look description lines for the given room.
+     *
+     * @param room        the room to describe (with occupants and merged items already embedded)
+     * @param viewer      the player requesting the description (excluded from the occupants list)
+     * @param lockedExits the set of currently locked exit directions in this room
+     * @return the list of output lines (name, description, exits, items, occupants)
+     */
+    public List<String> describeRoom(Room room, Username viewer, Set<Direction> lockedExits) {
+        Objects.requireNonNull(room, "Room is required");
+        Objects.requireNonNull(viewer, "Viewer is required");
+        Objects.requireNonNull(lockedExits, "Locked exits set is required");
+        List<String> lines = new ArrayList<>();
+        lines.add(room.getName());
+        lines.add(room.getDescription());
+        lines.add("Exits: " + formatExits(room.getExits(), lockedExits));
+        lines.add("Items: " + formatItems(room.getItems()));
+        lines.add("Occupants: " + formatOccupants(room.getOccupants(), viewer));
+        return lines;
+    }
+
+    private String formatExits(Map<Direction, RoomId> exits, Set<Direction> lockedExits) {
+        if (exits.isEmpty()) {
+            return "none";
+        }
+        return exits.keySet().stream()
+            .sorted(Comparator.comparing(Direction::label))
+            .map(dir -> lockedExits.contains(dir) ? dir.label() + " [locked]" : dir.label())
+            .collect(Collectors.joining(", "));
+    }
+
+    private String formatItems(List<Item> items) {
+        if (items.isEmpty()) {
+            return "none";
+        }
+        return items.stream()
+            .map(Item::getName)
+            .collect(Collectors.joining(", "));
+    }
+
+    private String formatOccupants(List<Username> occupants, Username viewer) {
+        List<String> names = occupants.stream()
+            .filter(username -> !username.equals(viewer))
+            .map(Username::getValue)
+            .toList();
+        if (names.isEmpty()) {
+            return "none";
+        }
+        return String.join(", ", names);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/RoomService.java
+++ b/src/main/java/io/taanielo/jmud/core/world/RoomService.java
@@ -1,236 +1,191 @@
 package io.taanielo.jmud.core.world;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
 
 import io.taanielo.jmud.core.authentication.Username;
 import io.taanielo.jmud.core.world.repository.RepositoryException;
 import io.taanielo.jmud.core.world.repository.RoomRepository;
 
 /**
- * Domain service for resolving player room state, movement, and room descriptions.
+ * Façade that coordinates {@link PlayerLocationService}, {@link RoomItemService}, and
+ * {@link RoomRenderer} for composite operations such as look, move, take, and drop.
+ *
+ * <p>Pure location and item operations are delegated directly to the focused services. This class
+ * exists to preserve existing caller call-sites while the three services are introduced; callers
+ * should migrate to the focused services over time, after which this façade can be removed.
+ *
+ * <p>The convenience constructor {@link #RoomService(RoomRepository, RoomId)} creates the three
+ * sub-services internally and is provided for legacy call sites (primarily tests).
  */
 public class RoomService {
 
     /**
      * Result of a look action, including rendered lines and the resolved room.
      */
-    public record LookResult(List<String> lines, Room room) {
+    public record LookResult(List<String> lines, @Nullable Room room) {
     }
 
     /**
-     * Result of a move action, including whether movement succeeded, output lines, and the resolved room.
+     * Result of a move action.
      */
-    public record MoveResult(boolean moved, List<String> lines, Room room) {
+    public record MoveResult(boolean moved, List<String> lines, @Nullable Room room) {
     }
 
-    /**
-     * Result of a lock or unlock door action.
-     *
-     * @param success       whether the action was performed
-     * @param playerMessage message shown to the acting player
-     * @param roomMessage   message broadcast to other room occupants, or {@code null} on failure
-     */
-    public record DoorActionResult(boolean success, String playerMessage, String roomMessage) {
-    }
-
+    private final PlayerLocationService locationService;
+    private final RoomItemService itemService;
+    private final RoomRenderer renderer;
     private final RoomRepository roomRepository;
-    private final RoomId startingRoomId;
-    private final ConcurrentHashMap<Username, RoomId> playerLocations = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<RoomId, List<Item>> transientItems = new ConcurrentHashMap<>();
-    private final ConcurrentLinkedQueue<Corpse> trackedCorpses = new ConcurrentLinkedQueue<>();
-    private final AtomicLong corpseCounter = new AtomicLong();
-    /**
-     * Runtime locked-exit state: maps each room id to the set of directions that are currently locked.
-     * Seeded lazily from each room's {@link Room#getLockedExits()} on first access.
-     */
-    private final ConcurrentHashMap<RoomId, Set<Direction>> runtimeLockedExits = new ConcurrentHashMap<>();
 
     /**
-     * Creates a room service with the provided repository and starting room id.
+     * Creates a room service façade wrapping the three focused services.
+     *
+     * @param locationService the player location and movement service
+     * @param itemService     the transient item and corpse service
+     * @param renderer        the stateless room renderer
+     * @param roomRepository  the room data store (used for static-item take operations)
+     */
+    public RoomService(
+            PlayerLocationService locationService,
+            RoomItemService itemService,
+            RoomRenderer renderer,
+            RoomRepository roomRepository) {
+        this.locationService = Objects.requireNonNull(locationService, "Location service is required");
+        this.itemService = Objects.requireNonNull(itemService, "Item service is required");
+        this.renderer = Objects.requireNonNull(renderer, "Room renderer is required");
+        this.roomRepository = Objects.requireNonNull(roomRepository, "Room repository is required");
+    }
+
+    /**
+     * Convenience constructor that creates the three focused services internally.
+     *
+     * <p>Provided for backward compatibility with test call sites. Production code should prefer
+     * the full constructor so that each service can be injected independently (e.g. to pass
+     * {@link RoomItemService} to {@link CorpseDecayTicker}).
+     *
+     * @param roomRepository the room data store
+     * @param startingRoomId the room id used when a player has no location
      */
     public RoomService(RoomRepository roomRepository, RoomId startingRoomId) {
-        this.roomRepository = Objects.requireNonNull(roomRepository, "Room repository is required");
-        this.startingRoomId = Objects.requireNonNull(startingRoomId, "Starting room id is required");
+        this(
+            new PlayerLocationService(roomRepository, startingRoomId),
+            new RoomItemService(),
+            new RoomRenderer(),
+            roomRepository
+        );
     }
+
+    // ── Location delegation ──────────────────────────────────────────────────
 
     /**
      * Returns all player usernames currently in the given room.
      */
     public List<Username> getPlayersInRoom(RoomId roomId) {
-        Objects.requireNonNull(roomId, "Room id is required");
-        return playerLocations.entrySet().stream()
-            .filter(e -> e.getValue().equals(roomId))
-            .map(java.util.Map.Entry::getKey)
-            .toList();
+        return locationService.getPlayersInRoom(roomId);
     }
 
     /**
      * Ensures a player has a location, defaulting to the starting room if missing.
      */
     public RoomId ensurePlayerLocation(Username username) {
-        Objects.requireNonNull(username, "Username is required");
-        return playerLocations.computeIfAbsent(username, ignored -> startingRoomId);
+        return locationService.ensurePlayerLocation(username);
     }
 
     /**
      * Returns the current player location, if any.
      */
     public Optional<RoomId> findPlayerLocation(Username username) {
-        Objects.requireNonNull(username, "Username is required");
-        return Optional.ofNullable(playerLocations.get(username));
+        return locationService.findPlayerLocation(username);
     }
 
     /**
      * Removes a player from the room tracking map.
      */
     public void clearPlayerLocation(Username username) {
-        Objects.requireNonNull(username, "Username is required");
-        playerLocations.remove(username);
+        locationService.clearPlayerLocation(username);
     }
 
     /**
      * Respawns a player at the starting room.
      */
     public RoomId respawnPlayer(Username username) {
-        Objects.requireNonNull(username, "Username is required");
-        playerLocations.put(username, startingRoomId);
-        return startingRoomId;
+        return locationService.respawnPlayer(username);
     }
 
     /**
      * Returns the exit map for the given room, or an empty map if the room cannot be found.
-     *
-     * <p>Used by mob AI to enumerate candidate wander destinations.
-     *
-     * @param roomId the room to query
-     * @return an unmodifiable map of direction to neighbouring room id (never null)
      */
     public Map<Direction, RoomId> getExits(RoomId roomId) {
-        Objects.requireNonNull(roomId, "Room id is required");
-        return findRoom(roomId).map(Room::getExits).orElse(Map.of());
+        return locationService.getExits(roomId);
     }
+
+    // ── Item delegation ──────────────────────────────────────────────────────
 
     /**
      * Adds a transient item to the specified room.
      */
     public void addItem(RoomId roomId, Item item) {
-        Objects.requireNonNull(roomId, "Room id is required");
-        Objects.requireNonNull(item, "Item is required");
-        transientItems.compute(roomId, (id, existing) -> {
-            List<Item> items = new ArrayList<>(existing == null ? List.of() : existing);
-            items.add(item);
-            return List.copyOf(items);
-        });
+        itemService.addItem(roomId, item);
     }
 
     /**
-     * Spawns a corpse item in the specified room, carrying the given amount of gold.
-     *
-     * <p>The spawned corpse is tracked internally and will be removed after the
-     * configured decay period by {@link #removeExpiredCorpses(Duration)}.
-     *
-     * @param username the player who died
-     * @param roomId   the room where the corpse is placed
-     * @param gold     gold carried by the player at time of death (0 if none)
-     * @return the {@link Corpse} tracking record
+     * Spawns a corpse item in the specified room.
      */
     public Corpse spawnCorpse(Username username, RoomId roomId, int gold) {
-        Objects.requireNonNull(username, "Username is required");
-        Objects.requireNonNull(roomId, "Room id is required");
-        if (gold < 0) {
-            throw new IllegalArgumentException("Gold must be non-negative");
-        }
-        Item corpseItem = createCorpse(username, gold);
-        addItem(roomId, corpseItem);
-        Corpse corpse = new Corpse(corpseItem.getId(), roomId, username.getValue(), gold, Instant.now());
-        trackedCorpses.add(corpse);
-        return corpse;
+        return itemService.spawnCorpse(username, roomId, gold);
     }
 
     /**
-     * Removes all tracked corpses that were spawned longer ago than {@code decayAfter}.
+     * Removes all tracked corpses older than the given duration.
      *
-     * <p>Called by {@link CorpseDecayTicker} on each tick.
-     *
-     * @param decayAfter the maximum age a corpse may be before it is removed
+     * @deprecated Prefer {@link RoomItemService#removeExpiredCorpses(Duration)} directly.
+     *             {@link CorpseDecayTicker} now accepts {@link RoomItemService} and no longer
+     *             uses this delegation path.
      */
+    @Deprecated
     public void removeExpiredCorpses(Duration decayAfter) {
-        Objects.requireNonNull(decayAfter, "Decay duration is required");
-        Instant cutoff = Instant.now().minus(decayAfter);
-        trackedCorpses.removeIf(corpse -> {
-            if (!corpse.spawnedAt().isAfter(cutoff)) {
-                removeTransientItemById(corpse.roomId(), corpse.itemId());
-                return true;
-            }
-            return false;
-        });
+        itemService.removeExpiredCorpses(decayAfter);
+    }
+
+    // ── Lock / Unlock delegation ─────────────────────────────────────────────
+
+    /**
+     * Attempts to unlock the exit in the given direction from the player's current room.
+     */
+    public DoorActionResult unlock(Username username, Direction direction, List<Item> inventory) {
+        return locationService.unlock(username, direction, inventory);
     }
 
     /**
-     * Removes an item from the player's current room.
+     * Attempts to lock the exit in the given direction from the player's current room.
      */
-    public Optional<Item> takeItem(Username username, String input) {
-        Objects.requireNonNull(username, "Username is required");
-        if (input == null || input.isBlank()) {
-            return Optional.empty();
-        }
-        Room room = loadRoomForPlayer(username);
-        if (room == null) {
-            return Optional.empty();
-        }
-        Item match = matchItem(room.getItems(), input);
-        if (match != null) {
-            removeRoomItem(room, match);
-            return Optional.of(match);
-        }
-        List<Item> extras = transientItems.get(room.getId());
-        if (extras == null || extras.isEmpty()) {
-            return Optional.empty();
-        }
-        match = matchItem(extras, input);
-        if (match == null) {
-            return Optional.empty();
-        }
-        removeTransientItem(room.getId(), match);
-        return Optional.of(match);
+    public DoorActionResult lock(Username username, Direction direction, List<Item> inventory) {
+        return locationService.lock(username, direction, inventory);
     }
 
-    /**
-     * Drops an item into the player's current room.
-     */
-    public boolean dropItem(Username username, Item item) {
-        Objects.requireNonNull(username, "Username is required");
-        Objects.requireNonNull(item, "Item is required");
-        RoomId roomId = ensurePlayerLocation(username);
-        addItem(roomId, item);
-        return true;
-    }
+    // ── Orchestrated operations ──────────────────────────────────────────────
 
     /**
      * Produces a look description for the player's current room.
      */
     public LookResult look(Username username) {
         Objects.requireNonNull(username, "Username is required");
-        Room room = loadRoomForPlayer(username);
-        if (room == null) {
+        Optional<Room> roomOpt = locationService.loadRoomForPlayer(username);
+        if (roomOpt.isEmpty()) {
             return new LookResult(List.of("You are nowhere. The world feels unfinished."), null);
         }
-        Room roomWithOccupants = withOccupants(room);
-        return new LookResult(describeRoom(roomWithOccupants, username), roomWithOccupants);
+        Room room = roomOpt.get();
+        Room enriched = enrichRoom(room);
+        Set<Direction> lockedExits = locationService.getLockedExits(room.getId());
+        return new LookResult(renderer.describeRoom(enriched, username, lockedExits), enriched);
     }
 
     /**
@@ -239,48 +194,59 @@ public class RoomService {
     public MoveResult move(Username username, Direction direction) {
         Objects.requireNonNull(username, "Username is required");
         Objects.requireNonNull(direction, "Direction is required");
-        Room room = loadRoomForPlayer(username);
-        if (room == null) {
-            return new MoveResult(false, List.of("You cannot move yet. The world has no rooms."), null);
-        }
-        RoomId destinationId = room.getExits().get(direction);
-        if (destinationId == null) {
-            return new MoveResult(false, List.of("You cannot go " + direction.label() + "."), room);
-        }
-        if (isExitLocked(room.getId(), direction)) {
-            return new MoveResult(false, List.of("The door to the " + direction.label() + " is locked."), room);
-        }
-        Room destination = findRoom(destinationId).orElse(null);
-        if (destination == null) {
-            return new MoveResult(false, List.of("The way " + direction.label() + " is blocked."), room);
-        }
-        playerLocations.put(username, destinationId);
-        Room destinationWithOccupants = withOccupants(destination);
-        List<String> lines = new ArrayList<>();
-        lines.add("You move " + direction.label() + ".");
-        lines.addAll(describeRoom(destinationWithOccupants, username));
-        return new MoveResult(true, lines, destinationWithOccupants);
+        PlayerLocationService.MoveAttempt attempt = locationService.attemptMove(username, direction);
+        return switch (attempt) {
+            case PlayerLocationService.MoveAttempt.Failed f ->
+                new MoveResult(false, List.of(f.reason()), f.currentRoom());
+            case PlayerLocationService.MoveAttempt.Succeeded s -> {
+                Room enriched = enrichRoom(s.destination());
+                Set<Direction> lockedExits = locationService.getLockedExits(enriched.getId());
+                List<String> lines = new ArrayList<>();
+                lines.add("You move " + direction.label() + ".");
+                lines.addAll(renderer.describeRoom(enriched, username, lockedExits));
+                yield new MoveResult(true, lines, enriched);
+            }
+        };
     }
 
-    private Room loadRoomForPlayer(Username username) {
-        RoomId roomId = ensurePlayerLocation(username);
-        return findRoom(roomId).orElse(null);
-    }
-
-    private Optional<Room> findRoom(RoomId roomId) {
-        try {
-            return roomRepository.findById(roomId);
-        } catch (RepositoryException e) {
+    /**
+     * Removes an item from the player's current room (checks static room items first, then
+     * transient items).
+     */
+    public Optional<Item> takeItem(Username username, String input) {
+        Objects.requireNonNull(username, "Username is required");
+        if (input == null || input.isBlank()) {
             return Optional.empty();
         }
+        Optional<Room> roomOpt = locationService.loadRoomForPlayer(username);
+        if (roomOpt.isEmpty()) {
+            return Optional.empty();
+        }
+        Room room = roomOpt.get();
+        Item match = matchItem(room.getItems(), input);
+        if (match != null) {
+            removeRoomItem(room, match);
+            return Optional.of(match);
+        }
+        return itemService.takeTransientItem(room.getId(), input);
     }
 
-    private Room withOccupants(Room room) {
-        List<Username> occupants = playerLocations.entrySet().stream()
-            .filter(entry -> entry.getValue().equals(room.getId()))
-            .map(Entry::getKey)
-            .toList();
-        List<Item> items = mergeItems(room);
+    /**
+     * Drops an item into the player's current room.
+     */
+    public boolean dropItem(Username username, Item item) {
+        Objects.requireNonNull(username, "Username is required");
+        Objects.requireNonNull(item, "Item is required");
+        RoomId roomId = locationService.ensurePlayerLocation(username);
+        itemService.addItem(roomId, item);
+        return true;
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private Room enrichRoom(Room room) {
+        List<Username> occupants = locationService.getPlayersInRoom(room.getId());
+        List<Item> items = itemService.mergeItems(room);
         return new Room(
             room.getId(),
             room.getName(),
@@ -292,58 +258,7 @@ public class RoomService {
         );
     }
 
-    private List<String> describeRoom(Room room, Username viewer) {
-        List<String> lines = new ArrayList<>();
-        lines.add(room.getName());
-        lines.add(room.getDescription());
-        lines.add("Exits: " + formatExits(room.getId(), room.getExits()));
-        lines.add("Items: " + formatItems(room.getItems()));
-        lines.add("Occupants: " + formatOccupants(room.getOccupants(), viewer));
-        return lines;
-    }
-
-    private String formatExits(RoomId roomId, Map<Direction, RoomId> exits) {
-        if (exits.isEmpty()) {
-            return "none";
-        }
-        Set<Direction> locked = ensureLockedState(roomId);
-        return exits.keySet().stream()
-            .sorted(Comparator.comparing(Direction::label))
-            .map(dir -> locked.contains(dir) ? dir.label() + " [locked]" : dir.label())
-            .collect(Collectors.joining(", "));
-    }
-
-    private String formatItems(List<Item> items) {
-        if (items.isEmpty()) {
-            return "none";
-        }
-        return items.stream()
-            .map(Item::getName)
-            .collect(Collectors.joining(", "));
-    }
-
-    private String formatOccupants(List<Username> occupants, Username viewer) {
-        List<String> names = occupants.stream()
-            .filter(username -> !username.equals(viewer))
-            .map(Username::getValue)
-            .toList();
-        if (names.isEmpty()) {
-            return "none";
-        }
-        return String.join(", ", names);
-    }
-
-    private List<Item> mergeItems(Room room) {
-        List<Item> extras = transientItems.get(room.getId());
-        if (extras == null || extras.isEmpty()) {
-            return room.getItems();
-        }
-        List<Item> merged = new ArrayList<>(room.getItems());
-        merged.addAll(extras);
-        return List.copyOf(merged);
-    }
-
-    private Item matchItem(List<Item> items, String input) {
+    private @Nullable Item matchItem(List<Item> items, String input) {
         String normalized = input.trim().toLowerCase(Locale.ROOT);
         for (Item item : items) {
             String name = item.getName().toLowerCase(Locale.ROOT);
@@ -375,171 +290,5 @@ public class RoomService {
         } catch (RepositoryException e) {
             // fallback: no-op if room persistence fails
         }
-    }
-
-    private void removeTransientItem(RoomId roomId, Item match) {
-        transientItems.computeIfPresent(roomId, (id, existing) -> {
-            List<Item> next = new ArrayList<>(existing);
-            next.removeIf(item -> item.getId().equals(match.getId()));
-            if (next.isEmpty()) {
-                return null;
-            }
-            return List.copyOf(next);
-        });
-    }
-
-    private void removeTransientItemById(RoomId roomId, ItemId itemId) {
-        transientItems.computeIfPresent(roomId, (id, existing) -> {
-            List<Item> next = new ArrayList<>(existing);
-            next.removeIf(item -> item.getId().equals(itemId));
-            return next.isEmpty() ? null : List.copyOf(next);
-        });
-    }
-
-    /**
-     * Attempts to unlock the exit in the given direction from the player's current room.
-     *
-     * <p>Succeeds when the exit is declared lockable in the room data, is currently locked,
-     * and the player's inventory contains the required key item.
-     *
-     * @param username  the acting player
-     * @param direction the direction of the exit to unlock
-     * @param inventory the player's current inventory (used to check for the required key)
-     * @return the result of the action
-     */
-    public DoorActionResult unlock(Username username, Direction direction, List<Item> inventory) {
-        Objects.requireNonNull(username, "Username is required");
-        Objects.requireNonNull(direction, "Direction is required");
-        Objects.requireNonNull(inventory, "Inventory is required");
-        Room room = loadRoomForPlayer(username);
-        if (room == null) {
-            return new DoorActionResult(false, "You are nowhere.", null);
-        }
-        ItemId requiredKey = room.getLockedExits().get(direction);
-        if (requiredKey == null) {
-            return new DoorActionResult(false, "There is no lockable door to the " + direction.label() + ".", null);
-        }
-        Set<Direction> locked = ensureLockedState(room.getId());
-        if (!locked.contains(direction)) {
-            return new DoorActionResult(false, "The door to the " + direction.label() + " is already unlocked.", null);
-        }
-        if (!hasItem(inventory, requiredKey)) {
-            return new DoorActionResult(false, "You need the right key to unlock this door.", null);
-        }
-        locked.remove(direction);
-        propagateLockState(room, direction, false);
-        String playerMsg = "You unlock the door to the " + direction.label() + ".";
-        String roomMsg = username.getValue() + " unlocks the door to the " + direction.label() + ".";
-        return new DoorActionResult(true, playerMsg, roomMsg);
-    }
-
-    /**
-     * Attempts to lock the exit in the given direction from the player's current room.
-     *
-     * <p>Succeeds when the exit is declared lockable, is currently unlocked, and the player's
-     * inventory contains the required key item.
-     *
-     * @param username  the acting player
-     * @param direction the direction of the exit to lock
-     * @param inventory the player's current inventory
-     * @return the result of the action
-     */
-    public DoorActionResult lock(Username username, Direction direction, List<Item> inventory) {
-        Objects.requireNonNull(username, "Username is required");
-        Objects.requireNonNull(direction, "Direction is required");
-        Objects.requireNonNull(inventory, "Inventory is required");
-        Room room = loadRoomForPlayer(username);
-        if (room == null) {
-            return new DoorActionResult(false, "You are nowhere.", null);
-        }
-        ItemId requiredKey = room.getLockedExits().get(direction);
-        if (requiredKey == null) {
-            return new DoorActionResult(false, "There is no lockable door to the " + direction.label() + ".", null);
-        }
-        Set<Direction> locked = ensureLockedState(room.getId());
-        if (locked.contains(direction)) {
-            return new DoorActionResult(false, "The door to the " + direction.label() + " is already locked.", null);
-        }
-        if (!hasItem(inventory, requiredKey)) {
-            return new DoorActionResult(false, "You need the right key to lock this door.", null);
-        }
-        locked.add(direction);
-        propagateLockState(room, direction, true);
-        String playerMsg = "You lock the door to the " + direction.label() + ".";
-        String roomMsg = username.getValue() + " locks the door to the " + direction.label() + ".";
-        return new DoorActionResult(true, playerMsg, roomMsg);
-    }
-
-    private boolean isExitLocked(RoomId roomId, Direction direction) {
-        return ensureLockedState(roomId).contains(direction);
-    }
-
-    /**
-     * Returns (and lazily seeds) the runtime locked-exit set for a room.
-     *
-     * <p>The first call for a given room id loads the room from the repository and
-     * initialises the set from the room's {@link Room#getLockedExits()} configuration.
-     */
-    private Set<Direction> ensureLockedState(RoomId roomId) {
-        return runtimeLockedExits.computeIfAbsent(roomId, id -> {
-            Set<Direction> set = ConcurrentHashMap.newKeySet();
-            findRoom(id).ifPresent(r -> set.addAll(r.getLockedExits().keySet()));
-            return set;
-        });
-    }
-
-    /**
-     * Propagates a lock state change to the opposite side of the door (if the destination
-     * room also declares the reverse direction as a lockable exit).
-     */
-    private void propagateLockState(Room room, Direction direction, boolean nowLocked) {
-        RoomId destId = room.getExits().get(direction);
-        if (destId == null) {
-            return;
-        }
-        Room dest = findRoom(destId).orElse(null);
-        if (dest == null) {
-            return;
-        }
-        Direction reverse = direction.opposite();
-        if (!dest.getLockedExits().containsKey(reverse)) {
-            return;
-        }
-        Set<Direction> destLocked = ensureLockedState(destId);
-        if (nowLocked) {
-            destLocked.add(reverse);
-        } else {
-            destLocked.remove(reverse);
-        }
-    }
-
-    private boolean hasItem(List<Item> inventory, ItemId itemId) {
-        for (Item item : inventory) {
-            if (item.getId().equals(itemId)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private Item createCorpse(Username username, int gold) {
-        String owner = username.getValue();
-        String id = "corpse-" + owner.toLowerCase(Locale.ROOT) + "-" + corpseCounter.incrementAndGet();
-        String description = gold > 0
-            ? "The corpse of " + owner + " lies here, containing "
-                + gold + " gold coin" + (gold == 1 ? "" : "s") + "."
-            : "The corpse of " + owner + " lies here.";
-        return new Item(
-            ItemId.of(id),
-            "the corpse of " + owner,
-            description,
-            ItemAttributes.empty(),
-            List.of(),
-            List.of(),
-            null,
-            0,
-            gold,
-            null
-        );
     }
 }

--- a/src/test/java/io/taanielo/jmud/core/world/CorpseDecayTickerTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/CorpseDecayTickerTest.java
@@ -18,16 +18,22 @@ import io.taanielo.jmud.core.world.repository.RoomRepository;
 
 /**
  * Unit tests for {@link CorpseDecayTicker} and the corpse-tracking behaviour of
- * {@link RoomService#removeExpiredCorpses(Duration)}.
+ * {@link RoomItemService#removeExpiredCorpses(Duration)}.
  */
 class CorpseDecayTickerTest {
 
     private static final RoomId ROOM_ID = RoomId.of("arena");
 
-    /** Builds a RoomService whose starting room is {@code ROOM_ID}. */
-    private RoomService buildRoomService() {
+    /** Builds a {@link RoomItemService} and a {@link RoomService} sharing the same item state. */
+    private record Services(RoomItemService itemService, RoomService roomService) {}
+
+    private Services buildServices() {
         Room room = new Room(ROOM_ID, "Arena", "A sandy arena.", Map.of(), List.of(), List.of());
-        return new RoomService(new StubRoomRepository(Map.of(ROOM_ID, room)), ROOM_ID);
+        RoomRepository repo = new StubRoomRepository(Map.of(ROOM_ID, room));
+        RoomItemService itemService = new RoomItemService();
+        RoomService roomService = new RoomService(
+            new PlayerLocationService(repo, ROOM_ID), itemService, new RoomRenderer(), repo);
+        return new Services(itemService, roomService);
     }
 
     private Username username(String name) {
@@ -36,9 +42,11 @@ class CorpseDecayTickerTest {
 
     @Test
     void expiredCorpseIsRemovedFromRoomAfterTick() throws InterruptedException {
-        RoomService roomService = buildRoomService();
+        Services services = buildServices();
+        RoomItemService itemService = services.itemService();
+        RoomService roomService = services.roomService();
         // 1-nanosecond decay so any corpse spawned before tick is already expired
-        CorpseDecayTicker ticker = new CorpseDecayTicker(roomService, Duration.ofNanos(1));
+        CorpseDecayTicker ticker = new CorpseDecayTicker(itemService, Duration.ofNanos(1));
 
         Username viewer = username("viewer");
         roomService.ensurePlayerLocation(viewer); // places viewer in ROOM_ID
@@ -63,8 +71,10 @@ class CorpseDecayTickerTest {
 
     @Test
     void freshCorpseIsRetainedBeforeDecayExpires() {
-        RoomService roomService = buildRoomService();
-        CorpseDecayTicker ticker = new CorpseDecayTicker(roomService, Duration.ofMinutes(5));
+        Services services = buildServices();
+        RoomItemService itemService = services.itemService();
+        RoomService roomService = services.roomService();
+        CorpseDecayTicker ticker = new CorpseDecayTicker(itemService, Duration.ofMinutes(5));
 
         Username viewer = username("viewer2");
         roomService.ensurePlayerLocation(viewer);
@@ -82,20 +92,20 @@ class CorpseDecayTickerTest {
 
     @Test
     void constructorRejectsZeroDecayDuration() {
-        RoomService roomService = buildRoomService();
+        Services services = buildServices();
         assertThrows(IllegalArgumentException.class,
-            () -> new CorpseDecayTicker(roomService, Duration.ZERO));
+            () -> new CorpseDecayTicker(services.itemService(), Duration.ZERO));
     }
 
     @Test
     void constructorRejectsNegativeDecayDuration() {
-        RoomService roomService = buildRoomService();
+        Services services = buildServices();
         assertThrows(IllegalArgumentException.class,
-            () -> new CorpseDecayTicker(roomService, Duration.ofSeconds(-1)));
+            () -> new CorpseDecayTicker(services.itemService(), Duration.ofSeconds(-1)));
     }
 
     @Test
-    void constructorRejectsNullRoomService() {
+    void constructorRejectsNullRoomItemService() {
         assertThrows(NullPointerException.class,
             () -> new CorpseDecayTicker(null, Duration.ofMinutes(5)));
     }

--- a/src/test/java/io/taanielo/jmud/core/world/PlayerLocationServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/PlayerLocationServiceTest.java
@@ -1,0 +1,231 @@
+package io.taanielo.jmud.core.world;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Unit tests for {@link PlayerLocationService}: move, lock, and unlock behaviour.
+ */
+class PlayerLocationServiceTest {
+
+    private static final RoomId ROOM_A = RoomId.of("a");
+    private static final RoomId ROOM_B = RoomId.of("b");
+    private static final ItemId KEY_ID = ItemId.of("iron-key");
+    private static final Item KEY = new Item(
+        KEY_ID, "Iron Key", "A key.", ItemAttributes.empty(), List.of(), List.of(), null, 1, 0, null);
+
+    private static Room basicRoom(RoomId id, Map<Direction, RoomId> exits) {
+        return new Room(id, "Room " + id.getValue(), "A room.", exits, List.of(), List.of());
+    }
+
+    private static Room lockedRoom(RoomId id, Map<Direction, RoomId> exits,
+            Map<Direction, ItemId> lockedExits) {
+        return new Room(id, "Room " + id.getValue(), "A room.", exits, List.of(), List.of(),
+            lockedExits);
+    }
+
+    private PlayerLocationService buildService(Map<RoomId, Room> rooms) {
+        return new PlayerLocationService(new TestRoomRepository(rooms), ROOM_A);
+    }
+
+    // ── Location tracking ─────────────────────────────────────────────
+
+    @Test
+    void ensurePlayerLocationAssignsStartingRoom() {
+        PlayerLocationService service = buildService(Map.of(
+            ROOM_A, basicRoom(ROOM_A, Map.of())));
+        Username alice = Username.of("Alice");
+
+        RoomId location = service.ensurePlayerLocation(alice);
+
+        assertEquals(ROOM_A, location);
+    }
+
+    @Test
+    void clearPlayerLocationRemovesEntry() {
+        PlayerLocationService service = buildService(Map.of(
+            ROOM_A, basicRoom(ROOM_A, Map.of())));
+        Username alice = Username.of("Alice");
+        service.ensurePlayerLocation(alice);
+
+        service.clearPlayerLocation(alice);
+
+        assertTrue(service.findPlayerLocation(alice).isEmpty());
+    }
+
+    @Test
+    void respawnPlayerSetsStartingRoom() {
+        PlayerLocationService service = buildService(Map.of(
+            ROOM_A, basicRoom(ROOM_A, Map.of(Direction.NORTH, ROOM_B)),
+            ROOM_B, basicRoom(ROOM_B, Map.of(Direction.SOUTH, ROOM_A))));
+        Username alice = Username.of("Alice");
+        service.ensurePlayerLocation(alice);
+        // Move to room B
+        service.attemptMove(alice, Direction.NORTH);
+        assertEquals(Optional.of(ROOM_B), service.findPlayerLocation(alice));
+
+        service.respawnPlayer(alice);
+
+        assertEquals(Optional.of(ROOM_A), service.findPlayerLocation(alice));
+    }
+
+    @Test
+    void getPlayersInRoomReturnsOccupants() {
+        PlayerLocationService service = buildService(Map.of(
+            ROOM_A, basicRoom(ROOM_A, Map.of())));
+        Username alice = Username.of("Alice");
+        Username bob = Username.of("Bob");
+        service.ensurePlayerLocation(alice);
+        service.ensurePlayerLocation(bob);
+
+        List<Username> occupants = service.getPlayersInRoom(ROOM_A);
+
+        assertTrue(occupants.contains(alice));
+        assertTrue(occupants.contains(bob));
+    }
+
+    // ── Movement ──────────────────────────────────────────────────────
+
+    @Test
+    void attemptMoveSucceedsWhenExitExists() {
+        PlayerLocationService service = buildService(Map.of(
+            ROOM_A, basicRoom(ROOM_A, Map.of(Direction.NORTH, ROOM_B)),
+            ROOM_B, basicRoom(ROOM_B, Map.of(Direction.SOUTH, ROOM_A))));
+        Username alice = Username.of("Alice");
+        service.ensurePlayerLocation(alice);
+
+        PlayerLocationService.MoveAttempt result = service.attemptMove(alice, Direction.NORTH);
+
+        assertInstanceOf(PlayerLocationService.MoveAttempt.Succeeded.class, result);
+        assertEquals(Optional.of(ROOM_B), service.findPlayerLocation(alice));
+    }
+
+    @Test
+    void attemptMoveFailsWhenNoExit() {
+        PlayerLocationService service = buildService(Map.of(
+            ROOM_A, basicRoom(ROOM_A, Map.of())));
+        Username alice = Username.of("Alice");
+        service.ensurePlayerLocation(alice);
+
+        PlayerLocationService.MoveAttempt result = service.attemptMove(alice, Direction.WEST);
+
+        assertInstanceOf(PlayerLocationService.MoveAttempt.Failed.class, result);
+        assertEquals(Optional.of(ROOM_A), service.findPlayerLocation(alice),
+            "Player should still be in room A after failed move");
+    }
+
+    @Test
+    void attemptMoveFailsThroughLockedExit() {
+        PlayerLocationService service = buildService(Map.of(
+            ROOM_A, lockedRoom(ROOM_A, Map.of(Direction.NORTH, ROOM_B),
+                Map.of(Direction.NORTH, KEY_ID)),
+            ROOM_B, basicRoom(ROOM_B, Map.of(Direction.SOUTH, ROOM_A))));
+        Username alice = Username.of("Alice");
+        service.ensurePlayerLocation(alice);
+
+        PlayerLocationService.MoveAttempt result = service.attemptMove(alice, Direction.NORTH);
+
+        PlayerLocationService.MoveAttempt.Failed failed =
+            assertInstanceOf(PlayerLocationService.MoveAttempt.Failed.class, result);
+        assertTrue(failed.reason().contains("locked"), "Reason should mention 'locked'");
+    }
+
+    // ── Lock / Unlock ──────────────────────────────────────────────────
+
+    @Test
+    void unlockWithCorrectKeySucceeds() {
+        PlayerLocationService service = buildService(Map.of(
+            ROOM_A, lockedRoom(ROOM_A, Map.of(Direction.NORTH, ROOM_B),
+                Map.of(Direction.NORTH, KEY_ID)),
+            ROOM_B, basicRoom(ROOM_B, Map.of(Direction.SOUTH, ROOM_A))));
+        Username alice = Username.of("Alice");
+        service.ensurePlayerLocation(alice);
+
+        DoorActionResult result = service.unlock(alice, Direction.NORTH, List.of(KEY));
+
+        assertTrue(result.success());
+        assertFalse(service.isExitLocked(ROOM_A, Direction.NORTH),
+            "Exit should be unlocked after successful unlock");
+    }
+
+    @Test
+    void unlockWithoutKeyFails() {
+        PlayerLocationService service = buildService(Map.of(
+            ROOM_A, lockedRoom(ROOM_A, Map.of(Direction.NORTH, ROOM_B),
+                Map.of(Direction.NORTH, KEY_ID)),
+            ROOM_B, basicRoom(ROOM_B, Map.of(Direction.SOUTH, ROOM_A))));
+        Username alice = Username.of("Alice");
+        service.ensurePlayerLocation(alice);
+
+        DoorActionResult result = service.unlock(alice, Direction.NORTH, List.of());
+
+        assertFalse(result.success());
+        assertTrue(service.isExitLocked(ROOM_A, Direction.NORTH),
+            "Exit should remain locked after failed unlock");
+    }
+
+    @Test
+    void lockAfterUnlockBlocksMovement() {
+        PlayerLocationService service = buildService(Map.of(
+            ROOM_A, lockedRoom(ROOM_A, Map.of(Direction.NORTH, ROOM_B),
+                Map.of(Direction.NORTH, KEY_ID)),
+            ROOM_B, basicRoom(ROOM_B, Map.of(Direction.SOUTH, ROOM_A))));
+        Username alice = Username.of("Alice");
+        service.ensurePlayerLocation(alice);
+
+        service.unlock(alice, Direction.NORTH, List.of(KEY));
+        service.lock(alice, Direction.NORTH, List.of(KEY));
+
+        assertInstanceOf(PlayerLocationService.MoveAttempt.Failed.class,
+            service.attemptMove(alice, Direction.NORTH));
+    }
+
+    @Test
+    void unlockFromOneSidePropagatesReverse() {
+        Room roomA = lockedRoom(ROOM_A, Map.of(Direction.NORTH, ROOM_B),
+            Map.of(Direction.NORTH, KEY_ID));
+        Room roomB = lockedRoom(ROOM_B, Map.of(Direction.SOUTH, ROOM_A),
+            Map.of(Direction.SOUTH, KEY_ID));
+        PlayerLocationService service = buildService(Map.of(ROOM_A, roomA, ROOM_B, roomB));
+        Username alice = Username.of("Alice");
+        service.ensurePlayerLocation(alice);
+
+        service.unlock(alice, Direction.NORTH, List.of(KEY));
+
+        assertFalse(service.isExitLocked(ROOM_A, Direction.NORTH),
+            "North exit of room A should be unlocked");
+        assertFalse(service.isExitLocked(ROOM_B, Direction.SOUTH),
+            "South exit of room B should also be unlocked (propagated)");
+    }
+
+    // ── stubs ──────────────────────────────────────────────────────────
+
+    private record TestRoomRepository(Map<RoomId, Room> rooms) implements RoomRepository {
+        TestRoomRepository(Map<RoomId, Room> rooms) {
+            this.rooms = new ConcurrentHashMap<>(rooms);
+        }
+
+        @Override
+        public void save(Room room) throws RepositoryException {
+            rooms.put(room.getId(), room);
+        }
+
+        @Override
+        public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return Optional.ofNullable(rooms.get(id));
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/world/RoomRendererTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomRendererTest.java
@@ -1,0 +1,126 @@
+package io.taanielo.jmud.core.world;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Username;
+
+/**
+ * Golden-output unit tests for {@link RoomRenderer}.
+ */
+class RoomRendererTest {
+
+    private static final RoomId ROOM_ID = RoomId.of("town-square");
+    private static final RoomId NORTH_ROOM = RoomId.of("market");
+    private static final RoomRenderer RENDERER = new RoomRenderer();
+
+    private static Item item(String id, String name) {
+        return new Item(
+            ItemId.of(id), name, name + " description.",
+            ItemAttributes.empty(), List.of(), List.of(), null, 1, 0, null);
+    }
+
+    @Test
+    void rendersRoomNameAndDescription() {
+        Room room = new Room(ROOM_ID, "Town Square", "A busy square.", Map.of(), List.of(), List.of());
+        List<String> lines = RENDERER.describeRoom(room, Username.of("alice"), Set.of());
+
+        assertTrue(lines.get(0).equals("Town Square"), "First line should be room name");
+        assertTrue(lines.get(1).equals("A busy square."), "Second line should be description");
+    }
+
+    @Test
+    void rendersUnlockedExits() {
+        Room room = new Room(ROOM_ID, "Town Square", "A busy square.",
+            Map.of(Direction.NORTH, NORTH_ROOM), List.of(), List.of());
+        List<String> lines = RENDERER.describeRoom(room, Username.of("alice"), Set.of());
+        String exitsLine = lines.stream().filter(l -> l.startsWith("Exits:")).findFirst().orElse("");
+
+        assertTrue(exitsLine.contains("north"), "Exit line should contain 'north'");
+        assertFalse(exitsLine.contains("[locked]"), "Unlocked exit should not show [locked]");
+    }
+
+    @Test
+    void rendersLockedExitWithSuffix() {
+        Room room = new Room(ROOM_ID, "Town Square", "A busy square.",
+            Map.of(Direction.NORTH, NORTH_ROOM), List.of(), List.of());
+        Set<Direction> locked = Set.of(Direction.NORTH);
+        List<String> lines = RENDERER.describeRoom(room, Username.of("alice"), locked);
+        String exitsLine = lines.stream().filter(l -> l.startsWith("Exits:")).findFirst().orElse("");
+
+        assertTrue(exitsLine.contains("north [locked]"), "Locked exit should show '[locked]' suffix");
+    }
+
+    @Test
+    void rendersNoExitsWhenNone() {
+        Room room = new Room(ROOM_ID, "Cave", "Dark and quiet.", Map.of(), List.of(), List.of());
+        List<String> lines = RENDERER.describeRoom(room, Username.of("alice"), Set.of());
+        String exitsLine = lines.stream().filter(l -> l.startsWith("Exits:")).findFirst().orElse("");
+
+        assertTrue(exitsLine.contains("none"), "Should show 'none' when there are no exits");
+    }
+
+    @Test
+    void rendersItems() {
+        Room room = new Room(ROOM_ID, "Cave", "Dark.",
+            Map.of(), List.of(item("torch", "Torch"), item("sword", "Rusty Sword")),
+            List.of());
+        List<String> lines = RENDERER.describeRoom(room, Username.of("alice"), Set.of());
+        String itemsLine = lines.stream().filter(l -> l.startsWith("Items:")).findFirst().orElse("");
+
+        assertTrue(itemsLine.contains("Torch"), "Items line should contain 'Torch'");
+        assertTrue(itemsLine.contains("Rusty Sword"), "Items line should contain 'Rusty Sword'");
+    }
+
+    @Test
+    void rendersNoItemsWhenRoomIsEmpty() {
+        Room room = new Room(ROOM_ID, "Cave", "Dark.", Map.of(), List.of(), List.of());
+        List<String> lines = RENDERER.describeRoom(room, Username.of("alice"), Set.of());
+        String itemsLine = lines.stream().filter(l -> l.startsWith("Items:")).findFirst().orElse("");
+
+        assertTrue(itemsLine.contains("none"), "Should show 'none' when no items are present");
+    }
+
+    @Test
+    void rendersOccupantsExcludingViewer() {
+        Username alice = Username.of("Alice");
+        Username bob = Username.of("Bob");
+        Room room = new Room(ROOM_ID, "Town Square", "Busy.", Map.of(), List.of(),
+            List.of(alice, bob));
+        List<String> lines = RENDERER.describeRoom(room, alice, Set.of());
+        String occupantsLine = lines.stream().filter(l -> l.startsWith("Occupants:")).findFirst().orElse("");
+
+        assertFalse(occupantsLine.contains("Alice"), "Viewer should be excluded from occupants");
+        assertTrue(occupantsLine.contains("Bob"), "Other players should be listed in occupants");
+    }
+
+    @Test
+    void rendersNoOccupantsWhenAlone() {
+        Username alice = Username.of("Alice");
+        Room room = new Room(ROOM_ID, "Town Square", "Busy.", Map.of(), List.of(), List.of(alice));
+        List<String> lines = RENDERER.describeRoom(room, alice, Set.of());
+        String occupantsLine = lines.stream().filter(l -> l.startsWith("Occupants:")).findFirst().orElse("");
+
+        assertTrue(occupantsLine.contains("none"), "Should show 'none' when viewer is the only occupant");
+    }
+
+    @Test
+    void exitsAreSortedAlphabetically() {
+        RoomId east = RoomId.of("east");
+        RoomId west = RoomId.of("west");
+        Room room = new Room(ROOM_ID, "Junction", "A fork.",
+            Map.of(Direction.WEST, west, Direction.EAST, east), List.of(), List.of());
+        List<String> lines = RENDERER.describeRoom(room, Username.of("alice"), Set.of());
+        String exitsLine = lines.stream().filter(l -> l.startsWith("Exits:")).findFirst().orElse("");
+
+        int eastIdx = exitsLine.indexOf("east");
+        int westIdx = exitsLine.indexOf("west");
+        assertTrue(eastIdx < westIdx, "Exits should be sorted alphabetically (east before west)");
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
@@ -1,6 +1,5 @@
 package io.taanielo.jmud.core.world;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -257,7 +256,7 @@ class RoomServiceTest {
         Username player = Username.of("Bob");
         service.ensurePlayerLocation(player);
 
-        RoomService.DoorActionResult unlockResult = service.unlock(player, Direction.NORTH, List.of(key));
+        DoorActionResult unlockResult = service.unlock(player, Direction.NORTH, List.of(key));
         assertTrue(unlockResult.success());
         assertTrue(unlockResult.playerMessage().contains("unlock"));
 
@@ -283,7 +282,7 @@ class RoomServiceTest {
         Username player = Username.of("Bob");
         service.ensurePlayerLocation(player);
 
-        RoomService.DoorActionResult result = service.unlock(player, Direction.NORTH, List.of());
+        DoorActionResult result = service.unlock(player, Direction.NORTH, List.of());
 
         assertFalse(result.success());
         assertTrue(result.playerMessage().contains("key"));


### PR DESCRIPTION
## Summary

- Extracts `PlayerLocationService` from `RoomService` to handle player movement and door interactions
- Extracts `RoomRenderer` from `RoomService` to handle room description rendering
- Extracts `RoomItemService` from `RoomService` to handle item-in-room operations
- Introduces `DoorActionResult` value type for door interaction outcomes
- Updates `GameContext`, `SocketCommandContextImpl`, and `CorpseDecayTicker` to use the new focused services
- Adds dedicated unit tests for `PlayerLocationService` and `RoomRenderer`

Closes #184

## Test plan

- [ ] `./gradlew check` passes (verified before this PR)
- [ ] `PlayerLocationServiceTest` covers movement and door interactions
- [ ] `RoomRendererTest` covers room description formatting
- [ ] `RoomServiceTest` updated for the slimmed-down `RoomService`
- [ ] `CorpseDecayTickerTest` updated for injected `RoomItemService`

🤖 Generated with [Claude Code](https://claude.com/claude-code)