### PR TITLE
feat(logging): add correlation-id MDC and optional JSON log layout

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 log4j-slf4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j-impl", version.ref = "log4j" }
+log4j-layout-template-json = { module = "org.apache.logging.log4j:log4j-layout-template-json", version.ref = "log4j" }
 
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commonsLang3" }
 
@@ -54,7 +55,7 @@ micrometer-core = { module = "io.micrometer:micrometer-core", version.ref = "mic
 micrometer-registry-jmx = { module = "io.micrometer:micrometer-registry-jmx", version.ref = "micrometer" }
 
 [bundles]
-log4j = ["log4j-api", "log4j-core", "log4j-slf4j-impl"]
+log4j = ["log4j-api", "log4j-core", "log4j-slf4j-impl", "log4j-layout-template-json"]
 
 [plugins]
 errorprone = { id = "net.ltgt.errorprone", version.ref = "errorpronePlugin" }

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,30 @@ Authentication settings are configured in `jmud.properties`:
 - `jmud.auth.lockout_seconds`
 - `jmud.auth.pbkdf2.iterations`
 
+### Logging
+
+jmud logs to both the console and `jmud.log` using Log4j2.
+
+Each log line includes a `correlationId` field (MDC key) that is populated while a player command executes on the tick thread. This makes server log lines joinable with the audit JSONL on the same field — any log line emitted during command handling will carry the same `correlationId` as the corresponding audit entry.
+
+**Default layout** (human-readable pattern, active automatically):
+
+```
+2024-01-01 12:00:00.000 [tick-thread] abc-123 Player sparky attacked goblin.
+```
+
+**JSON layout** (NDJSON / JSON-Lines, one object per line):
+
+Activate by passing `-Dlog4j2.configurationFile=log4j2-json.xml` to the JVM at startup:
+
+```sh
+./gradlew run --args="..." -Dlog4j2.configurationFile=log4j2-json.xml
+# or for the jar:
+java -Dlog4j2.configurationFile=log4j2-json.xml -jar jmud.jar
+```
+
+Each line is a JSON object with the fields `timestamp`, `level`, `thread`, `logger`, `message`, `correlationId`, and `thrown` (when an exception is present). The `correlationId` field is absent for log lines emitted outside a command scope.
+
 ## Basics of Java Telnet Socket Connection
 
 In this game, telnet is used as a simple protocol to handle text-based user interactions. The `ServerSocket` class in Java is used to create a server socket that listens on a specified port. When a client connects, a new `Socket` instance is created to handle the connection.

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcher.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcher.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.apache.logging.log4j.ThreadContext;
+
 import io.taanielo.jmud.core.audit.AuditEvent;
 import io.taanielo.jmud.core.audit.AuditService;
 import io.taanielo.jmud.core.audit.AuditSubject;
@@ -14,9 +16,11 @@ import io.taanielo.jmud.core.audit.AuditSubject;
  * Dispatches socket command input to registered command handlers.
  */
 public class SocketCommandDispatcher {
+    /** MDC key used to propagate the per-command correlation id into Log4j2's {@link ThreadContext}. */
+    public static final String MDC_CORRELATION_ID = "correlationId";
+
     private final SocketCommandRegistry registry;
     private final AuditService auditService;
-    private final ThreadLocal<String> currentCorrelationId = new ThreadLocal<>();
 
     /**
      * Creates a dispatcher that reads commands from the provided registry.
@@ -30,27 +34,32 @@ public class SocketCommandDispatcher {
      * Returns the correlation id of the command currently being executed on this
      * (tick) thread, or {@code null} when no command dispatch is in progress.
      *
-     * <p>Set by {@link #dispatch} for the duration of a single command execution so
-     * that audit events emitted from within command handling (e.g. {@code
-     * SocketCommandContextImpl}) can be correlated with the originating input line.
+     * <p>Written by {@link #dispatch} into Log4j2's {@link ThreadContext} (MDC) for
+     * the duration of a single command execution so that both server log lines and
+     * audit events share the same id and can be correlated in post-processing.
      */
     public String currentCorrelationId() {
-        return currentCorrelationId.get();
+        return ThreadContext.get(MDC_CORRELATION_ID);
     }
 
     /**
      * Parses the incoming line and executes the appropriate command.
+     *
+     * <p>The {@code correlationId} is placed into Log4j2's {@link ThreadContext} under
+     * the key {@value #MDC_CORRELATION_ID} before dispatch and removed in a
+     * {@code finally} block, so server log lines emitted during execution carry the
+     * id and the tick thread is never left with a stale value.
      */
     public void dispatch(SocketCommandContext context, String clientInput, String correlationId) {
         Objects.requireNonNull(context, "Command context is required");
         if (clientInput == null) {
             return;
         }
-        currentCorrelationId.set(correlationId);
+        ThreadContext.put(MDC_CORRELATION_ID, correlationId);
         try {
             dispatchInternal(context, clientInput, correlationId);
         } finally {
-            currentCorrelationId.remove();
+            ThreadContext.remove(MDC_CORRELATION_ID);
         }
     }
 

--- a/src/main/resources/jmud-log-template.json
+++ b/src/main/resources/jmud-log-template.json
@@ -1,0 +1,33 @@
+{
+  "timestamp": {
+    "$resolver": "timestamp",
+    "pattern": {
+      "format": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+      "timeZone": "UTC"
+    }
+  },
+  "level": {
+    "$resolver": "level",
+    "field": "name"
+  },
+  "thread": {
+    "$resolver": "thread",
+    "field": "name"
+  },
+  "logger": {
+    "$resolver": "logger",
+    "field": "name"
+  },
+  "message": {
+    "$resolver": "message",
+    "stringified": true
+  },
+  "correlationId": {
+    "$resolver": "mdc",
+    "key": "correlationId"
+  },
+  "thrown": {
+    "$resolver": "exception",
+    "field": "message"
+  }
+}

--- a/src/main/resources/log4j2-json.xml
+++ b/src/main/resources/log4j2-json.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JSON log layout for jmud — activate with:
+      -Dlog4j2.configurationFile=log4j2-json.xml
+
+  Each log line is a self-contained JSON object (NDJSON / JSON-Lines format).
+  The "correlationId" field is populated whenever a player command is executing on
+  the tick thread; it is absent (not emitted) for log lines outside a command scope.
+  This makes server log lines joinable with the audit JSONL on the same field.
+-->
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <JsonTemplateLayout eventTemplateUri="classpath:jmud-log-template.json"/>
+        </Console>
+        <File name="File" fileName="jmud.log">
+            <JsonTemplateLayout eventTemplateUri="classpath:jmud-log-template.json"/>
+        </File>
+    </Appenders>
+    <Loggers>
+        <Root level="TRACE">
+            <AppenderRef ref="STDOUT"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,13 +1,13 @@
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %X{correlationId} %m%n
 
 appender.file.type = File
 appender.file.name = File
 appender.file.fileName = jmud.log
 appender.file.layout.type = PatternLayout
-appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %m%n
+appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %X{correlationId} %m%n
 
 rootLogger.level = TRACE
 rootLogger.appenderRef.stdout.ref = STDOUT

--- a/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherMdcTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/SocketCommandDispatcherMdcTest.java
@@ -1,0 +1,301 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.audit.AuditService;
+import io.taanielo.jmud.core.audit.NoOpAuditSink;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerVitals;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Verifies that {@link SocketCommandDispatcher} correctly propagates the
+ * per-command correlation id into Log4j2's {@link ThreadContext} (MDC) during
+ * execution and removes it in the finally block so the tick thread is never
+ * left with a stale value.
+ */
+class SocketCommandDispatcherMdcTest {
+
+    @AfterEach
+    void clearThreadContext() {
+        // Guard: ensure the MDC is clean between tests regardless of test outcome
+        ThreadContext.clearAll();
+    }
+
+    @Test
+    void threadContextContainsCorrelationIdDuringExecution() {
+        AtomicReference<String> capturedId = new AtomicReference<>();
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        registry.register(new CapturingCommand("look", capturedId));
+        AuditService auditService = new AuditService(new NoOpAuditSink(), Clock.systemUTC(), () -> 0L, () -> "test");
+        SocketCommandDispatcher dispatcher = new SocketCommandDispatcher(registry, auditService);
+
+        Player player = new Player(
+            User.of(Username.of("tester"), Password.hash("pw", 1000)),
+            1,
+            0,
+            new PlayerVitals(5, 20, 5, 20, 5, 20),
+            List.of(),
+            "prompt",
+            false,
+            List.of(),
+            null,
+            null
+        );
+
+        dispatcher.dispatch(new NoOpContext(player), "look", "corr-mdc-1");
+
+        assertEquals("corr-mdc-1", capturedId.get(),
+            "ThreadContext must contain the correlationId during command execution");
+    }
+
+    @Test
+    void threadContextIsClearedAfterDispatch() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        AuditService auditService = new AuditService(new NoOpAuditSink(), Clock.systemUTC(), () -> 0L, () -> "test");
+        SocketCommandDispatcher dispatcher = new SocketCommandDispatcher(registry, auditService);
+
+        Player player = new Player(
+            User.of(Username.of("tester"), Password.hash("pw", 1000)),
+            1,
+            0,
+            new PlayerVitals(5, 20, 5, 20, 5, 20),
+            List.of(),
+            "prompt",
+            false,
+            List.of(),
+            null,
+            null
+        );
+
+        dispatcher.dispatch(new NoOpContext(player), "unknown-cmd", "corr-mdc-2");
+
+        assertNull(ThreadContext.get(SocketCommandDispatcher.MDC_CORRELATION_ID),
+            "ThreadContext must be cleared after dispatch completes");
+    }
+
+    @Test
+    void threadContextIsClearedEvenWhenCommandThrows() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        registry.register(new ThrowingCommand("boom"));
+        AuditService auditService = new AuditService(new NoOpAuditSink(), Clock.systemUTC(), () -> 0L, () -> "test");
+        SocketCommandDispatcher dispatcher = new SocketCommandDispatcher(registry, auditService);
+
+        Player player = new Player(
+            User.of(Username.of("tester"), Password.hash("pw", 1000)),
+            1,
+            0,
+            new PlayerVitals(5, 20, 5, 20, 5, 20),
+            List.of(),
+            "prompt",
+            false,
+            List.of(),
+            null,
+            null
+        );
+
+        try {
+            dispatcher.dispatch(new NoOpContext(player), "boom", "corr-mdc-3");
+        } catch (RuntimeException ignored) {
+            // expected
+        }
+
+        assertNull(ThreadContext.get(SocketCommandDispatcher.MDC_CORRELATION_ID),
+            "ThreadContext must be cleared even when command execution throws");
+    }
+
+    // ── Test helpers ──────────────────────────────────────────────────────────
+
+    /** Records the MDC correlationId at the moment its command executes. */
+    private static class CapturingCommand implements SocketCommandHandler {
+        private final String name;
+        private final AtomicReference<String> capturedId;
+
+        private CapturingCommand(String name, AtomicReference<String> capturedId) {
+            this.name = name;
+            this.capturedId = capturedId;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public Optional<SocketCommandMatch> match(String input) {
+            if (!input.equalsIgnoreCase(name)) {
+                return Optional.empty();
+            }
+            return Optional.of(new SocketCommandMatch(this, context ->
+                capturedId.set(ThreadContext.get(SocketCommandDispatcher.MDC_CORRELATION_ID))
+            ));
+        }
+    }
+
+    /** Always throws during execution to test finally-block cleanup. */
+    private static class ThrowingCommand implements SocketCommandHandler {
+        private final String name;
+
+        private ThrowingCommand(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public Optional<SocketCommandMatch> match(String input) {
+            if (!input.equalsIgnoreCase(name)) {
+                return Optional.empty();
+            }
+            return Optional.of(new SocketCommandMatch(this, context -> {
+                throw new RuntimeException("simulated command failure");
+            }));
+        }
+    }
+
+    private static class NoOpContext implements SocketCommandContext {
+        private final Player player;
+
+        private NoOpContext(Player player) {
+            this.player = player;
+        }
+
+        @Override
+        public boolean isAuthenticated() {
+            return true;
+        }
+
+        @Override
+        public Player getPlayer() {
+            return player;
+        }
+
+        @Override
+        public List<Client> clients() {
+            return List.of();
+        }
+
+        @Override
+        public List<Username> onlinePlayerNames() {
+            return List.of();
+        }
+
+        @Override
+        public void sendLook() {
+        }
+
+        @Override
+        public void sendLookAt(String targetInput) {
+        }
+
+        @Override
+        public void sendMove(Direction direction) {
+        }
+
+        @Override
+        public void useAbility(String args) {
+        }
+
+        @Override
+        public void updateAnsi(String args) {
+        }
+
+        @Override
+        public void writeLineWithPrompt(String message) {
+        }
+
+        @Override
+        public void writeLineSafe(String message) {
+        }
+
+        @Override
+        public void sendPrompt() {
+        }
+
+        @Override
+        public void sendToUsername(Username username, String message) {
+        }
+
+        @Override
+        public void sendToRoom(Player source, Player target, String message) {
+        }
+
+        @Override
+        public void sendToRoom(Player source, String message) {
+        }
+
+        @Override
+        public Optional<Player> resolveTarget(Player source, String input) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void executeAttack(String args) {
+        }
+
+        @Override
+        public void getItem(String args) {
+        }
+
+        @Override
+        public void dropItem(String args) {
+        }
+
+        @Override
+        public void quaffItem(String args) {
+        }
+
+        @Override
+        public void equipItem(String args) {
+        }
+
+        @Override
+        public void unequipItem(String args) {
+        }
+
+        @Override
+        public void killMob(String args) {
+        }
+
+        @Override
+        public void fleeCombat() {
+        }
+
+        @Override
+        public void sendInventory() {
+        }
+
+        @Override
+        public void sendEquipment() {
+        }
+
+        @Override
+        public void sendMessage(io.taanielo.jmud.core.messaging.Message message) {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void run() {
+        }
+    }
+}


### PR DESCRIPTION
Closes #187

## Summary

- `SocketCommandDispatcher` now calls `ThreadContext.put("correlationId", ...)` before dispatching each command and clears it in a `finally` block, preventing MDC leakage across tick-thread commands
- `log4j2.properties` updated to include `%X{correlationId}` in all pattern layouts
- Added `log4j-layout-template-json` dependency for structured log output
- New `log4j2-json.xml` + `jmud-log-template.json` provide an optional NDJSON log configuration activated via `-Dlog4j2.configurationFile=log4j2-json.xml`
- New `SocketCommandDispatcherMdcTest` with 3 tests covering MDC population, cleanup on success, and cleanup on exception
- readme updated with a logging configuration section

## Test plan

- [ ] `./gradlew build` passes (unit tests including new MDC tests)
- [ ] Start server normally and verify correlationId appears in log lines
- [ ] Start server with `-Dlog4j2.configurationFile=log4j2-json.xml` and verify NDJSON output
- [ ] Confirm no MDC leakage between commands by running multiple commands in sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)