### PR TITLE
feat(bootstrap): add data/ backup script and --validate-data startup flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build
         run: ./gradlew build --no-daemon
 
+      - name: Validate game data
+        run: ./gradlew run --args='--validate-data' --no-daemon
+
       - name: Upload test reports
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ data/ssh/
 
 ### Claude Code agent runtime state ###
 .claude/agents/state/
+
+### Local data backups created by scripts/backup-data.sh ###
+backups/

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -18,6 +18,8 @@ See also: `readme.md` for prerequisites and configuration key reference.
 6. [Logs and audit trail](#6-logs-and-audit-trail)
 7. [Tick health](#7-tick-health)
 8. [Common failures](#8-common-failures)
+9. [Automated data backups](#9-automated-data-backups)
+10. [Validating game data (--validate-data)](#10-validating-game-data----validate-data)
 
 ---
 
@@ -599,3 +601,128 @@ network mount, or a very high player-command rate.
 
 Resolution: increase `jmud.audit.queue_size` (default 2048), move the
 `jmud.audit.path` to local fast storage, or reduce load.
+
+---
+
+## 9. Automated data backups
+
+`scripts/backup-data.sh` creates a compressed, timestamped archive of the entire
+`data/` tree and prunes archives older than a configurable number of days.
+
+### What it archives
+
+The script archives the entire `data/` directory, which includes all game content
+(rooms, items, mobs, races, classes, skills, attacks, quests, shops, banks) as
+well as the runtime-state directories (`users/`, `banks/`). Player save files
+live in `players/` at the project root and are **not** included in the archive —
+use a separate backup step for those if needed (see §3 Backup procedure).
+
+### Running the script
+
+```sh
+# Run from the project root with default 14-day retention
+./scripts/backup-data.sh
+
+# Override retention period (keep last 30 days)
+./scripts/backup-data.sh --retain-days 30
+```
+
+Archives are written to `backups/` in the project root (excluded from git).
+Each archive is named `data-YYYY-MM-DD-HHmmSS.tar.gz`.
+
+### Crontab example
+
+The script header contains a ready-to-use crontab line. To install it:
+
+```sh
+crontab -e
+```
+
+Then add (adjust the path and retention as needed):
+
+```
+0 3 * * * cd /opt/jmud && ./scripts/backup-data.sh --retain-days 14 >> /var/log/jmud-backup.log 2>&1
+```
+
+This runs every day at 03:00 and retains the last 14 daily archives.
+
+### Restore from archive
+
+```sh
+# Stop the server first to prevent concurrent writes
+sudo systemctl stop jmud
+
+# Move existing data aside in case you need to revert
+mv data data.old
+
+# Restore
+tar xzf backups/data-YYYY-MM-DD-HHmmSS.tar.gz
+
+# Verify then start
+ls data/
+sudo systemctl start jmud
+```
+
+If the restore looks correct, remove the old data:
+
+```sh
+rm -rf data.old
+```
+
+---
+
+## 10. Validating game data (--validate-data)
+
+The `--validate-data` startup flag instructs jmud to scan every JSON file in the
+`data/` tree and the `players/` directory, report per-domain counts, and exit
+without starting any servers. It does not require a running game instance.
+
+### Usage
+
+```sh
+# Via Gradle (recommended for development)
+./gradlew run --args='--validate-data'
+
+# Via the distribution binary
+/opt/jmud-1.0-SNAPSHOT/bin/jmud --validate-data
+```
+
+### Output
+
+On success (all files parse cleanly):
+
+```
+  [OK]   rooms         12 file(s)
+  [OK]   items         47 file(s)
+  ...
+
+Data validation PASSED: 134 file(s) across 13 domain(s)
+```
+
+On failure (one or more files are broken):
+
+```
+  [OK]   rooms         12 file(s)
+  [FAIL] items         1 error(s) / 47 file(s)
+         /opt/jmud/data/items/broken-sword.json
+         -> ... parse error detail ...
+  ...
+
+Data validation FAILED: 1 error(s) in 134 file(s) scanned
+```
+
+The exit code is `0` on success and `1` on failure. CI runs this step
+automatically for every pull request so broken data is caught before deployment.
+
+### When to run it
+
+- After manually editing any JSON file in `data/`
+- Before deploying a new content update
+- As a pre-flight check after restoring from a backup (see §9)
+
+### What it validates
+
+The validator checks every `*.json` file in the following domains (all relative
+to `data/`): `rooms`, `items`, `mobs`, `attacks`, `skills`, `classes`, `races`,
+`shops`, `quests`, `banks`, `users`, `characters`, plus all files under
+`players/`. A file that produces no parse error is considered valid.

--- a/scripts/backup-data.sh
+++ b/scripts/backup-data.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# backup-data.sh — create a compressed archive of the jmud data/ tree.
+#
+# Usage:
+#   ./scripts/backup-data.sh [--retain-days N]
+#
+# The script creates a timestamped archive under backups/ and then prunes
+# archives older than RETAIN_DAYS days (default: 14).
+#
+# Recommended crontab entry (runs every day at 03:00, retains 14 days):
+#   0 3 * * * cd /opt/jmud && ./scripts/backup-data.sh --retain-days 14 >> /var/log/jmud-backup.log 2>&1
+#
+# Restore:
+#   tar xzf backups/data-YYYY-MM-DD-HHmmSS.tar.gz
+# The data/ directory is restored relative to the current working directory.
+# See docs/runbook.md § "Automated archive backups" for full restore steps.
+
+set -euo pipefail
+
+# ── configuration ────────────────────────────────────────────────────────────
+RETAIN_DAYS=14
+
+# parse optional --retain-days argument
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --retain-days)
+            RETAIN_DAYS="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── paths ─────────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BACKUP_DIR="${PROJECT_ROOT}/backups"
+DATA_DIR="${PROJECT_ROOT}/data"
+TIMESTAMP="$(date +%F-%H%M%S)"
+ARCHIVE="${BACKUP_DIR}/data-${TIMESTAMP}.tar.gz"
+
+# ── sanity checks ─────────────────────────────────────────────────────────────
+if [[ ! -d "${DATA_DIR}" ]]; then
+    echo "ERROR: data directory not found at ${DATA_DIR}" >&2
+    exit 1
+fi
+
+mkdir -p "${BACKUP_DIR}"
+
+# ── create archive ────────────────────────────────────────────────────────────
+echo "[$(date -Iseconds)] Creating backup: ${ARCHIVE}"
+tar czf "${ARCHIVE}" -C "${PROJECT_ROOT}" data/
+echo "[$(date -Iseconds)] Backup complete: $(du -sh "${ARCHIVE}" | cut -f1)"
+
+# ── retention: remove archives older than RETAIN_DAYS days ───────────────────
+echo "[$(date -Iseconds)] Pruning archives older than ${RETAIN_DAYS} day(s) in ${BACKUP_DIR}/"
+find "${BACKUP_DIR}" -name "data-*.tar.gz" -mtime +"${RETAIN_DAYS}" -print -delete
+echo "[$(date -Iseconds)] Pruning done."

--- a/src/main/java/io/taanielo/jmud/Main.java
+++ b/src/main/java/io/taanielo/jmud/Main.java
@@ -1,11 +1,13 @@
 package io.taanielo.jmud;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
 import lombok.extern.slf4j.Slf4j;
 
+import io.taanielo.jmud.bootstrap.DataValidator;
 import io.taanielo.jmud.bootstrap.GameContext;
 import io.taanielo.jmud.core.server.ClientPool;
 import io.taanielo.jmud.core.server.Server;
@@ -18,6 +20,10 @@ import io.taanielo.jmud.core.server.ssh.SshServer;
 public class Main {
 
     public static void main(String[] args) {
+        if (hasFlag(args, "--validate-data")) {
+            System.exit(runDataValidation());
+        }
+
         boolean telnetEnabled = resolveBoolean(args, "--telnet-enabled", "JMUD_TELNET_ENABLED", true);
         String telnetHost = resolveHost(args, "--telnet-host", "JMUD_TELNET_HOST", "127.0.0.1");
         int telnetPort = resolvePort(args, "--telnet-port", "JMUD_TELNET_PORT", 4444);
@@ -154,5 +160,52 @@ public class Main {
     private static boolean isLoopbackHost(String host) {
         String normalized = host.trim().toLowerCase(Locale.ROOT);
         return "127.0.0.1".equals(normalized) || "localhost".equals(normalized) || "::1".equals(normalized);
+    }
+
+    private static boolean hasFlag(String[] args, String flagName) {
+        for (String arg : args) {
+            if (flagName.equals(arg)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Runs the data-validation mode: constructs the data validator, scans every
+     * domain directory under {@code data/} and the player-save directory, and
+     * prints a per-domain summary.
+     *
+     * @return {@code 0} when all files parse successfully, {@code 1} if any file
+     *         failed to parse
+     */
+    private static int runDataValidation() {
+        log.info("Running data validation …");
+        DataValidator validator = new DataValidator();
+        DataValidator.ValidationReport report = validator.validate(Path.of("data"), Path.of("players"));
+
+        for (DataValidator.DomainResult domain : report.domains()) {
+            if (domain.clean()) {
+                System.out.printf("  [OK]   %-12s  %d file(s)%n", domain.domain(), domain.fileCount());
+            } else {
+                System.out.printf("  [FAIL] %-12s  %d error(s) / %d file(s)%n",
+                    domain.domain(), domain.errors().size(), domain.fileCount());
+                for (DataValidator.FileError error : domain.errors()) {
+                    System.out.printf("         %s%n", error.path());
+                    System.out.printf("         -> %s%n", error.error());
+                }
+            }
+        }
+
+        System.out.printf("%n");
+        if (report.clean()) {
+            System.out.printf("Data validation PASSED: %d file(s) across %d domain(s)%n",
+                report.totalFiles(), report.domains().size());
+            return 0;
+        } else {
+            System.out.printf("Data validation FAILED: %d error(s) in %d file(s) scanned%n",
+                report.totalErrors(), report.totalFiles());
+            return 1;
+        }
     }
 }

--- a/src/main/java/io/taanielo/jmud/bootstrap/DataValidator.java
+++ b/src/main/java/io/taanielo/jmud/bootstrap/DataValidator.java
@@ -1,0 +1,132 @@
+package io.taanielo.jmud.bootstrap;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import io.taanielo.jmud.core.world.repository.json.JsonDataFileValidator;
+
+/**
+ * Validates all game-data JSON files under the {@code data/} tree and the
+ * player-save directory.
+ *
+ * <p>Validation walks each known sub-directory, parses every {@code *.json}
+ * file using the same Jackson configuration as the production repositories, and
+ * collects the outcome per domain. On success each domain reports a file count;
+ * on failure the broken file path and parse error are recorded, and scanning
+ * continues so that <em>all</em> broken files are reported in one pass.
+ *
+ * <p>This class belongs in the composition root (bootstrap) because it
+ * orchestrates multiple repository-layer parsers, mirroring the role of
+ * {@link GameContext} during normal startup (AGENTS.md §3.3).
+ */
+public final class DataValidator {
+
+    /**
+     * A file that failed JSON parsing: the absolute path and the error detail.
+     *
+     * @param path  absolute path of the file that failed to parse
+     * @param error the parse-error message
+     */
+    public record FileError(String path, String error) {}
+
+    /**
+     * Result for one data domain (e.g. "rooms", "players").
+     *
+     * @param domain    human-readable domain name
+     * @param fileCount number of {@code .json} files scanned in the directory
+     * @param errors    list of parse errors (empty when clean)
+     */
+    public record DomainResult(String domain, int fileCount, List<FileError> errors) {
+        /** Returns {@code true} when no parse errors were found in this domain. */
+        public boolean clean() {
+            return errors.isEmpty();
+        }
+    }
+
+    /**
+     * Full validation report across all domains.
+     *
+     * @param domains one {@link DomainResult} per scanned directory
+     */
+    public record ValidationReport(List<DomainResult> domains) {
+        /** Returns {@code true} when every domain is clean. */
+        public boolean clean() {
+            return domains.stream().allMatch(DomainResult::clean);
+        }
+
+        /** Total number of {@code .json} files scanned across all domains. */
+        public int totalFiles() {
+            return domains.stream().mapToInt(DomainResult::fileCount).sum();
+        }
+
+        /** Total number of parse errors across all domains. */
+        public int totalErrors() {
+            return domains.stream().mapToInt(d -> d.errors().size()).sum();
+        }
+    }
+
+    /**
+     * Ordered list of sub-directory names (relative to {@code dataRoot}) that are
+     * validated. Directories that do not exist are silently skipped.
+     */
+    private static final List<String> DATA_DOMAINS = List.of(
+        "rooms", "items", "mobs", "attacks", "skills", "classes",
+        "races", "shops", "quests", "banks", "users", "characters"
+    );
+
+    private final JsonDataFileValidator fileValidator;
+
+    /** Creates a validator using the project-standard JSON parser configuration. */
+    public DataValidator() {
+        this.fileValidator = new JsonDataFileValidator();
+    }
+
+    /**
+     * Validates all game-data and player-save files.
+     *
+     * @param dataRoot    root of the game data tree (typically {@code data/})
+     * @param playersRoot root of the player-save directory (typically {@code players/})
+     * @return a {@link ValidationReport} that is never {@code null}
+     */
+    public ValidationReport validate(Path dataRoot, Path playersRoot) {
+        List<DomainResult> results = new ArrayList<>();
+
+        for (String domain : DATA_DOMAINS) {
+            Path dir = dataRoot.resolve(domain);
+            results.add(validateDirectory(domain, dir));
+        }
+
+        results.add(validateDirectory("players", playersRoot));
+
+        return new ValidationReport(List.copyOf(results));
+    }
+
+    private DomainResult validateDirectory(String domain, Path dir) {
+        if (!Files.exists(dir) || !Files.isDirectory(dir)) {
+            return new DomainResult(domain, 0, List.of());
+        }
+
+        List<FileError> errors = new ArrayList<>();
+        List<Path> jsonFiles;
+
+        try (var stream = Files.list(dir)) {
+            jsonFiles = stream
+                .filter(p -> p.toString().endsWith(".json"))
+                .toList();
+        } catch (IOException e) {
+            errors.add(new FileError(dir.toString(), "Failed to list directory: " + e));
+            return new DomainResult(domain, 0, List.copyOf(errors));
+        }
+
+        for (Path file : jsonFiles) {
+            Optional<String> error = fileValidator.validate(file);
+            error.ifPresent(msg -> errors.add(new FileError(file.toAbsolutePath().toString(), msg)));
+        }
+
+        return new DomainResult(domain, jsonFiles.size(), List.copyOf(errors));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/repository/json/JsonDataFileValidator.java
+++ b/src/main/java/io/taanielo/jmud/core/world/repository/json/JsonDataFileValidator.java
@@ -1,0 +1,45 @@
+package io.taanielo.jmud.core.world.repository.json;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Validates that a single JSON file is syntactically valid and parseable using
+ * the project-standard Jackson configuration (snake_case, Java time support).
+ *
+ * <p>This class lives in the {@code repository.json} layer, which is the only
+ * layer allowed to use Jackson directly (AGENTS.md §3.2, ArchitectureTest
+ * {@code jackson_containment}). Callers outside that layer must use this class
+ * rather than instantiating an {@link ObjectMapper} themselves.
+ */
+@NullMarked
+public final class JsonDataFileValidator {
+
+    private final ObjectMapper objectMapper;
+
+    /** Creates a validator backed by the standard project Jackson configuration. */
+    public JsonDataFileValidator() {
+        this.objectMapper = JsonDataMapper.create();
+    }
+
+    /**
+     * Attempts to parse the given file as JSON.
+     *
+     * @param file the file to validate; must exist and be readable
+     * @return an empty {@link Optional} on success, or an {@link Optional} containing
+     *         the error message on parse failure
+     */
+    public Optional<String> validate(Path file) {
+        try {
+            objectMapper.readTree(file.toFile());
+            return Optional.empty();
+        } catch (IOException e) {
+            String message = e.getMessage();
+            return Optional.of(message != null ? message : e.getClass().getSimpleName());
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/bootstrap/DataValidatorTest.java
+++ b/src/test/java/io/taanielo/jmud/bootstrap/DataValidatorTest.java
@@ -1,0 +1,112 @@
+package io.taanielo.jmud.bootstrap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DataValidatorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void cleanData_reportsSuccess() throws IOException {
+        Path dataRoot = tempDir.resolve("data");
+        Path playersRoot = tempDir.resolve("players");
+        Files.createDirectories(dataRoot.resolve("rooms"));
+        Files.createDirectories(playersRoot);
+
+        // Valid JSON files
+        Files.writeString(dataRoot.resolve("rooms/room1.json"), "{\"id\": \"town-square\", \"name\": \"Town Square\"}");
+        Files.writeString(dataRoot.resolve("rooms/room2.json"), "[1, 2, 3]");
+        Files.writeString(playersRoot.resolve("hero.json"), "{\"username\": \"hero\"}");
+
+        DataValidator validator = new DataValidator();
+        DataValidator.ValidationReport report = validator.validate(dataRoot, playersRoot);
+
+        assertTrue(report.clean(), "Expected a clean report but got errors: " + report);
+        assertEquals(0, report.totalErrors());
+
+        // rooms domain should have 2 files; players should have 1
+        DataValidator.DomainResult rooms = domainResult(report, "rooms");
+        assertEquals(2, rooms.fileCount());
+        assertTrue(rooms.clean());
+
+        DataValidator.DomainResult players = domainResult(report, "players");
+        assertEquals(1, players.fileCount());
+        assertTrue(players.clean());
+    }
+
+    @Test
+    void brokenJson_reportedInErrors() throws IOException {
+        Path dataRoot = tempDir.resolve("data");
+        Path playersRoot = tempDir.resolve("players");
+        Files.createDirectories(dataRoot.resolve("items"));
+        Files.createDirectories(playersRoot);
+
+        // One valid file, one broken file
+        Files.writeString(dataRoot.resolve("items/sword.json"), "{\"id\": \"sword\"}");
+        Path brokenFile = dataRoot.resolve("items/axe.json");
+        Files.writeString(brokenFile, "{ this is not valid JSON !!!");
+
+        DataValidator validator = new DataValidator();
+        DataValidator.ValidationReport report = validator.validate(dataRoot, playersRoot);
+
+        assertFalse(report.clean(), "Expected validation to fail for broken JSON");
+        assertEquals(1, report.totalErrors());
+
+        DataValidator.DomainResult items = domainResult(report, "items");
+        assertFalse(items.clean());
+        assertEquals(1, items.errors().size());
+        assertTrue(items.errors().get(0).path().contains("axe.json"),
+            "Error path should mention axe.json, but was: " + items.errors().get(0).path());
+    }
+
+    @Test
+    void missingDirectory_skippedWithZeroFiles() {
+        Path dataRoot = tempDir.resolve("data");   // does not exist
+        Path playersRoot = tempDir.resolve("players"); // does not exist
+
+        DataValidator validator = new DataValidator();
+        DataValidator.ValidationReport report = validator.validate(dataRoot, playersRoot);
+
+        assertTrue(report.clean(), "Missing directories should produce a clean report");
+        assertEquals(0, report.totalFiles());
+    }
+
+    @Test
+    void multipleErrors_allReported() throws IOException {
+        Path dataRoot = tempDir.resolve("data");
+        Path playersRoot = tempDir.resolve("players");
+        Files.createDirectories(dataRoot.resolve("mobs"));
+        Files.createDirectories(playersRoot);
+
+        Files.writeString(dataRoot.resolve("mobs/mob1.json"), "{ broken");
+        Files.writeString(dataRoot.resolve("mobs/mob2.json"), "also broken");
+        Files.writeString(dataRoot.resolve("mobs/mob3.json"), "{\"id\": \"mob3\"}");
+
+        DataValidator validator = new DataValidator();
+        DataValidator.ValidationReport report = validator.validate(dataRoot, playersRoot);
+
+        assertFalse(report.clean());
+        assertEquals(2, report.totalErrors(), "Both broken files should be reported");
+
+        DataValidator.DomainResult mobs = domainResult(report, "mobs");
+        assertEquals(3, mobs.fileCount());
+        assertEquals(2, mobs.errors().size());
+    }
+
+    private static DataValidator.DomainResult domainResult(DataValidator.ValidationReport report, String domain) {
+        return report.domains().stream()
+            .filter(d -> d.domain().equals(domain))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Domain not found in report: " + domain));
+    }
+}


### PR DESCRIPTION
Closes #189

## Summary

- Add `scripts/backup-data.sh` with timestamped tar.gz archives and 14-day retention policy
- Add `DataValidator` interface and `JsonDataFileValidator` in bootstrap/infrastructure covering all 12 data domains plus `players/`
- Add `--validate-data` flag to `Main.java`: exits 0 on clean data, 1 with a full listing of broken files
- Update CI workflow to run `--validate-data` against committed game data on every build
- Add `backups/` to `.gitignore`
- Update `docs/runbook.md` with backup and validation runbook sections
- Add `DataValidatorTest` with 4 unit tests

## Test plan

- [ ] Run `./gradlew build` — all tests including `DataValidatorTest` pass
- [ ] Run `java -jar build/libs/jmud.jar --validate-data` against a clean `data/` tree — exits 0
- [ ] Introduce a malformed JSON file in `data/` and re-run — exits 1 with the offending file listed
- [ ] Run `scripts/backup-data.sh` — a timestamped `.tar.gz` is created under `backups/` and archives older than 14 days are pruned
- [ ] Verify CI workflow runs the `--validate-data` step on a push

🤖 Generated with [Claude Code](https://claude.com/claude-code)