### PR TITLE
fix(player): stop PlayerCombatState.effects() leaking internal mutable list (#215)

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/effects/EffectEngine.java
+++ b/src/main/java/io/taanielo/jmud/core/effects/EffectEngine.java
@@ -1,6 +1,5 @@
 package io.taanielo.jmud.core.effects;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,12 +24,11 @@ public class EffectEngine {
         Objects.requireNonNull(sink, "Effect message sink is required");
 
         EffectDefinition definition = definitionOrThrow(id);
-        List<EffectInstance> effects = target.effects();
-        EffectInstance existing = findInstance(effects, id);
+        EffectInstance existing = findInstance(target.effects(), id);
         boolean applied = false;
         if (existing == null) {
             EffectInstance instance = EffectInstance.of(id, definition.durationTicks());
-            effects.add(instance);
+            target.addEffect(instance);
             applied = true;
         } else {
             applied = applyStacking(existing, definition);
@@ -44,17 +42,14 @@ public class EffectEngine {
     public void tick(EffectTarget target, EffectMessageSink sink) throws EffectRepositoryException {
         Objects.requireNonNull(target, "Effect target is required");
         Objects.requireNonNull(sink, "Effect message sink is required");
-        List<EffectInstance> effects = target.effects();
-        Iterator<EffectInstance> iterator = effects.iterator();
-        while (iterator.hasNext()) {
-            EffectInstance instance = iterator.next();
+        for (EffectInstance instance : target.effects()) {
             EffectDefinition definition = definitionOrThrow(instance.id());
             if (definition.isPermanent()) {
                 continue;
             }
             instance.tickDown();
             if (instance.remainingTicks() <= 0) {
-                iterator.remove();
+                target.removeEffect(instance);
                 sendMessages(target, definition, MessagePhase.EXPIRE, sink);
             }
         }

--- a/src/main/java/io/taanielo/jmud/core/effects/EffectTarget.java
+++ b/src/main/java/io/taanielo/jmud/core/effects/EffectTarget.java
@@ -5,7 +5,30 @@ import java.util.List;
 import io.taanielo.jmud.core.authentication.Username;
 
 public interface EffectTarget {
+
+    /**
+     * Returns an immutable snapshot of the target's active effects.
+     *
+     * <p>Implementations must not return their internal mutable collection;
+     * mutation goes through {@link #addEffect(EffectInstance)} and
+     * {@link #removeEffect(EffectInstance)} on the tick thread only.
+     */
     List<EffectInstance> effects();
+
+    /**
+     * Adds an active effect to this target. Tick-thread only (AGENTS.md §5).
+     *
+     * @param instance the effect instance to add
+     */
+    void addEffect(EffectInstance instance);
+
+    /**
+     * Removes an active effect from this target. Tick-thread only (AGENTS.md §5).
+     *
+     * @param instance the effect instance to remove
+     * @return {@code true} if the instance was present and removed
+     */
+    boolean removeEffect(EffectInstance instance);
 
     default Username username() {
         return null;

--- a/src/main/java/io/taanielo/jmud/core/player/Player.java
+++ b/src/main/java/io/taanielo/jmud/core/player/Player.java
@@ -344,6 +344,18 @@ public class Player implements EffectTarget, Combatant {
         return combatState.effects();
     }
 
+    /** {@inheritDoc} Tick-thread only (AGENTS.md §5). */
+    @Override
+    public void addEffect(EffectInstance instance) {
+        combatState.addEffect(instance);
+    }
+
+    /** {@inheritDoc} Tick-thread only (AGENTS.md §5). */
+    @Override
+    public boolean removeEffect(EffectInstance instance) {
+        return combatState.removeEffect(instance);
+    }
+
     @Override
     public Username username() {
         return getUsername();

--- a/src/main/java/io/taanielo/jmud/core/player/PlayerCombatState.java
+++ b/src/main/java/io/taanielo/jmud/core/player/PlayerCombatState.java
@@ -6,6 +6,14 @@ import java.util.Objects;
 
 import io.taanielo.jmud.core.effects.EffectInstance;
 
+/**
+ * Holds a player's combat-related state: vitals, active effects and death flag.
+ *
+ * <p>The effects collection is owned by this class. Callers observe it through the
+ * immutable snapshot returned by {@link #effects()} and mutate it only through
+ * {@link #addEffect(EffectInstance)} and {@link #removeEffect(EffectInstance)},
+ * which — like all game-state mutation — must run on the tick thread (AGENTS.md §5).
+ */
 public class PlayerCombatState {
     private final PlayerVitals vitals;
     private final List<EffectInstance> effects;
@@ -22,8 +30,37 @@ public class PlayerCombatState {
         return vitals;
     }
 
+    /**
+     * Returns an immutable snapshot of the currently active effects.
+     *
+     * <p>The returned list never reflects later mutations and throws
+     * {@link UnsupportedOperationException} on any modification attempt. Use
+     * {@link #addEffect(EffectInstance)} / {@link #removeEffect(EffectInstance)}
+     * to change the active effects.
+     *
+     * @return an unmodifiable copy of the active effects
+     */
     public List<EffectInstance> effects() {
-        return effects;
+        return List.copyOf(effects);
+    }
+
+    /**
+     * Adds an active effect. Tick-thread only (AGENTS.md §5).
+     *
+     * @param instance the effect instance to add
+     */
+    public void addEffect(EffectInstance instance) {
+        effects.add(Objects.requireNonNull(instance, "Effect instance is required"));
+    }
+
+    /**
+     * Removes an active effect. Tick-thread only (AGENTS.md §5).
+     *
+     * @param instance the effect instance to remove
+     * @return {@code true} if the instance was present and removed
+     */
+    public boolean removeEffect(EffectInstance instance) {
+        return effects.remove(Objects.requireNonNull(instance, "Effect instance is required"));
     }
 
     public boolean dead() {

--- a/src/test/java/io/taanielo/jmud/core/healing/HealingEngineTest.java
+++ b/src/test/java/io/taanielo/jmud/core/healing/HealingEngineTest.java
@@ -118,8 +118,8 @@ class HealingEngineTest {
         assertEquals(21, boosted.getVitals().hp());
         assertEquals(20, boosted.getVitals().baseMaxHp());
 
-        boosted.effects().clear();
-        Player reverted = engine.apply(boosted, 1);
+        Player cleared = boosted.withoutEffects();
+        Player reverted = engine.apply(cleared, 1);
 
         assertEquals(20, reverted.getVitals().maxHp());
         assertEquals(20, reverted.getVitals().hp());
@@ -157,7 +157,7 @@ class HealingEngineTest {
 
         Player updated = engine.apply(player, 2);
 
-        assertSame(player.effects(), updated.effects());
+        assertSame(player, updated);
         assertEquals(1, updated.effects().size());
     }
 

--- a/src/test/java/io/taanielo/jmud/core/player/PlayerCombatStateTest.java
+++ b/src/test/java/io/taanielo/jmud/core/player/PlayerCombatStateTest.java
@@ -1,0 +1,65 @@
+package io.taanielo.jmud.core.player;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.effects.EffectId;
+import io.taanielo.jmud.core.effects.EffectInstance;
+
+class PlayerCombatStateTest {
+
+    @Test
+    void effectsReturnsUnmodifiableView() {
+        EffectInstance stoneskin = new EffectInstance(EffectId.of("stoneskin"), 5, 1);
+        PlayerCombatState state = new PlayerCombatState(PlayerVitals.defaults(), List.of(stoneskin), false);
+
+        List<EffectInstance> view = state.effects();
+
+        assertThrows(UnsupportedOperationException.class,
+            () -> view.add(new EffectInstance(EffectId.of("shield"), 3, 1)));
+        assertThrows(UnsupportedOperationException.class, () -> view.remove(stoneskin));
+        assertThrows(UnsupportedOperationException.class, view::clear);
+    }
+
+    @Test
+    void effectsSnapshotDoesNotReflectLaterMutations() {
+        PlayerCombatState state = new PlayerCombatState(PlayerVitals.defaults(), List.of(), false);
+
+        List<EffectInstance> snapshot = state.effects();
+        state.addEffect(new EffectInstance(EffectId.of("regen"), 10, 1));
+
+        assertTrue(snapshot.isEmpty());
+        assertEquals(1, state.effects().size());
+    }
+
+    @Test
+    void addAndRemoveEffectMutateInternalState() {
+        EffectInstance regen = new EffectInstance(EffectId.of("regen"), 10, 1);
+        PlayerCombatState state = new PlayerCombatState(PlayerVitals.defaults(), List.of(), false);
+
+        state.addEffect(regen);
+        assertEquals(List.of(regen), state.effects());
+
+        assertTrue(state.removeEffect(regen));
+        assertTrue(state.effects().isEmpty());
+        assertFalse(state.removeEffect(regen));
+    }
+
+    @Test
+    void constructorTakesDefensiveCopyOfEffects() {
+        List<EffectInstance> input = new ArrayList<>();
+        input.add(new EffectInstance(EffectId.of("stoneskin"), 5, 1));
+        PlayerCombatState state = new PlayerCombatState(PlayerVitals.defaults(), input, false);
+
+        input.clear();
+
+        assertEquals(1, state.effects().size());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes C4: `PlayerCombatState.effects()` previously returned its internal mutable list, letting callers mutate combat state from outside.

- `PlayerCombatState.effects()` now returns a `List.copyOf` snapshot
- Mutation goes through new `addEffect`/`removeEffect` methods
- `EffectTarget` interface declares the mutators; `EffectEngine` mutates via target methods; `Player` delegates
- New `PlayerCombatStateTest`; `HealingEngineTest` updated

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)