### PR TITLE
fix(ssh): persist host key as OpenSSH PEM instead of Java serialization (#216)

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -178,7 +178,7 @@ Cross-reference: `readme.md` § Configuration has further detail and examples.
 | `users/` | Runtime state (auth credentials) | No |
 | `players/` | Runtime state (player character state) | No |
 | `banks/` | Runtime state (bank account balances) | No |
-| `ssh/hostkey.ser` | SSH host key | No |
+| `ssh/hostkey.pem` | SSH host key | No |
 
 Content directories (rooms, items, mobs, etc.) are versioned in git and do not
 need separate backup — use `git pull` to restore them.
@@ -315,16 +315,28 @@ overwritten by the new empty character.
 ### Location
 
 ```
-data/ssh/hostkey.ser
+data/ssh/hostkey.pem
 ```
 
-The file is serialized by Apache MINA sshd and contains the server's RSA host
-key pair.
+The file is written in the standard OpenSSH PEM format
+(`-----BEGIN OPENSSH PRIVATE KEY-----`) and contains the server's host key
+pair (Ed25519 when available, otherwise RSA-3072). It can be inspected with
+standard tooling, e.g. `ssh-keygen -l -f data/ssh/hostkey.pem`.
+
+### Legacy `hostkey.ser` cleanup
+
+Older versions stored the host key as a Java-serialized `data/ssh/hostkey.ser`
+file. On startup the server now deletes a leftover `hostkey.ser` automatically
+(logging a one-line notice) and generates a fresh PEM key at
+`data/ssh/hostkey.pem`. This is a one-time host key rotation: SSH clients will
+see a **host key changed** warning once and must refresh their known-hosts
+entry (see below). If you find a stray `hostkey.ser` in old backups, it can be
+deleted — it is never read or written anymore.
 
 ### What happens if it is deleted
 
 On the next startup, sshd generates a fresh key pair and writes a new
-`hostkey.ser`. Existing SSH clients will see a **host key changed** warning and
+`hostkey.pem`. Existing SSH clients will see a **host key changed** warning and
 refuse to connect until the known-hosts entry is updated or removed:
 
 ```sh
@@ -339,7 +351,7 @@ Telnet connections are unaffected.
 2. Delete the key file:
 
    ```sh
-   rm data/ssh/hostkey.ser
+   rm data/ssh/hostkey.pem
    ```
 
 3. Start the server — a new key is generated automatically.

--- a/src/main/java/io/taanielo/jmud/core/server/ssh/PemHostKeyProvider.java
+++ b/src/main/java/io/taanielo/jmud/core/server/ssh/PemHostKeyProvider.java
@@ -1,0 +1,78 @@
+package io.taanielo.jmud.core.server.ssh;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+
+import org.apache.sshd.common.NamedResource;
+import org.apache.sshd.common.config.keys.writer.openssh.OpenSSHKeyEncryptionContext;
+import org.apache.sshd.common.config.keys.writer.openssh.OpenSSHKeyPairResourceWriter;
+import org.apache.sshd.common.util.security.SecurityUtils;
+import org.apache.sshd.server.keyprovider.AbstractGeneratorHostKeyProvider;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Generating SSH host key provider that persists the key pair in the standard OpenSSH PEM
+ * format ({@code -----BEGIN OPENSSH PRIVATE KEY-----}) instead of Java object serialization.
+ *
+ * <p>Unlike {@link org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider}, which
+ * writes the key pair with {@link java.io.ObjectOutputStream} (an opaque format and a known
+ * deserialization-attack surface), this provider writes a key file that is inspectable and
+ * manageable with standard tooling such as {@code ssh-keygen}. Reading is handled by the
+ * inherited {@code doReadKeyPairs}, which parses PEM/OpenSSH resources via
+ * {@link SecurityUtils#loadKeyPairIdentities}.
+ *
+ * <p>The key algorithm is Ed25519 when EdDSA support is available, otherwise RSA-3072.
+ */
+@Slf4j
+public class PemHostKeyProvider extends AbstractGeneratorHostKeyProvider {
+
+    private static final String KEY_COMMENT = "jmud-host-key";
+
+    /**
+     * Creates a provider that loads the host key from {@code hostKeyPath}, generating and
+     * persisting a fresh key pair in OpenSSH PEM format if the file does not exist yet.
+     *
+     * @param hostKeyPath location of the PEM host key file, e.g. {@code data/ssh/hostkey.pem}
+     */
+    public PemHostKeyProvider(Path hostKeyPath) {
+        setPath(hostKeyPath);
+        setStrictFilePermissions(true);
+        if (SecurityUtils.isEDDSACurveSupported()) {
+            setAlgorithm("Ed25519");
+        } else {
+            setAlgorithm("RSA");
+            setKeySize(3072);
+        }
+    }
+
+    @Override
+    protected void doWriteKeyPair(NamedResource resourceKey, KeyPair keyPair, OutputStream outputStream)
+        throws IOException, GeneralSecurityException {
+        OpenSSHKeyPairResourceWriter.INSTANCE
+            .writePrivateKey(keyPair, KEY_COMMENT, (OpenSSHKeyEncryptionContext) null, outputStream);
+        log.info("Persisted SSH host key in OpenSSH PEM format (algorithm: {})", getAlgorithm());
+    }
+
+    /**
+     * Deletes a legacy Java-serialized host key file ({@code hostkey.ser}) if one exists.
+     * Removing the legacy key triggers generation of a fresh PEM key on the next load, which
+     * means SSH clients will see a changed-host-key warning once.
+     *
+     * @param legacyKeyPath path of the legacy serialized key file
+     * @return {@code true} if a legacy key file was found and removed
+     * @throws IOException if the file exists but cannot be deleted
+     */
+    public static boolean removeLegacySerializedKey(Path legacyKeyPath) throws IOException {
+        boolean removed = Files.deleteIfExists(legacyKeyPath);
+        if (removed) {
+            log.info("Removed legacy Java-serialized SSH host key {}; "
+                + "a PEM host key will be used instead (clients may see a changed-host-key warning once)", legacyKeyPath);
+        }
+        return removed;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/ssh/SshServer.java
+++ b/src/main/java/io/taanielo/jmud/core/server/ssh/SshServer.java
@@ -21,7 +21,6 @@ import org.apache.sshd.common.util.security.SecurityUtils;
 import org.apache.sshd.core.CoreModuleProperties;
 import org.apache.sshd.server.auth.password.UserAuthPasswordFactory;
 import org.apache.sshd.server.forward.RejectAllForwardingFilter;
-import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import lombok.extern.slf4j.Slf4j;
@@ -66,10 +65,12 @@ public class SshServer implements Server {
         ));
         server.setShellFactory(new SshGameShellFactory(context, clientPool));
         configureSecurity(server);
-        Path hostKeyPath = Path.of("data/ssh/hostkey.ser");
+        Path hostKeyPath = Path.of("data/ssh/hostkey.pem");
+        Path legacyHostKeyPath = Path.of("data/ssh/hostkey.ser");
         try {
             Files.createDirectories(hostKeyPath.getParent());
-            server.setKeyPairProvider(buildHostKeyProvider(hostKeyPath));
+            PemHostKeyProvider.removeLegacySerializedKey(legacyHostKeyPath);
+            server.setKeyPairProvider(new PemHostKeyProvider(hostKeyPath));
             server.start();
             sshdServer = server;
             while (!Thread.currentThread().isInterrupted() && !stopRequested.get()) {
@@ -146,18 +147,6 @@ public class SshServer implements Server {
         if (!signatureFactories.isEmpty()) {
             server.setSignatureFactories(signatureFactories);
         }
-    }
-
-    private SimpleGeneratorHostKeyProvider buildHostKeyProvider(Path hostKeyPath) {
-        SimpleGeneratorHostKeyProvider provider = new SimpleGeneratorHostKeyProvider(hostKeyPath);
-        provider.setStrictFilePermissions(true);
-        if (SecurityUtils.isEDDSACurveSupported()) {
-            provider.setAlgorithm("Ed25519");
-        } else {
-            provider.setAlgorithm("RSA");
-            provider.setKeySize(3072);
-        }
-        return provider;
     }
 
     private List<NamedFactory<Cipher>> cipherFactories() {

--- a/src/test/java/io/taanielo/jmud/core/server/ssh/PemHostKeyProviderTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/ssh/PemHostKeyProviderTest.java
@@ -1,0 +1,84 @@
+package io.taanielo.jmud.core.server.ssh;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PemHostKeyProviderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void generatesPemHostKeyOnFirstLoad() throws Exception {
+        Path hostKeyPath = tempDir.resolve("hostkey.pem");
+        PemHostKeyProvider provider = new PemHostKeyProvider(hostKeyPath);
+
+        List<KeyPair> keys = provider.loadKeys(null);
+
+        assertEquals(1, keys.size());
+        assertTrue(Files.exists(hostKeyPath), "host key file should be created on first load");
+        List<String> lines = Files.readAllLines(hostKeyPath);
+        assertEquals("-----BEGIN OPENSSH PRIVATE KEY-----", lines.get(0));
+        byte[] content = Files.readAllBytes(hostKeyPath);
+        // Java serialization streams start with the magic bytes 0xAC 0xED — must never appear here
+        assertFalse((content[0] & 0xFF) == 0xAC && (content[1] & 0xFF) == 0xED,
+            "host key must not be written with Java object serialization");
+    }
+
+    @Test
+    void reusesPersistedHostKeyOnSubsequentLoads() throws Exception {
+        Path hostKeyPath = tempDir.resolve("hostkey.pem");
+
+        List<KeyPair> firstBoot = new PemHostKeyProvider(hostKeyPath).loadKeys(null);
+        List<KeyPair> secondBoot = new PemHostKeyProvider(hostKeyPath).loadKeys(null);
+
+        assertEquals(1, firstBoot.size());
+        assertEquals(1, secondBoot.size());
+        assertArrayEquals(
+            firstBoot.get(0).getPublic().getEncoded(),
+            secondBoot.get(0).getPublic().getEncoded(),
+            "restart must reuse the persisted host key instead of generating a new one");
+    }
+
+    @Test
+    void removesLegacySerializedKeyWhenPresent() throws Exception {
+        Path legacyPath = tempDir.resolve("hostkey.ser");
+        Files.write(legacyPath, new byte[] {(byte)0xAC, (byte)0xED, 0x00, 0x05});
+
+        assertTrue(PemHostKeyProvider.removeLegacySerializedKey(legacyPath));
+        assertFalse(Files.exists(legacyPath), "legacy serialized key file should be deleted");
+    }
+
+    @Test
+    void legacyRemovalIsNoOpWhenFileMissing() throws Exception {
+        Path legacyPath = tempDir.resolve("hostkey.ser");
+
+        assertFalse(PemHostKeyProvider.removeLegacySerializedKey(legacyPath));
+    }
+
+    @Test
+    void generatesFreshKeyAfterLegacyMigration() throws Exception {
+        Path hostKeyPath = tempDir.resolve("hostkey.pem");
+        Path legacyPath = tempDir.resolve("hostkey.ser");
+        Files.write(legacyPath, new byte[] {(byte)0xAC, (byte)0xED, 0x00, 0x05});
+
+        PemHostKeyProvider.removeLegacySerializedKey(legacyPath);
+        List<KeyPair> keys = new PemHostKeyProvider(hostKeyPath).loadKeys(null);
+
+        assertEquals(1, keys.size());
+        assertTrue(Files.exists(hostKeyPath));
+        assertFalse(Files.exists(legacyPath));
+        assertNotEquals(0, keys.get(0).getPublic().getEncoded().length);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PemHostKeyProvider` that persists the SSH host key as OpenSSH PEM using `OpenSSHKeyPairResourceWriter` (Ed25519 preferred, RSA-3072 fallback).
- Switch `SshServer` from `SimpleGeneratorHostKeyProvider` / `hostkey.ser` (Java serialization) to `data/ssh/hostkey.pem`, with one-time cleanup of the legacy `.ser` file.
- Add `PemHostKeyProviderTest` (5 tests) covering generation, persistence/reload, and format.
- Update `docs/runbook.md` section 5 for the new host key location and format.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)