### PR TITLE
fix(socket): bound per-player command queue and cap per-tick drain (#217)

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/server/socket/PlayerCommandQueue.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/PlayerCommandQueue.java
@@ -1,30 +1,85 @@
 package io.taanielo.jmud.core.server.socket;
 
 import java.util.Objects;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import lombok.extern.slf4j.Slf4j;
 
 import io.taanielo.jmud.core.tick.Tickable;
 
+/**
+ * Bounded per-player command queue drained by the tick thread.
+ *
+ * <p>Reader threads enqueue parsed commands via {@link #enqueue(Runnable)}; the tick
+ * thread executes them in FIFO order in {@link #tick()} (AGENTS.md §5). The queue is
+ * bounded so a flooding client cannot grow memory without limit: once
+ * {@code capacity} commands are pending, {@link #enqueue(Runnable)} rejects further
+ * commands without blocking, and the caller is expected to inform the player.
+ *
+ * <p>Each tick drains at most {@code maxCommandsPerTick} commands so a full queue
+ * cannot monopolize a tick; the remainder carries over to the next tick.
+ */
 @Slf4j
 public class PlayerCommandQueue implements Tickable {
-    private final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<>();
 
-    public void enqueue(Runnable command) {
-        queue.add(Objects.requireNonNull(command, "Command is required"));
+    /** Default maximum number of pending commands (enough for legitimate fast typing/aliases). */
+    public static final int DEFAULT_CAPACITY = 20;
+    /** Default maximum number of commands executed per tick. */
+    public static final int DEFAULT_MAX_COMMANDS_PER_TICK = 5;
+
+    private final LinkedBlockingQueue<Runnable> queue;
+    private final int maxCommandsPerTick;
+
+    /**
+     * Creates a queue with {@link #DEFAULT_CAPACITY} and {@link #DEFAULT_MAX_COMMANDS_PER_TICK}.
+     */
+    public PlayerCommandQueue() {
+        this(DEFAULT_CAPACITY, DEFAULT_MAX_COMMANDS_PER_TICK);
+    }
+
+    /**
+     * Creates a queue with the given bounds.
+     *
+     * @param capacity maximum number of pending commands; must be positive
+     * @param maxCommandsPerTick maximum commands executed per tick; must be positive
+     */
+    public PlayerCommandQueue(int capacity, int maxCommandsPerTick) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("Capacity must be positive");
+        }
+        if (maxCommandsPerTick <= 0) {
+            throw new IllegalArgumentException("Max commands per tick must be positive");
+        }
+        this.queue = new LinkedBlockingQueue<>(capacity);
+        this.maxCommandsPerTick = maxCommandsPerTick;
+    }
+
+    /**
+     * Attempts to enqueue a command without blocking. Safe to call from reader threads.
+     *
+     * @param command the command to run on the tick thread
+     * @return {@code true} if the command was accepted; {@code false} if the queue is
+     *     full and the command was dropped
+     */
+    public boolean enqueue(Runnable command) {
+        boolean accepted = queue.offer(Objects.requireNonNull(command, "Command is required"));
+        if (!accepted) {
+            log.debug("Player command queue full ({} pending); dropping command", queue.size());
+        }
+        return accepted;
     }
 
     @Override
     public void tick() {
-        Runnable task = queue.poll();
-        while (task != null) {
+        int executed = 0;
+        Runnable task;
+        while (executed < maxCommandsPerTick && (task = queue.poll()) != null) {
+            executed++;
             try {
                 task.run();
             } catch (Exception e) {
                 log.error("Player command failed", e);
             }
-            task = queue.poll();
         }
     }
 

--- a/src/main/java/io/taanielo/jmud/core/server/socket/PlayerSession.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/PlayerSession.java
@@ -183,8 +183,17 @@ public class PlayerSession {
         return playerTicker;
     }
 
-    public void enqueueCommand(Runnable command) {
-        commandQueue.enqueue(command);
+    /**
+     * Attempts to enqueue a command for execution on the tick thread. Safe to call
+     * from reader threads; never blocks.
+     *
+     * @param command the command to run on the tick thread
+     * @return {@code true} if the command was accepted; {@code false} if the
+     *     bounded queue is full and the command was dropped — the caller should
+     *     inform the player without touching game state (AGENTS.md §5)
+     */
+    public boolean enqueueCommand(Runnable command) {
+        return commandQueue.enqueue(command);
     }
 
     /**

--- a/src/main/java/io/taanielo/jmud/core/server/socket/PlayerTicker.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/PlayerTicker.java
@@ -17,7 +17,8 @@ import io.taanielo.jmud.core.tick.system.CooldownSystem;
  *
  * <p>Stage execution order (matches the former separate-subscription order):
  * <ol>
- *   <li><b>Command queue</b> — drains and executes all enqueued player commands</li>
+ *   <li><b>Command queue</b> — executes enqueued player commands (bounded per tick,
+ *       see {@link PlayerCommandQueue})</li>
  *   <li><b>Ability cooldowns</b> — decrements all in-flight ability cooldown counters</li>
  *   <li><b>Respawn</b> — counts down the respawn timer and triggers respawn when due</li>
  *   <li><b>Effects</b> — applies per-tick effect events (only when enabled via

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -277,7 +277,10 @@ public class SocketClient implements Client {
 
     private void handleCommand(String clientInput) {
         String cid = auditService.newCorrelationId();
-        session.enqueueCommand(() -> commandDispatcher.dispatch(commandContext, clientInput, cid));
+        boolean accepted = session.enqueueCommand(() -> commandDispatcher.dispatch(commandContext, clientInput, cid));
+        if (!accepted) {
+            connection.writeLine("You are entering commands too quickly.");
+        }
     }
     // Package-private accessors used by SocketCommandContextImpl
     Optional<Username> authenticatedUsername() {

--- a/src/test/java/io/taanielo/jmud/core/server/socket/PlayerCommandQueueTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/PlayerCommandQueueTest.java
@@ -1,9 +1,15 @@
 package io.taanielo.jmud.core.server.socket;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,5 +30,87 @@ class PlayerCommandQueueTest {
         queue.tick();
 
         assertEquals(List.of("first", "boom", "third"), executed);
+    }
+
+    @Test
+    void rejectsCommandsBeyondCapacityWithoutBlocking() {
+        PlayerCommandQueue queue = new PlayerCommandQueue(2, 5);
+
+        assertTrue(queue.enqueue(() -> { }));
+        assertTrue(queue.enqueue(() -> { }));
+        assertFalse(queue.enqueue(() -> { }), "Offer past capacity must be rejected");
+        assertEquals(2, queue.size(), "Dropped command must not be queued");
+    }
+
+    @Test
+    void acceptsAgainAfterDraining() {
+        PlayerCommandQueue queue = new PlayerCommandQueue(1, 5);
+
+        assertTrue(queue.enqueue(() -> { }));
+        assertFalse(queue.enqueue(() -> { }));
+
+        queue.tick();
+
+        assertTrue(queue.enqueue(() -> { }), "Capacity must be released after drain");
+    }
+
+    @Test
+    void drainsAtMostMaxCommandsPerTickAndPreservesOrderAcrossTicks() {
+        PlayerCommandQueue queue = new PlayerCommandQueue(10, 3);
+        List<Integer> executed = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            int value = i;
+            assertTrue(queue.enqueue(() -> executed.add(value)));
+        }
+
+        queue.tick();
+        assertEquals(List.of(0, 1, 2), executed, "First tick drains at most the cap, in order");
+        assertEquals(4, queue.size(), "Remainder carries over to the next tick");
+
+        queue.tick();
+        assertEquals(List.of(0, 1, 2, 3, 4, 5), executed);
+
+        queue.tick();
+        assertEquals(List.of(0, 1, 2, 3, 4, 5, 6), executed);
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    void concurrentOffersNeverExceedCapacity() throws InterruptedException {
+        int capacity = 20;
+        PlayerCommandQueue queue = new PlayerCommandQueue(capacity, 5);
+        int threads = 4;
+        int offersPerThread = 50;
+        AtomicInteger accepted = new AtomicInteger();
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+
+        for (int i = 0; i < threads; i++) {
+            Thread.ofVirtual().start(() -> {
+                try {
+                    start.await();
+                    for (int j = 0; j < offersPerThread; j++) {
+                        if (queue.enqueue(() -> { })) {
+                            accepted.incrementAndGet();
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        start.countDown();
+        assertTrue(done.await(10, TimeUnit.SECONDS), "Offer threads must finish");
+
+        assertEquals(capacity, accepted.get(), "Exactly the capacity worth of offers is accepted");
+        assertEquals(capacity, queue.size());
+    }
+
+    @Test
+    void rejectsInvalidBounds() {
+        assertThrows(IllegalArgumentException.class, () -> new PlayerCommandQueue(0, 5));
+        assertThrows(IllegalArgumentException.class, () -> new PlayerCommandQueue(10, 0));
     }
 }


### PR DESCRIPTION
## Summary
- Bound `PlayerCommandQueue` with a `LinkedBlockingQueue` (default capacity 20) and non-blocking `offer`, so a flooding client can no longer grow an unbounded queue.
- Cap per-tick drain at 5 commands with carry-over to the next tick, keeping tick duration predictable.
- `PlayerSession.enqueueCommand` now returns `boolean`; the `SocketClient` reader path sends "You are entering commands too quickly." when input is rejected.
- Added Javadoc to `PlayerTicker` and expanded `PlayerCommandQueueTest` to cover capacity limits, rejection, and drain-cap/carry-over behavior.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)