### PR TITLE
test(character): cover nonexistent-path scenarios in repository findAll tests

### DIFF
--- a/src/test/java/io/taanielo/jmud/core/character/JsonClassRepositoryFindAllTest.java
+++ b/src/test/java/io/taanielo/jmud/core/character/JsonClassRepositoryFindAllTest.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.taanielo.jmud.core.character.repository.ClassRepositoryException;
 import io.taanielo.jmud.core.character.repository.json.JsonClassRepository;
@@ -40,8 +41,11 @@ class JsonClassRepositoryFindAllTest {
     }
 
     @Test
-    void findAll_returnsEmptyForEmptyDir() throws ClassRepositoryException {
-        JsonClassRepository repo = new JsonClassRepository(Path.of("data-nonexistent-xyz"));
+    void findAll_returnsEmptyForEmptyDir(@TempDir Path tempDir) throws ClassRepositoryException {
+        // A fresh temp subdirectory guarantees the path has no class files on every
+        // machine and in CI, and keeps the repository working tree free of
+        // directories created by JsonClassRepository's constructor.
+        JsonClassRepository repo = new JsonClassRepository(tempDir.resolve("missing-subdir"));
         List<ClassDefinition> classes = repo.findAll();
         assertTrue(classes.isEmpty());
     }

--- a/src/test/java/io/taanielo/jmud/core/character/JsonRaceRepositoryFindAllTest.java
+++ b/src/test/java/io/taanielo/jmud/core/character/JsonRaceRepositoryFindAllTest.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.taanielo.jmud.core.character.repository.RaceRepositoryException;
 import io.taanielo.jmud.core.character.repository.json.JsonRaceRepository;
@@ -39,9 +40,12 @@ class JsonRaceRepositoryFindAllTest {
     }
 
     @Test
-    void findAll_returnsEmptyForEmptyDir() throws RaceRepositoryException {
-        // Requesting a non-existent data root must return empty rather than throw.
-        JsonRaceRepository repo = new JsonRaceRepository(Path.of("data-nonexistent-xyz"));
+    void findAll_returnsEmptyForEmptyDir(@TempDir Path tempDir) throws RaceRepositoryException {
+        // Requesting a data root with no race files must return empty rather than throw.
+        // A fresh temp subdirectory guarantees this holds on every machine and in CI,
+        // and keeps the repository working tree free of directories created by
+        // JsonRaceRepository's constructor.
+        JsonRaceRepository repo = new JsonRaceRepository(tempDir.resolve("missing-subdir"));
         List<Race> races = repo.findAll();
         assertTrue(races.isEmpty());
     }


### PR DESCRIPTION
Closes #218

Adds test coverage for nonexistent-path scenarios in JsonClassRepositoryFindAllTest and JsonRaceRepositoryFindAllTest.