### PR TITLE
feat(combat): add poison damage-over-time on-hit effect

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,7 @@
 - [x] Add weapon type variety: blunt, piercing, slashing with different damage dice and attack messages
 - [x] Add armour items (chest, legs, head slots) with AC value reducing incoming damage in combat engine
 - [x] Add SCORE prompt stat: show current AC derived from equipped armour
-- [ ] Add poison status effect applied by certain mob attacks (damage-over-time ticks)
+- [x] Add poison status effect applied by certain mob attacks (damage-over-time ticks)
 - [ ] Add CURE ability/potion to remove poison and other negative status effects
 - [ ] Add mob special ability: boss mobs can use a defined ability once per combat (e.g. troll smash)
 - [ ] Add WRITE and READ commands with scroll items that teach a new ability on use

--- a/data/attacks/attack.spider.json
+++ b/data/attacks/attack.spider.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 4,
   "id": "attack.spider",
   "name": "spider fangs",
   "min_damage": 2,
@@ -7,6 +7,10 @@
   "hit_bonus": -5,
   "crit_bonus": 5,
   "damage_bonus": 0,
+  "applies_effect": {
+    "effect_id": "poison",
+    "chance_percent": 40
+  },
   "messages": [
     {
       "phase": "attack_hit",

--- a/docs/schemas/attack.v4.json
+++ b/docs/schemas/attack.v4.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "jmud:attack:v4",
+  "title": "Attack (v4)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "name",
+    "min_damage",
+    "max_damage",
+    "hit_bonus",
+    "crit_bonus",
+    "damage_bonus"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 4
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9._-]+$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "min_damage": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "max_damage": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "hit_bonus": {
+      "type": "integer"
+    },
+    "crit_bonus": {
+      "type": "integer"
+    },
+    "damage_bonus": {
+      "type": "integer"
+    },
+    "weapon_type": {
+      "type": "string",
+      "enum": [
+        "BLUNT",
+        "PIERCING",
+        "SLASHING"
+      ],
+      "description": "Optional; added in schema version 3. Defaults to SLASHING when omitted."
+    },
+    "messages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "phase",
+          "channel",
+          "text"
+        ],
+        "properties": {
+          "phase": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "applies_effect": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional; added in schema version 4. Describes a status effect this attack applies to its target on a successful hit.",
+      "required": [
+        "effect_id",
+        "chance_percent"
+      ],
+      "properties": {
+        "effect_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$",
+          "description": "Must match the id of an EffectDefinition under data/effects/."
+        },
+        "chance_percent": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
@@ -162,7 +162,7 @@ public record GameContext(
         EquipmentArmorResolver equipmentArmorResolver = new EquipmentArmorResolver(itemRepository);
         RaceArmorBonusResolver raceArmorBonusResolver = new RaceArmorBonusResolver(raceRepository);
         CombatEngine combatEngine =
-                createCombatEngine(config, effectRepository, raceArmorBonusResolver, equipmentArmorResolver, attackRepository, tickClock::currentTick);
+                createCombatEngine(config, effectRepository, raceArmorBonusResolver, equipmentArmorResolver, attackRepository, tickClock::currentTick, effectEngine);
 
         EncumbranceService encumbranceService = new EncumbranceService(raceRepository, classRepository);
 
@@ -178,6 +178,7 @@ public record GameContext(
         MobRegistry mobRegistry = createMobRegistry(
                 playerEventBus, roomService, playerRepository, persistenceQueue, itemRepository, attackRepository);
         if (mobRegistry != null) {
+            mobRegistry.setEffectEngine(effectEngine);
             mobRegistry.init();
             tickRegistry.register(mobRegistry);
         }
@@ -287,19 +288,22 @@ public record GameContext(
         RaceArmorBonusResolver armorBonusResolver,
         EquipmentArmorResolver equipmentArmorResolver,
         JsonAttackRepository attackRepository,
-        LongSupplier tickSupplier
+        LongSupplier tickSupplier,
+        EffectEngine effectEngine
     ) {
         CombatModifierResolver resolver = new CombatModifierResolver(effectRepository);
         String rngMode = config.getString("jmud.combat.rng", "seeded");
         if ("threadlocal".equalsIgnoreCase(rngMode)) {
-            return new CombatEngine(attackRepository, resolver, armorBonusResolver, equipmentArmorResolver, new ThreadLocalCombatRandom());
+            return new CombatEngine(
+                attackRepository, resolver, armorBonusResolver, equipmentArmorResolver, new ThreadLocalCombatRandom(), effectEngine);
         }
         // Default: seeded mode — derive world seed from config, or generate a random one.
         // The SeededCombatRandomProvider constructor logs the effective seed at INFO so
         // any session can be reconstructed; set jmud.world.seed to replay a specific session.
         long worldSeed = config.getLong("jmud.world.seed", ThreadLocalRandom.current().nextLong());
         SeededCombatRandomProvider provider = new SeededCombatRandomProvider(worldSeed);
-        return new CombatEngine(attackRepository, resolver, armorBonusResolver, equipmentArmorResolver, provider, tickSupplier);
+        return new CombatEngine(
+            attackRepository, resolver, armorBonusResolver, equipmentArmorResolver, provider, tickSupplier, effectEngine);
     }
 
     private static ItemRepository createItemRepository() {

--- a/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
+++ b/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
@@ -150,6 +150,12 @@ public class GameActionService {
             if (result.roomMessage() != null && !result.roomMessage().isBlank()) {
                 messages.add(GameMessage.toRoom(source.getUsername(), target.getUsername(), result.roomMessage()));
             }
+            for (String effectTargetMessage : result.effectTargetMessages()) {
+                messages.add(GameMessage.toPlayer(target.getUsername(), effectTargetMessage));
+            }
+            for (String effectRoomMessage : result.effectRoomMessages()) {
+                messages.add(GameMessage.toRoom(source.getUsername(), target.getUsername(), effectRoomMessage));
+            }
             GameActionResult deathResult = resolveDeathIfNeeded(result.target(), source);
             Player updatedTarget = deathResult.updatedTarget();
             messages.addAll(deathResult.messages());

--- a/src/main/java/io/taanielo/jmud/core/combat/AttackDefinition.java
+++ b/src/main/java/io/taanielo/jmud/core/combat/AttackDefinition.java
@@ -20,9 +20,59 @@ public class AttackDefinition {
     private final int damageBonus;
     private final List<MessageSpec> messages;
     private final WeaponType weaponType;
+    private final AttackEffectApplication effectOnHit;
 
     /**
-     * Constructs an attack definition with explicit weapon type.
+     * Constructs an attack definition with explicit weapon type and an optional
+     * on-hit status effect application.
+     *
+     * @param id          unique identifier for this attack
+     * @param name        display name of the attack
+     * @param minDamage   minimum damage dealt on a hit (non-negative)
+     * @param maxDamage   maximum damage dealt on a hit (must be &gt;= minDamage)
+     * @param hitBonus    additive bonus to hit chance
+     * @param critBonus   additive bonus to critical hit chance
+     * @param damageBonus additive bonus applied to raw damage roll
+     * @param messages    flavour messages for hit, miss, and crit phases
+     * @param weaponType  classification of the weapon's damage style
+     * @param effectOnHit optional status effect to apply to the target on a successful hit;
+     *                    {@code null} means this attack applies no effect
+     */
+    public AttackDefinition(
+        AttackId id,
+        String name,
+        int minDamage,
+        int maxDamage,
+        int hitBonus,
+        int critBonus,
+        int damageBonus,
+        List<MessageSpec> messages,
+        WeaponType weaponType,
+        AttackEffectApplication effectOnHit
+    ) {
+        this.id = Objects.requireNonNull(id, "Attack id is required");
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Attack name must not be blank");
+        }
+        if (minDamage < 0 || maxDamage < 0) {
+            throw new IllegalArgumentException("Attack damage must be non-negative");
+        }
+        if (maxDamage < minDamage) {
+            throw new IllegalArgumentException("Attack max damage must be >= min damage");
+        }
+        this.name = name;
+        this.minDamage = minDamage;
+        this.maxDamage = maxDamage;
+        this.hitBonus = hitBonus;
+        this.critBonus = critBonus;
+        this.damageBonus = damageBonus;
+        this.messages = List.copyOf(Objects.requireNonNullElse(messages, List.of()));
+        this.weaponType = Objects.requireNonNullElse(weaponType, WeaponType.SLASHING);
+        this.effectOnHit = effectOnHit;
+    }
+
+    /**
+     * Constructs an attack definition with explicit weapon type and no on-hit effect.
      *
      * @param id          unique identifier for this attack
      * @param name        display name of the attack
@@ -45,28 +95,11 @@ public class AttackDefinition {
         List<MessageSpec> messages,
         WeaponType weaponType
     ) {
-        this.id = Objects.requireNonNull(id, "Attack id is required");
-        if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("Attack name must not be blank");
-        }
-        if (minDamage < 0 || maxDamage < 0) {
-            throw new IllegalArgumentException("Attack damage must be non-negative");
-        }
-        if (maxDamage < minDamage) {
-            throw new IllegalArgumentException("Attack max damage must be >= min damage");
-        }
-        this.name = name;
-        this.minDamage = minDamage;
-        this.maxDamage = maxDamage;
-        this.hitBonus = hitBonus;
-        this.critBonus = critBonus;
-        this.damageBonus = damageBonus;
-        this.messages = List.copyOf(Objects.requireNonNullElse(messages, List.of()));
-        this.weaponType = Objects.requireNonNullElse(weaponType, WeaponType.SLASHING);
+        this(id, name, minDamage, maxDamage, hitBonus, critBonus, damageBonus, messages, weaponType, null);
     }
 
     /**
-     * Constructs an attack definition defaulting to {@link WeaponType#SLASHING}.
+     * Constructs an attack definition defaulting to {@link WeaponType#SLASHING} and no on-hit effect.
      *
      * @param id          unique identifier for this attack
      * @param name        display name of the attack
@@ -87,7 +120,7 @@ public class AttackDefinition {
         int damageBonus,
         List<MessageSpec> messages
     ) {
-        this(id, name, minDamage, maxDamage, hitBonus, critBonus, damageBonus, messages, WeaponType.SLASHING);
+        this(id, name, minDamage, maxDamage, hitBonus, critBonus, damageBonus, messages, WeaponType.SLASHING, null);
     }
 
     /** @return unique identifier for this attack */
@@ -133,5 +166,10 @@ public class AttackDefinition {
     /** @return weapon type classifying this attack's damage style */
     public WeaponType weaponType() {
         return weaponType;
+    }
+
+    /** @return the on-hit status effect application, or {@code null} if this attack applies no effect */
+    public AttackEffectApplication effectOnHit() {
+        return effectOnHit;
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/combat/AttackEffectApplication.java
+++ b/src/main/java/io/taanielo/jmud/core/combat/AttackEffectApplication.java
@@ -1,0 +1,22 @@
+package io.taanielo.jmud.core.combat;
+
+import java.util.Objects;
+
+import io.taanielo.jmud.core.effects.EffectId;
+
+/**
+ * Describes an optional status effect an {@link AttackDefinition} applies to its
+ * target on a successful hit, and the percentage chance that it triggers.
+ *
+ * @param effectId      identifier of the effect to apply (resolved via {@code EffectEngine})
+ * @param chancePercent whole-number chance (1-100 inclusive) that the effect is applied on hit
+ */
+public record AttackEffectApplication(EffectId effectId, int chancePercent) {
+
+    public AttackEffectApplication {
+        Objects.requireNonNull(effectId, "Effect id is required");
+        if (chancePercent < 1 || chancePercent > 100) {
+            throw new IllegalArgumentException("Effect application chance must be between 1 and 100");
+        }
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/combat/CombatEngine.java
+++ b/src/main/java/io/taanielo/jmud/core/combat/CombatEngine.java
@@ -1,10 +1,13 @@
 package io.taanielo.jmud.core.combat;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.LongSupplier;
 
 import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.effects.EffectEngine;
+import io.taanielo.jmud.core.effects.EffectMessageSink;
 import io.taanielo.jmud.core.effects.EffectRepositoryException;
 import io.taanielo.jmud.core.messaging.MessageChannel;
 import io.taanielo.jmud.core.messaging.MessageContext;
@@ -30,6 +33,7 @@ public class CombatEngine {
     private final EquipmentArmorResolver equipmentArmorResolver;
     private final CombatRandomProvider randomProvider;
     private final LongSupplier tickSupplier;
+    private final EffectEngine effectEngine;
     private final MessageRenderer renderer = new MessageRenderer();
 
     // ── Legacy constructors (wrap a fixed CombatRandom; tick is always 0) ─────────
@@ -37,13 +41,28 @@ public class CombatEngine {
     /**
      * Creates a combat engine with the provided dependencies.
      * The supplied {@link CombatRandom} is used for every encounter (tick-independent).
+     * On-hit status effect application is disabled (no {@link EffectEngine} supplied).
      */
     public CombatEngine(
         AttackRepository attackRepository,
         CombatModifierResolver modifierResolver,
         CombatRandom random
     ) {
-        this(attackRepository, modifierResolver, RaceArmorBonusResolver.noOp(), EquipmentArmorResolver.noOp(), random);
+        this(attackRepository, modifierResolver, RaceArmorBonusResolver.noOp(), EquipmentArmorResolver.noOp(), random, null);
+    }
+
+    /**
+     * Creates a combat engine with the provided dependencies and an {@link EffectEngine}
+     * capable of applying on-hit status effects (see {@link AttackDefinition#effectOnHit()}).
+     * The supplied {@link CombatRandom} is used for every encounter (tick-independent).
+     */
+    public CombatEngine(
+        AttackRepository attackRepository,
+        CombatModifierResolver modifierResolver,
+        CombatRandom random,
+        EffectEngine effectEngine
+    ) {
+        this(attackRepository, modifierResolver, RaceArmorBonusResolver.noOp(), EquipmentArmorResolver.noOp(), random, effectEngine);
     }
 
     /**
@@ -56,12 +75,13 @@ public class CombatEngine {
         RaceArmorBonusResolver armorBonusResolver,
         CombatRandom random
     ) {
-        this(attackRepository, modifierResolver, armorBonusResolver, EquipmentArmorResolver.noOp(), random);
+        this(attackRepository, modifierResolver, armorBonusResolver, EquipmentArmorResolver.noOp(), random, null);
     }
 
     /**
      * Creates a combat engine with both race and equipment armor resolution.
      * The supplied {@link CombatRandom} is used for every encounter (tick-independent).
+     * On-hit status effect application is disabled (no {@link EffectEngine} supplied).
      */
     public CombatEngine(
         AttackRepository attackRepository,
@@ -70,13 +90,30 @@ public class CombatEngine {
         EquipmentArmorResolver equipmentArmorResolver,
         CombatRandom random
     ) {
+        this(attackRepository, modifierResolver, armorBonusResolver, equipmentArmorResolver, random, null);
+    }
+
+    /**
+     * Creates a combat engine with both race and equipment armor resolution and an
+     * {@link EffectEngine} capable of applying on-hit status effects.
+     * The supplied {@link CombatRandom} is used for every encounter (tick-independent).
+     */
+    public CombatEngine(
+        AttackRepository attackRepository,
+        CombatModifierResolver modifierResolver,
+        RaceArmorBonusResolver armorBonusResolver,
+        EquipmentArmorResolver equipmentArmorResolver,
+        CombatRandom random,
+        EffectEngine effectEngine
+    ) {
         this(
             attackRepository,
             modifierResolver,
             armorBonusResolver,
             equipmentArmorResolver,
             (tick, actorId) -> random,
-            () -> 0L
+            () -> 0L,
+            effectEngine
         );
     }
 
@@ -85,6 +122,7 @@ public class CombatEngine {
     /**
      * Creates a combat engine that derives a per-encounter seed from the tick and
      * actor, using the provided {@link CombatRandomProvider} and tick source.
+     * On-hit status effect application is disabled (no {@link EffectEngine} supplied).
      *
      * @param attackRepository       source of attack definitions
      * @param modifierResolver       resolves combat modifier chains from player effects
@@ -101,12 +139,39 @@ public class CombatEngine {
         CombatRandomProvider randomProvider,
         LongSupplier tickSupplier
     ) {
+        this(attackRepository, modifierResolver, armorBonusResolver, equipmentArmorResolver, randomProvider, tickSupplier, null);
+    }
+
+    /**
+     * Creates a combat engine that derives a per-encounter seed from the tick and
+     * actor, using the provided {@link CombatRandomProvider} and tick source, and
+     * capable of applying on-hit status effects via the supplied {@link EffectEngine}.
+     *
+     * @param attackRepository       source of attack definitions
+     * @param modifierResolver       resolves combat modifier chains from player effects
+     * @param armorBonusResolver     resolves race-based AC bonuses on the target
+     * @param equipmentArmorResolver resolves equipment-based AC bonuses on the target
+     * @param randomProvider         produces a fresh {@link CombatRandom} per encounter
+     * @param tickSupplier           supplies the current world tick number
+     * @param effectEngine           applies {@link AttackDefinition#effectOnHit()} to targets;
+     *                               {@code null} disables on-hit effect application
+     */
+    public CombatEngine(
+        AttackRepository attackRepository,
+        CombatModifierResolver modifierResolver,
+        RaceArmorBonusResolver armorBonusResolver,
+        EquipmentArmorResolver equipmentArmorResolver,
+        CombatRandomProvider randomProvider,
+        LongSupplier tickSupplier,
+        EffectEngine effectEngine
+    ) {
         this.attackRepository = Objects.requireNonNull(attackRepository, "Attack repository is required");
         this.modifierResolver = Objects.requireNonNull(modifierResolver, "Modifier resolver is required");
         this.armorBonusResolver = Objects.requireNonNull(armorBonusResolver, "Armor bonus resolver is required");
         this.equipmentArmorResolver = Objects.requireNonNull(equipmentArmorResolver, "Equipment armor resolver is required");
         this.randomProvider = Objects.requireNonNull(randomProvider, "Combat random provider is required");
         this.tickSupplier = Objects.requireNonNull(tickSupplier, "Tick supplier is required");
+        this.effectEngine = effectEngine;
     }
 
     /**
@@ -182,6 +247,30 @@ public class CombatEngine {
             ? target.withVitals(target.getVitals().damage(damage))
             : target;
 
+        List<String> effectTargetMessages = new ArrayList<>();
+        List<String> effectRoomMessages = new ArrayList<>();
+        if (hit && effectEngine != null && attack.effectOnHit() != null) {
+            AttackEffectApplication effectApplication = attack.effectOnHit();
+            int effectRoll = random.roll(1, 100);
+            if (effectRoll <= effectApplication.chancePercent()) {
+                effectEngine.apply(updatedTarget, effectApplication.effectId(), new EffectMessageSink() {
+                    @Override
+                    public void sendToTarget(String message) {
+                        if (message != null && !message.isBlank()) {
+                            effectTargetMessages.add(message);
+                        }
+                    }
+
+                    @Override
+                    public void sendToRoom(String message) {
+                        if (message != null && !message.isBlank()) {
+                            effectRoomMessages.add(message);
+                        }
+                    }
+                });
+            }
+        }
+
         String sourceMessage = null;
         String targetMessage = null;
         String roomMessage = null;
@@ -233,7 +322,7 @@ public class CombatEngine {
         }
 
         return new CombatResult(attacker, updatedTarget, hit, crit, damage,
-            sourceMessage, targetMessage, roomMessage, rngSeed);
+            sourceMessage, targetMessage, roomMessage, rngSeed, effectTargetMessages, effectRoomMessages);
     }
 
     private int clamp(int value, int min, int max) {

--- a/src/main/java/io/taanielo/jmud/core/combat/CombatResult.java
+++ b/src/main/java/io/taanielo/jmud/core/combat/CombatResult.java
@@ -1,10 +1,19 @@
 package io.taanielo.jmud.core.combat;
 
+import java.util.List;
+import java.util.Objects;
+
 import io.taanielo.jmud.core.player.Player;
 
 /**
  * The outcome of a single combat resolution, including updated target state,
  * messages to deliver, and the RNG seed used so any encounter is fully replayable.
+ *
+ * @param effectTargetMessages messages delivered to the target when an on-hit status
+ *                             effect was applied (e.g. "You are poisoned."); empty when
+ *                             no effect was applied
+ * @param effectRoomMessages   messages delivered to room occupants when an on-hit status
+ *                             effect was applied; empty when no effect was applied
  */
 public record CombatResult(
     Player attacker,
@@ -16,6 +25,29 @@ public record CombatResult(
     String targetMessage,
     String roomMessage,
     // The per-encounter seed used to produce this result; 0 when unseeded.
-    long rngSeed
+    long rngSeed,
+    List<String> effectTargetMessages,
+    List<String> effectRoomMessages
 ) {
+    public CombatResult {
+        effectTargetMessages = List.copyOf(Objects.requireNonNullElse(effectTargetMessages, List.of()));
+        effectRoomMessages = List.copyOf(Objects.requireNonNullElse(effectRoomMessages, List.of()));
+    }
+
+    /**
+     * Convenience constructor for results that apply no on-hit status effect.
+     */
+    public CombatResult(
+        Player attacker,
+        Player target,
+        boolean hit,
+        boolean crit,
+        int damage,
+        String sourceMessage,
+        String targetMessage,
+        String roomMessage,
+        long rngSeed
+    ) {
+        this(attacker, target, hit, crit, damage, sourceMessage, targetMessage, roomMessage, rngSeed, List.of(), List.of());
+    }
 }

--- a/src/main/java/io/taanielo/jmud/core/combat/dto/AttackDto.java
+++ b/src/main/java/io/taanielo/jmud/core/combat/dto/AttackDto.java
@@ -10,6 +10,9 @@ import io.taanielo.jmud.core.messaging.dto.MessageSpecDto;
  * <p>Schema version 3 adds the optional {@code weapon_type} field.
  * Files at schema version 2 that omit {@code weapon_type} are still accepted;
  * the mapper defaults to {@code SLASHING} in that case.
+ *
+ * <p>Schema version 4 adds the optional {@code applies_effect} field, describing
+ * a status effect this attack applies to its target on a successful hit.
  */
 public record AttackDto(
     int schemaVersion,
@@ -21,6 +24,16 @@ public record AttackDto(
     int critBonus,
     int damageBonus,
     List<MessageSpecDto> messages,
-    String weaponType
+    String weaponType,
+    AppliesEffectDto appliesEffect
 ) {
+
+    /**
+     * Data-transfer object describing an on-hit status effect application.
+     *
+     * @param effectId      id of the effect to apply (matches an {@code EffectDefinition} id)
+     * @param chancePercent whole-number chance (1-100 inclusive) that the effect is applied on hit
+     */
+    public record AppliesEffectDto(String effectId, int chancePercent) {
+    }
 }

--- a/src/main/java/io/taanielo/jmud/core/combat/dto/AttackMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/combat/dto/AttackMapper.java
@@ -4,17 +4,20 @@ import java.util.List;
 import java.util.Objects;
 
 import io.taanielo.jmud.core.combat.AttackDefinition;
+import io.taanielo.jmud.core.combat.AttackEffectApplication;
 import io.taanielo.jmud.core.combat.AttackId;
 import io.taanielo.jmud.core.combat.WeaponType;
+import io.taanielo.jmud.core.effects.EffectId;
 import io.taanielo.jmud.core.messaging.MessageSpec;
 import io.taanielo.jmud.core.messaging.MessageSpecMapper;
 
 /**
  * Maps {@link AttackDto} instances to {@link AttackDefinition} domain objects.
  *
- * <p>Accepts both schema version 2 (no {@code weapon_type} field) and schema
- * version 3 (with optional {@code weapon_type} field).  When the field is absent
- * or unrecognised the weapon type defaults to {@link WeaponType#SLASHING}.
+ * <p>Accepts schema versions 2 through 4. Schema version 2 omits {@code weapon_type};
+ * the mapper defaults to {@link WeaponType#SLASHING} in that case. Schema version 4
+ * additionally accepts an optional {@code applies_effect} field describing an on-hit
+ * status effect application.
  */
 public class AttackMapper {
 
@@ -28,11 +31,13 @@ public class AttackMapper {
     public AttackDefinition toDomain(AttackDto dto) {
         Objects.requireNonNull(dto, "Attack DTO is required");
         if (dto.schemaVersion() != AttackSchemaVersions.V2
-            && dto.schemaVersion() != AttackSchemaVersions.V3) {
+            && dto.schemaVersion() != AttackSchemaVersions.V3
+            && dto.schemaVersion() != AttackSchemaVersions.V4) {
             throw new IllegalArgumentException("Unsupported attack schema version " + dto.schemaVersion());
         }
         List<MessageSpec> messages = MessageSpecMapper.fromDtos(dto.messages());
         WeaponType weaponType = parseWeaponType(dto.weaponType());
+        AttackEffectApplication effectOnHit = parseEffectOnHit(dto.appliesEffect());
         return new AttackDefinition(
             AttackId.of(dto.id()),
             dto.name(),
@@ -42,8 +47,16 @@ public class AttackMapper {
             dto.critBonus(),
             dto.damageBonus(),
             messages,
-            weaponType
+            weaponType,
+            effectOnHit
         );
+    }
+
+    private AttackEffectApplication parseEffectOnHit(AttackDto.AppliesEffectDto dto) {
+        if (dto == null || dto.effectId() == null || dto.effectId().isBlank()) {
+            return null;
+        }
+        return new AttackEffectApplication(EffectId.of(dto.effectId()), dto.chancePercent());
     }
 
     private WeaponType parseWeaponType(String raw) {

--- a/src/main/java/io/taanielo/jmud/core/combat/dto/AttackSchemaVersions.java
+++ b/src/main/java/io/taanielo/jmud/core/combat/dto/AttackSchemaVersions.java
@@ -5,6 +5,8 @@ public final class AttackSchemaVersions {
     public static final int V2 = 2;
     /** V3 adds the {@code weapon_type} field. */
     public static final int V3 = 3;
+    /** V4 adds the optional {@code applies_effect} field (on-hit status effect application). */
+    public static final int V4 = 4;
 
     private AttackSchemaVersions() {
     }

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -18,9 +18,13 @@ import io.taanielo.jmud.core.action.GameMessage;
 import io.taanielo.jmud.core.action.PlayerEventBus;
 import io.taanielo.jmud.core.authentication.Username;
 import io.taanielo.jmud.core.combat.AttackDefinition;
+import io.taanielo.jmud.core.combat.AttackEffectApplication;
 import io.taanielo.jmud.core.combat.AttackId;
 import io.taanielo.jmud.core.combat.CombatSettings;
 import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.effects.EffectEngine;
+import io.taanielo.jmud.core.effects.EffectMessageSink;
+import io.taanielo.jmud.core.effects.EffectRepositoryException;
 import io.taanielo.jmud.core.party.PartyService;
 import io.taanielo.jmud.core.persistence.PersistenceQueue;
 import io.taanielo.jmud.core.player.LevelUpService;
@@ -59,6 +63,8 @@ public class MobRegistry implements Tickable {
     private QuestKillService questKillService;
     /** Optional party service for XP splitting; may be null when parties are disabled. */
     private PartyService partyService;
+    /** Optional effect engine used to apply on-hit status effects (e.g. poison); may be null when disabled. */
+    private EffectEngine effectEngine;
 
     private final ConcurrentHashMap<UUID, MobInstance> instances = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Username, UUID> playerCombatTargets = new ConcurrentHashMap<>();
@@ -88,6 +94,16 @@ public class MobRegistry implements Tickable {
      */
     public void setQuestKillService(QuestKillService questKillService) {
         this.questKillService = questKillService;
+    }
+
+    /**
+     * Registers the effect engine used to apply a mob attack's on-hit status effect
+     * (see {@link AttackDefinition#effectOnHit()}) to the player it hits.
+     *
+     * @param effectEngine the effect engine; may be null to disable on-hit effect application
+     */
+    public void setEffectEngine(EffectEngine effectEngine) {
+        this.effectEngine = effectEngine;
     }
 
     /**
@@ -349,7 +365,6 @@ public class MobRegistry implements Tickable {
         if (damagedPlayer.getVitals().hp() <= 0) {
             handleMobKill(mob, damagedPlayer, candidates);
         } else {
-            saveOrLog(damagedPlayer);
             List<GameMessage> messages = new ArrayList<>();
             if (firstEngagement) {
                 messages.add(GameMessage.toSource(
@@ -357,8 +372,66 @@ public class MobRegistry implements Tickable {
             }
             messages.add(GameMessage.toSource(
                 "The " + mob.template().name() + " hits you for " + damage + " damage!"));
+            applyOnHitEffect(attack, damagedPlayer, targetUsername, candidates, messages);
+            saveOrLog(damagedPlayer);
             playerEventBus.publish(targetUsername,
                 new GameActionResult(damagedPlayer, null, messages));
+        }
+    }
+
+    /**
+     * Applies a mob attack's on-hit status effect (see {@link AttackDefinition#effectOnHit()})
+     * to the player it hit, respecting the configured application chance.
+     *
+     * @param attack           the attack that just landed a hit
+     * @param target           the player hit by the attack; mutated in place with the new effect
+     * @param targetUsername   the target's username, used to route room messages
+     * @param roomOccupants     usernames of players in the mob's room, used to deliver room messages
+     * @param targetMessages    mutable list of self-facing messages to append to
+     */
+    private void applyOnHitEffect(
+        AttackDefinition attack,
+        Player target,
+        Username targetUsername,
+        List<Username> roomOccupants,
+        List<GameMessage> targetMessages
+    ) {
+        AttackEffectApplication effectApplication = attack.effectOnHit();
+        if (effectEngine == null || effectApplication == null) {
+            return;
+        }
+        int roll = ThreadLocalRandom.current().nextInt(1, 101);
+        if (roll > effectApplication.chancePercent()) {
+            return;
+        }
+        List<String> roomMessages = new ArrayList<>();
+        try {
+            effectEngine.apply(target, effectApplication.effectId(), new EffectMessageSink() {
+                @Override
+                public void sendToTarget(String message) {
+                    if (message != null && !message.isBlank()) {
+                        targetMessages.add(GameMessage.toSource(message));
+                    }
+                }
+
+                @Override
+                public void sendToRoom(String message) {
+                    if (message != null && !message.isBlank()) {
+                        roomMessages.add(message);
+                    }
+                }
+            });
+        } catch (EffectRepositoryException e) {
+            log.warn("Failed to apply on-hit effect {}: {}", effectApplication.effectId(), e.getMessage());
+            return;
+        }
+        for (String roomMessage : roomMessages) {
+            for (Username occupant : roomOccupants) {
+                if (!occupant.equals(targetUsername)) {
+                    playerEventBus.publish(occupant,
+                        new GameActionResult(null, null, List.of(GameMessage.toSource(roomMessage))));
+                }
+            }
         }
     }
 

--- a/src/test/java/io/taanielo/jmud/core/combat/CombatEngineTest.java
+++ b/src/test/java/io/taanielo/jmud/core/combat/CombatEngineTest.java
@@ -16,12 +16,16 @@ import io.taanielo.jmud.core.authentication.User;
 import io.taanielo.jmud.core.authentication.Username;
 import io.taanielo.jmud.core.combat.repository.AttackRepository;
 import io.taanielo.jmud.core.effects.EffectDefinition;
+import io.taanielo.jmud.core.effects.EffectEngine;
 import io.taanielo.jmud.core.effects.EffectId;
 import io.taanielo.jmud.core.effects.EffectInstance;
 import io.taanielo.jmud.core.effects.EffectModifier;
 import io.taanielo.jmud.core.effects.EffectRepository;
 import io.taanielo.jmud.core.effects.EffectStacking;
 import io.taanielo.jmud.core.effects.ModifierOperation;
+import io.taanielo.jmud.core.messaging.MessageChannel;
+import io.taanielo.jmud.core.messaging.MessagePhase;
+import io.taanielo.jmud.core.messaging.MessageSpec;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerVitals;
 import io.taanielo.jmud.core.world.repository.RepositoryException;
@@ -116,6 +120,97 @@ class CombatEngineTest {
 
         assertEquals(6, result.damage());
         assertEquals(14, result.target().getVitals().hp());
+    }
+
+    @Test
+    void appliesOnHitEffectWhenChanceRollSucceeds() throws Exception {
+        AttackId attackId = AttackId.of("attack.poisonous-bite");
+        EffectId poisonId = EffectId.of("poison");
+        EffectDefinition poison = new EffectDefinition(
+            poisonId,
+            "Poison",
+            10,
+            1,
+            EffectStacking.REFRESH,
+            List.of(),
+            List.of(new MessageSpec(MessagePhase.APPLY, MessageChannel.SELF, "You are poisoned!"))
+        );
+        AttackDefinition attack = new AttackDefinition(
+            attackId, "poisonous bite", 2, 2, 0, 0, 0, List.of(), WeaponType.PIERCING,
+            new AttackEffectApplication(poisonId, 50)
+        );
+        EffectEngine effectEngine = new EffectEngine(new StubEffectRepository(Map.of(poisonId, poison)));
+        CombatEngine engine = new CombatEngine(
+            new StubAttackRepository(Map.of(attackId, attack)),
+            new CombatModifierResolver(new StubEffectRepository(Map.of())),
+            new FixedCombatRandom(10, 2, 100, 25),
+            effectEngine
+        );
+        Player attacker = player("attacker", List.of());
+        Player target = player("target", List.of());
+
+        CombatResult result = engine.resolve(attacker, target, attackId);
+
+        assertTrue(result.hit());
+        assertEquals(1, result.target().effects().size());
+        assertEquals(poisonId, result.target().effects().getFirst().id());
+        assertEquals(List.of("You are poisoned!"), result.effectTargetMessages());
+    }
+
+    @Test
+    void doesNotApplyOnHitEffectWhenChanceRollFails() throws Exception {
+        AttackId attackId = AttackId.of("attack.poisonous-bite-fail");
+        EffectId poisonId = EffectId.of("poison");
+        EffectDefinition poison = new EffectDefinition(
+            poisonId, "Poison", 10, 1, EffectStacking.REFRESH, List.of(), null
+        );
+        AttackDefinition attack = new AttackDefinition(
+            attackId, "poisonous bite", 2, 2, 0, 0, 0, List.of(), WeaponType.PIERCING,
+            new AttackEffectApplication(poisonId, 50)
+        );
+        EffectEngine effectEngine = new EffectEngine(new StubEffectRepository(Map.of(poisonId, poison)));
+        CombatEngine engine = new CombatEngine(
+            new StubAttackRepository(Map.of(attackId, attack)),
+            new CombatModifierResolver(new StubEffectRepository(Map.of())),
+            new FixedCombatRandom(10, 2, 100, 75),
+            effectEngine
+        );
+        Player attacker = player("attacker", List.of());
+        Player target = player("target", List.of());
+
+        CombatResult result = engine.resolve(attacker, target, attackId);
+
+        assertTrue(result.hit());
+        assertTrue(result.target().effects().isEmpty());
+        assertTrue(result.effectTargetMessages().isEmpty());
+    }
+
+    @Test
+    void doesNotApplyOnHitEffectWhenAttackMisses() throws Exception {
+        AttackId attackId = AttackId.of("attack.poisonous-bite-miss");
+        EffectId poisonId = EffectId.of("poison");
+        EffectDefinition poison = new EffectDefinition(
+            poisonId, "Poison", 10, 1, EffectStacking.REFRESH, List.of(), null
+        );
+        AttackDefinition attack = new AttackDefinition(
+            attackId, "poisonous bite", 2, 2, 0, 0, 0, List.of(), WeaponType.PIERCING,
+            new AttackEffectApplication(poisonId, 100)
+        );
+        EffectEngine effectEngine = new EffectEngine(new StubEffectRepository(Map.of(poisonId, poison)));
+        CombatEngine engine = new CombatEngine(
+            new StubAttackRepository(Map.of(attackId, attack)),
+            new CombatModifierResolver(new StubEffectRepository(Map.of())),
+            new FixedCombatRandom(100),
+            effectEngine
+        );
+        Player attacker = player("attacker", List.of());
+        Player target = player("target", List.of());
+
+        CombatResult result = engine.resolve(attacker, target, attackId);
+
+        assertFalse(result.hit());
+        assertTrue(result.target().effects().isEmpty());
+        assertTrue(result.effectTargetMessages().isEmpty());
     }
 
     @Test

--- a/src/test/java/io/taanielo/jmud/core/combat/WeaponTypeTest.java
+++ b/src/test/java/io/taanielo/jmud/core/combat/WeaponTypeTest.java
@@ -62,7 +62,7 @@ class WeaponTypeTest {
     @Test
     void mapperParsesBluntFromV3() {
         AttackDto dto = new AttackDto(
-            AttackSchemaVersions.V3, "attack.mace", "iron mace", 5, 10, 2, 2, 2, List.of(), "BLUNT"
+            AttackSchemaVersions.V3, "attack.mace", "iron mace", 5, 10, 2, 2, 2, List.of(), "BLUNT", null
         );
         AttackDefinition def = mapper.toDomain(dto);
         assertEquals(WeaponType.BLUNT, def.weaponType());
@@ -71,7 +71,7 @@ class WeaponTypeTest {
     @Test
     void mapperParsesPiercingFromV3() {
         AttackDto dto = new AttackDto(
-            AttackSchemaVersions.V3, "attack.dagger", "dagger", 1, 5, 8, 4, 0, List.of(), "PIERCING"
+            AttackSchemaVersions.V3, "attack.dagger", "dagger", 1, 5, 8, 4, 0, List.of(), "PIERCING", null
         );
         AttackDefinition def = mapper.toDomain(dto);
         assertEquals(WeaponType.PIERCING, def.weaponType());
@@ -80,7 +80,7 @@ class WeaponTypeTest {
     @Test
     void mapperParsesSlashingFromV3() {
         AttackDto dto = new AttackDto(
-            AttackSchemaVersions.V3, "attack.sword", "iron sword", 3, 8, 5, 1, 1, List.of(), "SLASHING"
+            AttackSchemaVersions.V3, "attack.sword", "iron sword", 3, 8, 5, 1, 1, List.of(), "SLASHING", null
         );
         AttackDefinition def = mapper.toDomain(dto);
         assertEquals(WeaponType.SLASHING, def.weaponType());
@@ -93,7 +93,7 @@ class WeaponTypeTest {
     @Test
     void mapperDefaultsToSlashingWhenWeaponTypeAbsentInV2() {
         AttackDto dto = new AttackDto(
-            AttackSchemaVersions.V2, "attack.old", "old sword", 2, 6, 3, 0, 0, List.of(), null
+            AttackSchemaVersions.V2, "attack.old", "old sword", 2, 6, 3, 0, 0, List.of(), null, null
         );
         AttackDefinition def = mapper.toDomain(dto);
         assertEquals(WeaponType.SLASHING, def.weaponType());
@@ -102,7 +102,7 @@ class WeaponTypeTest {
     @Test
     void mapperDefaultsToSlashingWhenWeaponTypeBlankInV3() {
         AttackDto dto = new AttackDto(
-            AttackSchemaVersions.V3, "attack.blank", "blank weapon", 1, 3, 0, 0, 0, List.of(), ""
+            AttackSchemaVersions.V3, "attack.blank", "blank weapon", 1, 3, 0, 0, 0, List.of(), "", null
         );
         AttackDefinition def = mapper.toDomain(dto);
         assertEquals(WeaponType.SLASHING, def.weaponType());
@@ -111,7 +111,7 @@ class WeaponTypeTest {
     @Test
     void mapperDefaultsToSlashingForUnknownWeaponType() {
         AttackDto dto = new AttackDto(
-            AttackSchemaVersions.V3, "attack.weird", "weird weapon", 1, 3, 0, 0, 0, List.of(), "UNKNOWN_TYPE"
+            AttackSchemaVersions.V3, "attack.weird", "weird weapon", 1, 3, 0, 0, 0, List.of(), "UNKNOWN_TYPE", null
         );
         AttackDefinition def = mapper.toDomain(dto);
         assertEquals(WeaponType.SLASHING, def.weaponType());

--- a/src/test/java/io/taanielo/jmud/core/combat/dto/AttackMapperTest.java
+++ b/src/test/java/io/taanielo/jmud/core/combat/dto/AttackMapperTest.java
@@ -1,0 +1,81 @@
+package io.taanielo.jmud.core.combat.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.combat.AttackDefinition;
+import io.taanielo.jmud.core.combat.AttackEffectApplication;
+import io.taanielo.jmud.core.effects.EffectId;
+
+class AttackMapperTest {
+
+    private final AttackMapper mapper = new AttackMapper();
+
+    @Test
+    void mapsAppliesEffectFromSchemaVersion4() {
+        AttackDto dto = new AttackDto(
+            AttackSchemaVersions.V4,
+            "attack.spider",
+            "spider fangs",
+            2,
+            6,
+            -5,
+            5,
+            0,
+            List.of(),
+            "PIERCING",
+            new AttackDto.AppliesEffectDto("poison", 40)
+        );
+
+        AttackDefinition attack = mapper.toDomain(dto);
+
+        AttackEffectApplication effectOnHit = attack.effectOnHit();
+        assertEquals(EffectId.of("poison"), effectOnHit.effectId());
+        assertEquals(40, effectOnHit.chancePercent());
+    }
+
+    @Test
+    void appliesEffectIsNullWhenAbsent() {
+        AttackDto dto = new AttackDto(
+            AttackSchemaVersions.V3,
+            "attack.dagger",
+            "dagger",
+            1,
+            5,
+            8,
+            4,
+            0,
+            List.of(),
+            "PIERCING",
+            null
+        );
+
+        AttackDefinition attack = mapper.toDomain(dto);
+
+        assertNull(attack.effectOnHit());
+    }
+
+    @Test
+    void rejectsUnsupportedSchemaVersion() {
+        AttackDto dto = new AttackDto(
+            99,
+            "attack.bad",
+            "bad",
+            1,
+            1,
+            0,
+            0,
+            0,
+            List.of(),
+            null,
+            null
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.toDomain(dto));
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryOnHitEffectTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryOnHitEffectTest.java
@@ -1,0 +1,215 @@
+package io.taanielo.jmud.core.mob;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.action.GameActionResult;
+import io.taanielo.jmud.core.action.PlayerEventBus;
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.combat.AttackDefinition;
+import io.taanielo.jmud.core.combat.AttackEffectApplication;
+import io.taanielo.jmud.core.combat.AttackId;
+import io.taanielo.jmud.core.combat.CombatSettings;
+import io.taanielo.jmud.core.combat.WeaponType;
+import io.taanielo.jmud.core.combat.repository.AttackRepository;
+import io.taanielo.jmud.core.effects.EffectDefinition;
+import io.taanielo.jmud.core.effects.EffectEngine;
+import io.taanielo.jmud.core.effects.EffectId;
+import io.taanielo.jmud.core.effects.EffectRepository;
+import io.taanielo.jmud.core.effects.EffectStacking;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.world.Item;
+import io.taanielo.jmud.core.world.ItemId;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.ItemRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Verifies that a mob attack configured with {@link AttackDefinition#effectOnHit()}
+ * applies the status effect to the player it hits, reachable via {@link MobRegistry}'s
+ * mob AI tick — the path used by mob-vs-player combat in-game.
+ */
+class MobRegistryOnHitEffectTest {
+
+    private static final RoomId ROOM_ID = RoomId.of("room.test");
+    private static final AttackId ATTACK_ID = AttackId.of(CombatSettings.DEFAULT_ATTACK_ID);
+    private static final EffectId POISON_ID = EffectId.of("poison");
+
+    private Player player(String name) {
+        User user = User.of(Username.of(name), Password.hash("pw", 1));
+        return Player.of(user, "%hp> ");
+    }
+
+    private MobRegistry buildRegistry(
+        Player target,
+        AttackDefinition attack,
+        EffectEngine effectEngine,
+        PlayerEventBus bus
+    ) {
+        MobTemplate template = new MobTemplate(
+            MobId.of("mob.spider"),
+            "Giant Spider",
+            100,
+            ATTACK_ID,
+            true,
+            List.of(),
+            ROOM_ID,
+            1,
+            10,
+            5,
+            null,
+            null,
+            false
+        );
+        MobTemplateRepository templateRepo = new StubMobTemplateRepository(List.of(template));
+        AttackRepository attackRepo = new StubAttackRepository(Map.of(ATTACK_ID, attack));
+        ItemRepository itemRepo = new StubItemRepository(Map.of());
+
+        RoomService roomService = new RoomService(new StubRoomRepository(ROOM_ID), ROOM_ID);
+        roomService.ensurePlayerLocation(target.getUsername());
+
+        PlayerRepository playerRepo = new StubPlayerRepository(target);
+
+        MobRegistry registry = new MobRegistry(
+            templateRepo, itemRepo, attackRepo, roomService, playerRepo,
+            MobRegistryTestSupport.persistenceQueueFor(playerRepo), bus);
+        registry.setEffectEngine(effectEngine);
+        registry.init();
+        return registry;
+    }
+
+    @Test
+    void mobAttackAppliesConfiguredEffectOnHit() {
+        Player target = player("hero");
+        EffectDefinition poison = new EffectDefinition(
+            POISON_ID, "Poison", 10, 1, EffectStacking.REFRESH, List.of(), null
+        );
+        EffectEngine effectEngine = new EffectEngine(new StubEffectRepository(Map.of(POISON_ID, poison)));
+        AttackDefinition attack = new AttackDefinition(
+            ATTACK_ID, "bite", 1, 1, 0, 0, 0, List.of(), WeaponType.PIERCING,
+            new AttackEffectApplication(POISON_ID, 100)
+        );
+        PlayerEventBus bus = new PlayerEventBus();
+        MobRegistry registry = buildRegistry(target, attack, effectEngine, bus);
+
+        AtomicReference<GameActionResult> received = new AtomicReference<>();
+        bus.register(target.getUsername(), received::set);
+
+        registry.tick();
+
+        GameActionResult result = received.get();
+        assertNotNull(result, "Expected a game event to be published to the target player");
+        Player updatedSource = result.updatedSource();
+        assertNotNull(updatedSource, "Expected the damaged player snapshot to be published");
+        assertEquals(1, updatedSource.effects().size());
+        assertEquals(POISON_ID, updatedSource.effects().getFirst().id());
+    }
+
+    @Test
+    void mobAttackDoesNotApplyEffectWithoutEffectEngine() {
+        Player target = player("hero2");
+        AttackDefinition attack = new AttackDefinition(
+            ATTACK_ID, "bite", 1, 1, 0, 0, 0, List.of(), WeaponType.PIERCING,
+            new AttackEffectApplication(POISON_ID, 100)
+        );
+        PlayerEventBus bus = new PlayerEventBus();
+        MobRegistry registry = buildRegistry(target, attack, null, bus);
+
+        AtomicReference<GameActionResult> received = new AtomicReference<>();
+        bus.register(target.getUsername(), received::set);
+
+        registry.tick();
+
+        GameActionResult result = received.get();
+        assertNotNull(result, "Expected a game event to be published to the target player");
+        Player updatedSource = result.updatedSource();
+        assertNotNull(updatedSource);
+        assertTrue(updatedSource.effects().isEmpty());
+    }
+
+    // ── stubs ─────────────────────────────────────────────────────────
+
+    private record StubMobTemplateRepository(List<MobTemplate> templates)
+        implements MobTemplateRepository {
+        @Override
+        public List<MobTemplate> findAll() { return templates; }
+    }
+
+    private record StubAttackRepository(Map<AttackId, AttackDefinition> attacks)
+        implements AttackRepository {
+        @Override
+        public Optional<AttackDefinition> findById(AttackId id) throws RepositoryException {
+            return Optional.ofNullable(attacks.get(id));
+        }
+    }
+
+    private record StubEffectRepository(Map<EffectId, EffectDefinition> definitions)
+        implements EffectRepository {
+        @Override
+        public Optional<EffectDefinition> findById(EffectId id) {
+            return Optional.ofNullable(definitions.get(id));
+        }
+    }
+
+    private static class StubItemRepository implements ItemRepository {
+        private final Map<ItemId, Item> items;
+
+        StubItemRepository(Map<ItemId, Item> items) { this.items = Map.copyOf(items); }
+
+        @Override
+        public void save(Item item) throws RepositoryException {}
+
+        @Override
+        public Optional<Item> findById(ItemId id) throws RepositoryException {
+            return Optional.ofNullable(items.get(id));
+        }
+    }
+
+    private static class StubPlayerRepository implements PlayerRepository {
+        private final ConcurrentHashMap<Username, Player> store = new ConcurrentHashMap<>();
+
+        StubPlayerRepository(Player initial) {
+            store.put(initial.getUsername(), initial);
+        }
+
+        @Override
+        public void savePlayer(Player player) { store.put(player.getUsername(), player); }
+
+        @Override
+        public Optional<Player> loadPlayer(Username username) {
+            return Optional.ofNullable(store.get(username));
+        }
+    }
+
+    private static class StubRoomRepository implements RoomRepository {
+        private final Room room;
+
+        StubRoomRepository(RoomId roomId) {
+            this.room = new Room(
+                roomId, "Test Room", "A featureless void.", Map.of(), List.of(), List.of());
+        }
+
+        @Override
+        public void save(Room room) throws RepositoryException {}
+
+        @Override
+        public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return room.getId().equals(id) ? Optional.of(room) : Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
Closes #223

Implements a poison damage-over-time status effect that mob attacks can apply on hit:

- New `AttackEffectApplication` value object and `CombatEngine` effect-on-hit logic (rolls chance via the `CombatRandom` port)
- Schema v4 support for `applies_effect` field in attack JSON (`docs/schemas/attack.v4.json`)
- `data/attacks/attack.spider.json` bumped to v4 with poison applies_effect (40% chance)
- `MobRegistry` optional `EffectEngine` hook wired from `GameContext` so mob-vs-player combat can apply the effect
- New tests: `CombatEngineTest`, `AttackMapperTest`, `MobRegistryOnHitEffectTest`

Verified with `./gradlew check` (compile, tests, spotless, jacoco coverage, ArchUnit) and the e2e smoke test (`scripts/smoke-test.sh`).