### PR TITLE
feat(ability): add CURE ability and potion to remove poison effect

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -66,7 +66,7 @@
 - [x] Add armour items (chest, legs, head slots) with AC value reducing incoming damage in combat engine
 - [x] Add SCORE prompt stat: show current AC derived from equipped armour
 - [x] Add poison status effect applied by certain mob attacks (damage-over-time ticks)
-- [ ] Add CURE ability/potion to remove poison and other negative status effects
+- [x] Add CURE ability/potion to remove poison and other negative status effects
 - [ ] Add mob special ability: boss mobs can use a defined ability once per combat (e.g. troll smash)
 - [ ] Add WRITE and READ commands with scroll items that teach a new ability on use
 - [ ] Add The Sewers zone with slimes and plague rats targeting mid-range players

--- a/data/items/cure-potion.json
+++ b/data/items/cure-potion.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 3,
+  "id": "cure-potion",
+  "name": "Cure Potion",
+  "description": "A shimmering blue vial that neutralizes toxins in the blood.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [
+    {
+      "effect_id": "poison",
+      "duration_ticks": 0,
+      "op": "REMOVE"
+    }
+  ],
+  "messages": [
+    {
+      "phase": "quaff",
+      "channel": "self",
+      "text": "You quaff {item}."
+    },
+    {
+      "phase": "quaff",
+      "channel": "room",
+      "text": "{source} quaffs {item}."
+    }
+  ],
+  "weight": 1,
+  "value": 15
+}

--- a/data/skills/spell.cure.json
+++ b/data/skills/spell.cure.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 2,
+  "id": "spell.cure",
+  "name": "cure",
+  "type": "SPELL",
+  "level": 1,
+  "cost": {
+    "mana": 4
+  },
+  "cooldown": {
+    "ticks": 3
+  },
+  "targeting": "BENEFICIAL",
+  "aliases": ["cure poison"],
+  "effects": [
+    {
+      "kind": "CURE",
+      "effect_id": "poison"
+    }
+  ],
+  "messages": [
+    {
+      "phase": "use",
+      "channel": "self",
+      "text": "You cast {ability} on {target}."
+    },
+    {
+      "phase": "use",
+      "channel": "target",
+      "text": "{source} casts {ability} on you."
+    },
+    {
+      "phase": "use",
+      "channel": "room",
+      "text": "{source} casts {ability} on {target}."
+    }
+  ]
+}

--- a/docs/schemas/ability.v1.json
+++ b/docs/schemas/ability.v1.json
@@ -70,7 +70,7 @@
         "properties": {
           "kind": {
             "type": "string",
-            "enum": ["VITALS", "EFFECT"]
+            "enum": ["VITALS", "EFFECT", "CURE"]
           },
           "stat": {
             "type": "string",
@@ -96,6 +96,10 @@
           },
           {
             "if": {"properties": {"kind": {"const": "EFFECT"}}},
+            "then": {"required": ["effect_id"]}
+          },
+          {
+            "if": {"properties": {"kind": {"const": "CURE"}}},
             "then": {"required": ["effect_id"]}
           }
         ]

--- a/docs/schemas/item.v3.json
+++ b/docs/schemas/item.v3.json
@@ -64,6 +64,11 @@
           "duration_ticks": {
             "type": "integer",
             "minimum": 0
+          },
+          "op": {
+            "type": "string",
+            "enum": ["APPLY", "REMOVE"],
+            "description": "Whether the item applies the effect (default) or removes it (a cure)."
           }
         }
       }

--- a/src/main/java/io/taanielo/jmud/core/ability/AbilityEffect.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/AbilityEffect.java
@@ -17,7 +17,7 @@ public record AbilityEffect(
             if (amount <= 0) {
                 throw new IllegalArgumentException("Effect amount must be positive");
             }
-        } else if (kind == AbilityEffectKind.EFFECT) {
+        } else if (kind == AbilityEffectKind.EFFECT || kind == AbilityEffectKind.CURE) {
             String trimmed = Objects.requireNonNull(effectId, "Effect id is required").trim();
             if (trimmed.isEmpty()) {
                 throw new IllegalArgumentException("Effect id must not be blank");

--- a/src/main/java/io/taanielo/jmud/core/ability/AbilityEffectKind.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/AbilityEffectKind.java
@@ -2,5 +2,11 @@ package io.taanielo.jmud.core.ability;
 
 public enum AbilityEffectKind {
     VITALS,
-    EFFECT
+    EFFECT,
+    /**
+     * Removes an active negative effect (e.g. poison) from the target instead of
+     * applying one. Data-driven "cure" abilities use this kind with {@code effectId}
+     * naming the effect to remove.
+     */
+    CURE
 }

--- a/src/main/java/io/taanielo/jmud/core/ability/AbilityEngine.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/AbilityEngine.java
@@ -284,6 +284,7 @@ public class AbilityEngine {
                 yield target.getUsername().getValue() + " " + verb + " " + effect.amount() + " " + stat + ".";
             }
             case EFFECT -> target.getUsername().getValue() + " is affected by " + effect.effectId() + ".";
+            case CURE -> target.getUsername().getValue() + " is cured of " + effect.effectId() + ".";
         };
     }
 

--- a/src/main/java/io/taanielo/jmud/core/ability/DefaultAbilityEffectResolver.java
+++ b/src/main/java/io/taanielo/jmud/core/ability/DefaultAbilityEffectResolver.java
@@ -27,13 +27,21 @@ public class DefaultAbilityEffectResolver implements AbilityEffectResolver {
     public void apply(AbilityEffect effect, AbilityContext context) {
         Objects.requireNonNull(effect, "Ability effect is required");
         Objects.requireNonNull(context, "Ability context is required");
-        if (effect.kind() == AbilityEffectKind.VITALS) {
-            applyVitals(effect, context);
-            listener.onApplied(effect, context);
-            return;
-        }
-        if (applyEffect(effect, context)) {
-            listener.onApplied(effect, context);
+        switch (effect.kind()) {
+            case VITALS -> {
+                applyVitals(effect, context);
+                listener.onApplied(effect, context);
+            }
+            case EFFECT -> {
+                if (applyEffect(effect, context)) {
+                    listener.onApplied(effect, context);
+                }
+            }
+            case CURE -> {
+                if (applyCure(effect, context)) {
+                    listener.onApplied(effect, context);
+                }
+            }
         }
     }
 
@@ -55,7 +63,25 @@ public class DefaultAbilityEffectResolver implements AbilityEffectResolver {
     }
 
     private boolean applyEffect(AbilityEffect effect, AbilityContext context) {
-        io.taanielo.jmud.core.effects.EffectMessageSink sink = new io.taanielo.jmud.core.effects.EffectMessageSink() {
+        io.taanielo.jmud.core.effects.EffectMessageSink sink = effectMessageSink(context);
+        try {
+            return effectEngine.apply(context.target(), EffectId.of(effect.effectId()), sink);
+        } catch (EffectRepositoryException e) {
+            throw new IllegalStateException("Failed to apply effect " + effect.effectId() + ": " + e.getMessage(), e);
+        }
+    }
+
+    private boolean applyCure(AbilityEffect effect, AbilityContext context) {
+        io.taanielo.jmud.core.effects.EffectMessageSink sink = effectMessageSink(context);
+        try {
+            return effectEngine.remove(context.target(), EffectId.of(effect.effectId()), sink);
+        } catch (EffectRepositoryException e) {
+            throw new IllegalStateException("Failed to remove effect " + effect.effectId() + ": " + e.getMessage(), e);
+        }
+    }
+
+    private io.taanielo.jmud.core.effects.EffectMessageSink effectMessageSink(AbilityContext context) {
+        return new io.taanielo.jmud.core.effects.EffectMessageSink() {
             @Override
             public void sendToTarget(String message) {
                 messageSink.sendToTarget(context.target(), message);
@@ -66,10 +92,5 @@ public class DefaultAbilityEffectResolver implements AbilityEffectResolver {
                 messageSink.sendToRoom(context.source(), context.target(), message);
             }
         };
-        try {
-            return effectEngine.apply(context.target(), EffectId.of(effect.effectId()), sink);
-        } catch (EffectRepositoryException e) {
-            throw new IllegalStateException("Failed to apply effect " + effect.effectId() + ": " + e.getMessage(), e);
-        }
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
+++ b/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
@@ -35,6 +35,7 @@ import io.taanielo.jmud.core.player.PlayerVitals;
 import io.taanielo.jmud.core.world.EquipmentSlot;
 import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.ItemEffect;
+import io.taanielo.jmud.core.world.ItemEffectOperation;
 import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.Room;
 import io.taanielo.jmud.core.world.RoomService;
@@ -311,8 +312,11 @@ public class GameActionService {
      *
      * <p>A positive {@code hp} stat in {@link io.taanielo.jmud.core.world.ItemAttributes} heals
      * the player (capped at max HP); a negative value deals damage. Item effects such as
-     * poison are applied after the stat change. An item that has neither an {@code hp} stat
-     * nor any effects results in a "Nothing happens." message.
+     * poison are applied after the stat change; an effect whose operation is
+     * {@link ItemEffectOperation#REMOVE} instead cures a matching active effect (e.g. a
+     * cure potion removing poison), silently doing nothing if the target has no such
+     * effect active. An item that has neither an {@code hp} stat nor any effects results
+     * in a "Nothing happens." message.
      *
      * @param source the player quaffing the item
      * @param itemInput the item name or id to quaff
@@ -352,7 +356,11 @@ public class GameActionService {
         );
         try {
             for (ItemEffect effect : item.getEffects()) {
-                abilityEffectEngine.apply(working, effect.id(), effectSink);
+                if (effect.operation() == ItemEffectOperation.REMOVE) {
+                    abilityEffectEngine.remove(working, effect.id(), effectSink);
+                } else {
+                    abilityEffectEngine.apply(working, effect.id(), effectSink);
+                }
             }
         } catch (EffectRepositoryException e) {
             return GameActionResult.error("You cannot use that item right now.");

--- a/src/main/java/io/taanielo/jmud/core/effects/EffectEngine.java
+++ b/src/main/java/io/taanielo/jmud/core/effects/EffectEngine.java
@@ -39,6 +39,32 @@ public class EffectEngine {
         return applied;
     }
 
+    /**
+     * Removes an active effect from the target on demand, before it would naturally
+     * expire (e.g. a cure ability or potion). Sends the effect's {@code expire}
+     * messages when an instance is actually removed. Tick-thread only (AGENTS.md §5).
+     *
+     * @param target the effect target to cure
+     * @param id the id of the effect to remove
+     * @param sink message sink for expire messages
+     * @return {@code true} if a matching active effect was found and removed,
+     *     {@code false} if the target had no such effect active
+     */
+    public boolean remove(EffectTarget target, EffectId id, EffectMessageSink sink) throws EffectRepositoryException {
+        Objects.requireNonNull(target, "Effect target is required");
+        Objects.requireNonNull(id, "Effect id is required");
+        Objects.requireNonNull(sink, "Effect message sink is required");
+
+        EffectInstance existing = findInstance(target.effects(), id);
+        if (existing == null) {
+            return false;
+        }
+        EffectDefinition definition = definitionOrThrow(id);
+        target.removeEffect(existing);
+        sendMessages(target, definition, MessagePhase.EXPIRE, sink);
+        return true;
+    }
+
     public void tick(EffectTarget target, EffectMessageSink sink) throws EffectRepositoryException {
         Objects.requireNonNull(target, "Effect target is required");
         Objects.requireNonNull(sink, "Effect message sink is required");

--- a/src/main/java/io/taanielo/jmud/core/world/ItemEffect.java
+++ b/src/main/java/io/taanielo/jmud/core/world/ItemEffect.java
@@ -2,7 +2,7 @@ package io.taanielo.jmud.core.world;
 
 import io.taanielo.jmud.core.effects.EffectId;
 
-public record ItemEffect(EffectId id, int durationTicks) {
+public record ItemEffect(EffectId id, int durationTicks, ItemEffectOperation operation) {
     public ItemEffect {
         if (id == null) {
             throw new IllegalArgumentException("Effect id is required");
@@ -10,5 +10,16 @@ public record ItemEffect(EffectId id, int durationTicks) {
         if (durationTicks < 0) {
             throw new IllegalArgumentException("Effect duration must be non-negative");
         }
+        if (operation == null) {
+            operation = ItemEffectOperation.APPLY;
+        }
+    }
+
+    /**
+     * Convenience constructor for effects that apply (rather than remove) the
+     * referenced effect, matching historical two-argument usages.
+     */
+    public ItemEffect(EffectId id, int durationTicks) {
+        this(id, durationTicks, ItemEffectOperation.APPLY);
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/ItemEffectOperation.java
+++ b/src/main/java/io/taanielo/jmud/core/world/ItemEffectOperation.java
@@ -1,0 +1,11 @@
+package io.taanielo.jmud.core.world;
+
+/**
+ * The action an {@link ItemEffect} performs when the item is used.
+ */
+public enum ItemEffectOperation {
+    /** Applies the referenced effect to the target (the default). */
+    APPLY,
+    /** Removes the referenced effect from the target if it is currently active (a "cure"). */
+    REMOVE
+}

--- a/src/main/java/io/taanielo/jmud/core/world/dto/ItemEffectDto.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/ItemEffectDto.java
@@ -1,4 +1,6 @@
 package io.taanielo.jmud.core.world.dto;
 
-public record ItemEffectDto(String effectId, int durationTicks) {
+import io.taanielo.jmud.core.world.ItemEffectOperation;
+
+public record ItemEffectDto(String effectId, int durationTicks, ItemEffectOperation op) {
 }

--- a/src/main/java/io/taanielo/jmud/core/world/dto/ItemMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/ItemMapper.java
@@ -11,6 +11,7 @@ import io.taanielo.jmud.core.world.EquipmentSlot;
 import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.ItemAttributes;
 import io.taanielo.jmud.core.world.ItemEffect;
+import io.taanielo.jmud.core.world.ItemEffectOperation;
 import io.taanielo.jmud.core.world.ItemId;
 
 public class ItemMapper {
@@ -19,7 +20,7 @@ public class ItemMapper {
         Objects.requireNonNull(item, "Item is required");
         ItemAttributesDto attributes = new ItemAttributesDto(item.getAttributes().getStats());
         List<ItemEffectDto> effects = item.getEffects().stream()
-            .map(effect -> new ItemEffectDto(effect.id().getValue(), effect.durationTicks()))
+            .map(effect -> new ItemEffectDto(effect.id().getValue(), effect.durationTicks(), effect.operation()))
             .toList();
         return new ItemDto(
             SchemaVersions.V3,
@@ -41,7 +42,11 @@ public class ItemMapper {
         ItemAttributesDto attributesDto = Objects.requireNonNull(dto.attributes(), "Item attributes are required");
         ItemAttributes attributes = new ItemAttributes(attributesDto.stats());
         List<ItemEffect> effects = dto.effects().stream()
-            .map(effect -> new ItemEffect(EffectId.of(effect.effectId()), effect.durationTicks()))
+            .map(effect -> new ItemEffect(
+                EffectId.of(effect.effectId()),
+                effect.durationTicks(),
+                effect.op() == null ? ItemEffectOperation.APPLY : effect.op()
+            ))
             .toList();
         List<MessageSpec> messages = MessageSpecMapper.fromDtos(dto.messages());
         EquipmentSlot slot = EquipmentSlot.fromId(dto.equipSlot());

--- a/src/test/java/io/taanielo/jmud/core/ability/DefaultAbilityEffectResolverTest.java
+++ b/src/test/java/io/taanielo/jmud/core/ability/DefaultAbilityEffectResolverTest.java
@@ -1,0 +1,117 @@
+package io.taanielo.jmud.core.ability;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.effects.EffectDefinition;
+import io.taanielo.jmud.core.effects.EffectEngine;
+import io.taanielo.jmud.core.effects.EffectId;
+import io.taanielo.jmud.core.effects.EffectInstance;
+import io.taanielo.jmud.core.effects.EffectStacking;
+import io.taanielo.jmud.core.messaging.MessageChannel;
+import io.taanielo.jmud.core.messaging.MessagePhase;
+import io.taanielo.jmud.core.messaging.MessageSpec;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerVitals;
+
+class DefaultAbilityEffectResolverTest {
+
+    private final EffectId poisonId = EffectId.of("poison");
+    private final EffectDefinition poisonDefinition = new EffectDefinition(
+        poisonId,
+        "Poison",
+        10,
+        1,
+        EffectStacking.REFRESH,
+        List.of(),
+        List.of(new MessageSpec(MessagePhase.EXPIRE, MessageChannel.SELF, "The poison leaves your body."))
+    );
+    private final EffectEngine effectEngine = new EffectEngine(id -> id.equals(poisonId)
+        ? Optional.of(poisonDefinition)
+        : Optional.empty());
+    private final RecordingAbilityMessageSink messageSink = new RecordingAbilityMessageSink();
+    private final RecordingAbilityEffectListener listener = new RecordingAbilityEffectListener();
+    private final DefaultAbilityEffectResolver resolver =
+        new DefaultAbilityEffectResolver(effectEngine, messageSink, listener);
+
+    @Test
+    void cureRemovesActiveEffectAndNotifiesListener() {
+        Player poisoned = playerWithEffect(new EffectInstance(poisonId, 5, 1));
+        AbilityContext context = new AbilityContext(poisoned, poisoned);
+        AbilityEffect cure = new AbilityEffect(AbilityEffectKind.CURE, null, null, 0, "poison");
+
+        resolver.apply(cure, context);
+
+        assertTrue(context.target().effects().isEmpty());
+        assertTrue(listener.applied);
+        assertEquals(List.of("The poison leaves your body."), messageSink.targetMessages);
+    }
+
+    @Test
+    void cureOnPlayerWithoutMatchingEffectDoesNothing() {
+        Player healthy = playerWithEffect(null);
+        AbilityContext context = new AbilityContext(healthy, healthy);
+        AbilityEffect cure = new AbilityEffect(AbilityEffectKind.CURE, null, null, 0, "poison");
+
+        resolver.apply(cure, context);
+
+        assertTrue(context.target().effects().isEmpty());
+        assertTrue(messageSink.targetMessages.isEmpty());
+        assertEquals(false, listener.applied);
+    }
+
+    private Player playerWithEffect(EffectInstance instance) {
+        List<EffectInstance> effects = new ArrayList<>();
+        if (instance != null) {
+            effects.add(instance);
+        }
+        return new Player(
+            User.of(Username.of("eve"), Password.hash("pw", 1000)),
+            1,
+            0,
+            PlayerVitals.defaults(),
+            effects,
+            "HP {hp}/{maxHp}",
+            false,
+            List.of(),
+            null,
+            null
+        );
+    }
+
+    private static class RecordingAbilityMessageSink implements AbilityMessageSink {
+        private final List<String> targetMessages = new ArrayList<>();
+
+        @Override
+        public void sendToSource(Player source, String message) {
+        }
+
+        @Override
+        public void sendToTarget(Player target, String message) {
+            targetMessages.add(message);
+        }
+
+        @Override
+        public void sendToRoom(Player source, Player target, String message) {
+        }
+    }
+
+    private static class RecordingAbilityEffectListener implements AbilityEffectListener {
+        private boolean applied = false;
+
+        @Override
+        public void onApplied(AbilityEffect effect, AbilityContext context) {
+            applied = true;
+        }
+    }
+
+}

--- a/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
@@ -352,6 +352,123 @@ class GameActionServiceTest {
     }
 
     @Test
+    void quaffCurePotionRemovesPoisonEffect() {
+        EffectId poisonId = EffectId.of("poison");
+        EffectDefinition poisonDefinition = new EffectDefinition(
+            poisonId,
+            "Poison",
+            10,
+            1,
+            EffectStacking.REFRESH,
+            List.of(),
+            List.of(new io.taanielo.jmud.core.messaging.MessageSpec(
+                io.taanielo.jmud.core.messaging.MessagePhase.EXPIRE,
+                io.taanielo.jmud.core.messaging.MessageChannel.SELF,
+                "The poison leaves your body."
+            ))
+        );
+        EffectEngine effectEngine = new EffectEngine(new StubEffectRepository(Map.of(poisonId, poisonDefinition)));
+        service = new GameActionService(
+            testAbilityRegistry(),
+            new BasicAbilityCostResolver(),
+            effectEngine,
+            new CombatEngine(
+                new StubAttackRepository(Map.of()),
+                new CombatModifierResolver(new StubEffectRepository(Map.of())),
+                new FixedCombatRandom(1)
+            ),
+            roomService,
+            (source, input) -> Optional.empty(),
+            new TestCooldowns(),
+            testEncumbranceService()
+        );
+        Item curePotion = new Item(
+            ItemId.of("cure-potion"),
+            "Cure Potion",
+            "A shimmering blue vial.",
+            ItemAttributes.empty(),
+            List.of(new io.taanielo.jmud.core.world.ItemEffect(
+                poisonId, 0, io.taanielo.jmud.core.world.ItemEffectOperation.REMOVE
+            )),
+            List.of(
+                new io.taanielo.jmud.core.messaging.MessageSpec(
+                    io.taanielo.jmud.core.messaging.MessagePhase.QUAFF,
+                    io.taanielo.jmud.core.messaging.MessageChannel.SELF,
+                    "You quaff {item}."
+                )
+            ),
+            null,
+            1,
+            1,
+            null
+        );
+        Player poisoned = attacker.addItem(curePotion);
+        poisoned.addEffect(new io.taanielo.jmud.core.effects.EffectInstance(poisonId, 5, 1));
+
+        GameActionResult result = service.quaffItem(poisoned, "cure potion");
+
+        assertTrue(result.updatedSource().effects().isEmpty());
+        assertTrue(result.messages().stream().anyMatch(message ->
+            message.text().equals("The poison leaves your body.")
+        ));
+    }
+
+    @Test
+    void quaffCurePotionOnHealthyPlayerDoesNotCrash() {
+        EffectId poisonId = EffectId.of("poison");
+        EffectDefinition poisonDefinition = new EffectDefinition(
+            poisonId,
+            "Poison",
+            10,
+            1,
+            EffectStacking.REFRESH,
+            List.of(),
+            List.of()
+        );
+        EffectEngine effectEngine = new EffectEngine(new StubEffectRepository(Map.of(poisonId, poisonDefinition)));
+        service = new GameActionService(
+            testAbilityRegistry(),
+            new BasicAbilityCostResolver(),
+            effectEngine,
+            new CombatEngine(
+                new StubAttackRepository(Map.of()),
+                new CombatModifierResolver(new StubEffectRepository(Map.of())),
+                new FixedCombatRandom(1)
+            ),
+            roomService,
+            (source, input) -> Optional.empty(),
+            new TestCooldowns(),
+            testEncumbranceService()
+        );
+        Item curePotion = new Item(
+            ItemId.of("cure-potion"),
+            "Cure Potion",
+            "A shimmering blue vial.",
+            ItemAttributes.empty(),
+            List.of(new io.taanielo.jmud.core.world.ItemEffect(
+                poisonId, 0, io.taanielo.jmud.core.world.ItemEffectOperation.REMOVE
+            )),
+            List.of(
+                new io.taanielo.jmud.core.messaging.MessageSpec(
+                    io.taanielo.jmud.core.messaging.MessagePhase.QUAFF,
+                    io.taanielo.jmud.core.messaging.MessageChannel.SELF,
+                    "You quaff {item}."
+                )
+            ),
+            null,
+            1,
+            1,
+            null
+        );
+        Player healthy = attacker.addItem(curePotion);
+
+        GameActionResult result = service.quaffItem(healthy, "cure potion");
+
+        assertTrue(result.updatedSource().effects().isEmpty());
+        assertEquals("You quaff Cure Potion.", result.messages().getFirst().text());
+    }
+
+    @Test
     void quaffItemHealsPlayerWhenHpStatIsPositive() {
         PlayerVitals lowVitals = new PlayerVitals(5, 20, 20, 20, 20, 20);
         Player injured = new Player(

--- a/src/test/java/io/taanielo/jmud/core/effects/EffectEngineTest.java
+++ b/src/test/java/io/taanielo/jmud/core/effects/EffectEngineTest.java
@@ -88,6 +88,77 @@ class EffectEngineTest {
         assertEquals(List.of("Shield fades."), sink.messages());
     }
 
+    @Test
+    void removesActiveEffectAndSendsExpireMessage() throws EffectRepositoryException {
+        EffectId id = EffectId.of("poison");
+        List<MessageSpec> messages = List.of(
+            new MessageSpec(MessagePhase.EXPIRE, MessageChannel.SELF, "The poison leaves your body.")
+        );
+        EffectDefinition definition = new EffectDefinition(
+            id,
+            "Poison",
+            10,
+            1,
+            EffectStacking.REFRESH,
+            List.of(),
+            messages
+        );
+        EffectEngine engine = new EffectEngine(new InMemoryEffectRepository(definition));
+        Player player = new Player(
+            User.of(Username.of("cara"), Password.hash("pw", 1000)),
+            1,
+            0,
+            PlayerVitals.defaults(),
+            new ArrayList<>(List.of(new EffectInstance(id, 1, 5))),
+            "HP {hp}/{maxHp}",
+            false,
+            List.of(),
+            null,
+            null
+        );
+        RecordingSink sink = new RecordingSink();
+
+        boolean removed = engine.remove(player, id, sink);
+
+        assertTrue(removed);
+        assertTrue(player.effects().isEmpty());
+        assertEquals(List.of("The poison leaves your body."), sink.messages());
+    }
+
+    @Test
+    void removeReturnsFalseWhenEffectNotActive() throws EffectRepositoryException {
+        EffectId id = EffectId.of("poison");
+        EffectDefinition definition = new EffectDefinition(
+            id,
+            "Poison",
+            10,
+            1,
+            EffectStacking.REFRESH,
+            List.of(),
+            List.of()
+        );
+        EffectEngine engine = new EffectEngine(new InMemoryEffectRepository(definition));
+        Player player = new Player(
+            User.of(Username.of("dan"), Password.hash("pw", 1000)),
+            1,
+            0,
+            PlayerVitals.defaults(),
+            new ArrayList<>(),
+            "HP {hp}/{maxHp}",
+            false,
+            List.of(),
+            null,
+            null
+        );
+        RecordingSink sink = new RecordingSink();
+
+        boolean removed = engine.remove(player, id, sink);
+
+        assertTrue(player.effects().isEmpty());
+        assertEquals(List.of(), sink.messages());
+        assertEquals(false, removed);
+    }
+
     private static class InMemoryEffectRepository implements EffectRepository {
         private final EffectDefinition definition;
 


### PR DESCRIPTION
Closes #225

Adds a CURE ability/potion that removes the poison status effect.

- EffectEngine.remove(EffectTarget, EffectId, EffectMessageSink)
- new CURE ability-effect kind wired through AbilityEffectKind/AbilityEffect/DefaultAbilityEffectResolver/AbilityEngine
- ItemEffectOperation (APPLY/REMOVE) added to ItemEffect/ItemEffectDto/ItemMapper
- GameActionService.quaffItem routes REMOVE-operation item effects through EffectEngine.remove
- new data: data/skills/spell.cure.json, data/items/cure-potion.json
- schema updates: docs/schemas/item.v3.json, docs/schemas/ability.v1.json
- new/updated tests: EffectEngineTest, DefaultAbilityEffectResolverTest, GameActionServiceTest
- TODO.md updated