### PR TITLE
feat(world): add Sewers zone with slime and plague rat mobs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -69,7 +69,7 @@
 - [x] Add CURE ability/potion to remove poison and other negative status effects
 - [x] Add mob special ability: boss mobs can use a defined ability once per combat (e.g. troll smash)
 - [x] Add WRITE and READ commands with scroll items that teach a new ability on use
-- [ ] Add The Sewers zone with slimes and plague rats targeting mid-range players
+- [x] Add The Sewers zone with slimes and plague rats targeting mid-range players
 - [ ] Add The Ruins zone with bandits and a bandit captain boss for outdoor wilderness content
 - [ ] Add zone-level entry restriction: show a warning when a player enters a zone above their level
 - [ ] Add SCORE-visible kill counter and a global high-score WHO listing sorted by total kills

--- a/data/attacks/attack.plague-rat.json
+++ b/data/attacks/attack.plague-rat.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "attack.plague-rat",
+  "name": "diseased bite",
+  "min_damage": 5,
+  "max_damage": 12,
+  "hit_bonus": 1,
+  "crit_bonus": 1,
+  "damage_bonus": 1,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The plague rat sinks its rotten teeth into you for {damage}."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The plague rat lunges at you but misses."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The plague rat's diseased jaws tear into you for {damage}!"
+    }
+  ]
+}

--- a/data/attacks/attack.slime.json
+++ b/data/attacks/attack.slime.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "attack.slime",
+  "name": "corrosive touch",
+  "min_damage": 6,
+  "max_damage": 14,
+  "hit_bonus": 0,
+  "crit_bonus": 0,
+  "damage_bonus": 1,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The slime lashes out with a corrosive pseudopod for {damage}."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The slime surges toward you but fails to connect."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The slime engulfs your arm, burning flesh for {damage}!"
+    }
+  ]
+}

--- a/data/mobs/plague-rat.json
+++ b/data/mobs/plague-rat.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "id": "plague-rat",
+  "name": "Plague Rat",
+  "max_hp": 38,
+  "attack_id": "attack.plague-rat",
+  "aggressive": true,
+  "spawn_room_id": "sewers-cistern",
+  "max_count": 2,
+  "respawn_ticks": 30,
+  "loot": [
+    { "item_id": "poisonous-potion", "drop_chance": 0.35 },
+    { "item_id": "mana-potion", "drop_chance": 0.2 }
+  ],
+  "gold_drop": {
+    "min": 8,
+    "max": 20
+  }
+}

--- a/data/mobs/slime.json
+++ b/data/mobs/slime.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "id": "slime",
+  "name": "Slime",
+  "max_hp": 48,
+  "attack_id": "attack.slime",
+  "aggressive": true,
+  "spawn_room_id": "sewers-tunnel",
+  "max_count": 2,
+  "respawn_ticks": 35,
+  "loot": [
+    { "item_id": "cure-potion", "drop_chance": 0.3 },
+    { "item_id": "health-potion", "drop_chance": 0.4 }
+  ],
+  "gold_drop": {
+    "min": 10,
+    "max": 24
+  }
+}

--- a/data/rooms/sewers-cistern.json
+++ b/data/rooms/sewers-cistern.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 2,
+  "id": "sewers-cistern",
+  "name": "Sewers Cistern",
+  "description": "A vast, vaulted cistern chamber where black water pools waist-deep around crumbling pillars. The stench of decay is overwhelming, and pale shapes writhe just beneath the surface.",
+  "item_ids": [],
+  "exits": {
+    "north": "sewers-tunnel"
+  }
+}

--- a/data/rooms/sewers-entrance.json
+++ b/data/rooms/sewers-entrance.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "sewers-entrance",
+  "name": "Sewers Entrance",
+  "description": "A slick stone stairway descends from the crypts into a dripping, foul-smelling tunnel. Rusted grates line the walls, and the sound of trickling water echoes from somewhere below.",
+  "item_ids": [],
+  "exits": {
+    "up": "warden-chamber",
+    "east": "sewers-tunnel"
+  }
+}

--- a/data/rooms/sewers-tunnel.json
+++ b/data/rooms/sewers-tunnel.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "sewers-tunnel",
+  "name": "Sewers Tunnel",
+  "description": "A narrow brick tunnel half-flooded with stagnant, oily water. Something viscous glistens on the walls, and skittering echoes ahead in the dark.",
+  "item_ids": [],
+  "exits": {
+    "west": "sewers-entrance",
+    "south": "sewers-cistern"
+  }
+}

--- a/data/rooms/warden-chamber.json
+++ b/data/rooms/warden-chamber.json
@@ -5,6 +5,7 @@
   "description": "A vaulted burial chamber dominated by a stone sarcophagus in its center. Chains hang from the ceiling, and the air is thick with a cold, unnatural chill. Something powerful guards this place.",
   "item_ids": [],
   "exits": {
-    "north": "crypt-corridor"
+    "north": "crypt-corridor",
+    "down": "sewers-entrance"
   }
 }

--- a/src/test/java/io/taanielo/jmud/core/mob/SewersMobSpawnSmokeTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/SewersMobSpawnSmokeTest.java
@@ -1,0 +1,85 @@
+package io.taanielo.jmud.core.mob;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.mob.repository.json.JsonMobTemplateRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+
+/**
+ * Integration smoke-test confirming that the two Sewers mob templates
+ * (slime, plague-rat) are present and have correct attributes when loaded
+ * from the production data directory.
+ */
+class SewersMobSpawnSmokeTest {
+
+    @Test
+    void sewers_mobTemplates_arePresent() throws RepositoryException {
+        JsonMobTemplateRepository repo = new JsonMobTemplateRepository(Path.of("data"));
+
+        List<MobTemplate> templates = repo.findAll();
+        Set<String> ids = templates.stream()
+            .map(t -> t.id().getValue())
+            .collect(Collectors.toSet());
+
+        assertTrue(ids.contains("slime"), "Expected 'slime' mob template");
+        assertTrue(ids.contains("plague-rat"), "Expected 'plague-rat' mob template");
+    }
+
+    @Test
+    void slime_template_hasCorrectAttributes() throws RepositoryException {
+        JsonMobTemplateRepository repo = new JsonMobTemplateRepository(Path.of("data"));
+
+        MobTemplate slime = repo.findAll().stream()
+            .filter(t -> "slime".equals(t.id().getValue()))
+            .findFirst()
+            .orElse(null);
+
+        assertNotNull(slime, "Slime template must be present");
+        assertEquals("Slime", slime.name());
+        assertEquals(48, slime.maxHp());
+        assertTrue(slime.aggressive(), "Slime should be aggressive");
+        assertEquals("sewers-tunnel", slime.spawnRoomId().getValue());
+        assertEquals(2, slime.maxCount());
+        assertEquals(35, slime.respawnTicks());
+        assertFalse(slime.lootTable().isEmpty(), "Slime should have at least one loot entry");
+        assertNotNull(slime.goldDrop(), "Slime should have a gold drop");
+        assertEquals(10, slime.goldDrop().min());
+        assertEquals(24, slime.goldDrop().max());
+        // Slime should be tougher than the low-level Darkwood mobs (Goblin: 15 HP).
+        assertTrue(slime.maxHp() > 15, "Slime should be tougher than a Goblin");
+    }
+
+    @Test
+    void plagueRat_template_hasCorrectAttributes() throws RepositoryException {
+        JsonMobTemplateRepository repo = new JsonMobTemplateRepository(Path.of("data"));
+
+        MobTemplate plagueRat = repo.findAll().stream()
+            .filter(t -> "plague-rat".equals(t.id().getValue()))
+            .findFirst()
+            .orElse(null);
+
+        assertNotNull(plagueRat, "Plague Rat template must be present");
+        assertEquals("Plague Rat", plagueRat.name());
+        assertEquals(38, plagueRat.maxHp());
+        assertTrue(plagueRat.aggressive(), "Plague Rat should be aggressive");
+        assertEquals("sewers-cistern", plagueRat.spawnRoomId().getValue());
+        assertEquals(2, plagueRat.maxCount());
+        assertEquals(30, plagueRat.respawnTicks());
+        assertFalse(plagueRat.lootTable().isEmpty(), "Plague Rat should have at least one loot entry");
+        assertNotNull(plagueRat.goldDrop(), "Plague Rat should have a gold drop");
+        assertEquals(8, plagueRat.goldDrop().min());
+        assertEquals(20, plagueRat.goldDrop().max());
+        // Plague Rat should be tougher than the low-level Darkwood mobs (Kobold: 12 HP).
+        assertTrue(plagueRat.maxHp() > 12, "Plague Rat should be tougher than a Kobold");
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/world/SewersZoneSmokeTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/SewersZoneSmokeTest.java
@@ -1,0 +1,60 @@
+package io.taanielo.jmud.core.world;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.json.JsonItemRepository;
+import io.taanielo.jmud.core.world.repository.json.JsonRoomRepository;
+
+/**
+ * Integration smoke-test confirming that the Sewers zone rooms are present,
+ * connected to each other, and reachable from the existing world graph when
+ * loaded from the production data directory.
+ */
+class SewersZoneSmokeTest {
+
+    @Test
+    void sewers_zoneIsReachableFromExistingWorld() throws RepositoryException {
+        JsonItemRepository itemRepository = new JsonItemRepository(Path.of("data"));
+        JsonRoomRepository roomRepository = new JsonRoomRepository(itemRepository, Path.of("data"));
+
+        Room wardenChamber = roomRepository.findById(RoomId.of("warden-chamber"))
+            .orElseThrow(() -> new AssertionError("Warden Chamber room must be present"));
+        assertEquals(RoomId.of("sewers-entrance"), wardenChamber.getExits().get(Direction.DOWN),
+            "Warden Chamber should have a 'down' exit into the Sewers");
+
+        Room entrance = roomRepository.findById(RoomId.of("sewers-entrance"))
+            .orElseThrow(() -> new AssertionError("Sewers Entrance room must be present"));
+        assertEquals(RoomId.of("warden-chamber"), entrance.getExits().get(Direction.UP),
+            "Sewers Entrance should lead back up to the Warden Chamber");
+        assertEquals(RoomId.of("sewers-tunnel"), entrance.getExits().get(Direction.EAST));
+
+        Room tunnel = roomRepository.findById(RoomId.of("sewers-tunnel"))
+            .orElseThrow(() -> new AssertionError("Sewers Tunnel room must be present"));
+        assertEquals(RoomId.of("sewers-entrance"), tunnel.getExits().get(Direction.WEST));
+        assertEquals(RoomId.of("sewers-cistern"), tunnel.getExits().get(Direction.SOUTH));
+
+        Room cistern = roomRepository.findById(RoomId.of("sewers-cistern"))
+            .orElseThrow(() -> new AssertionError("Sewers Cistern room must be present"));
+        assertEquals(RoomId.of("sewers-tunnel"), cistern.getExits().get(Direction.NORTH));
+    }
+
+    @Test
+    void sewers_roomsHaveDescriptions() throws RepositoryException {
+        JsonItemRepository itemRepository = new JsonItemRepository(Path.of("data"));
+        JsonRoomRepository roomRepository = new JsonRoomRepository(itemRepository, Path.of("data"));
+
+        for (String roomId : new String[] { "sewers-entrance", "sewers-tunnel", "sewers-cistern" }) {
+            Optional<Room> room = roomRepository.findById(RoomId.of(roomId));
+            assertTrue(room.isPresent(), "Room " + roomId + " must be present");
+            assertTrue(room.get().getDescription() != null && !room.get().getDescription().isBlank(),
+                "Room " + roomId + " must have a description");
+        }
+    }
+}


### PR DESCRIPTION
Closes #231

Adds a new "Sewers" zone reachable from the warden chamber via a new down/up exit pair:
- Rooms: sewers-entrance, sewers-tunnel, sewers-cistern
- Mobs: slime (48 HP) and plague rat (38 HP) with matching attacks
- Smoke tests: SewersMobSpawnSmokeTest, SewersZoneSmokeTest
- TODO.md item checked off

Content-only change; ./gradlew check and scripts/smoke-test.sh both pass.