### PR TITLE
feat(world): add Ruins wilderness zone with bandit camp

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -70,7 +70,7 @@
 - [x] Add mob special ability: boss mobs can use a defined ability once per combat (e.g. troll smash)
 - [x] Add WRITE and READ commands with scroll items that teach a new ability on use
 - [x] Add The Sewers zone with slimes and plague rats targeting mid-range players
-- [ ] Add The Ruins zone with bandits and a bandit captain boss for outdoor wilderness content
+- [x] Add The Ruins zone with bandits and a bandit captain boss for outdoor wilderness content
 - [ ] Add zone-level entry restriction: show a warning when a player enters a zone above their level
 - [ ] Add SCORE-visible kill counter and a global high-score WHO listing sorted by total kills
 - [ ] Add player title system: automatically grant titles (Rat Slayer, Goblin Crusher) on quest completion

--- a/data/attacks/attack.bandit-captain.json
+++ b/data/attacks/attack.bandit-captain.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "attack.bandit-captain",
+  "name": "captain's blade",
+  "min_damage": 12,
+  "max_damage": 22,
+  "hit_bonus": 2,
+  "crit_bonus": 2,
+  "damage_bonus": 4,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The bandit captain drives their blade into you for {damage}."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The bandit captain feints, but you read the strike and dodge clear."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The bandit captain's blade finds a gap in your guard for {damage}!"
+    }
+  ]
+}

--- a/data/attacks/attack.bandit.json
+++ b/data/attacks/attack.bandit.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "attack.bandit",
+  "name": "bandit blade",
+  "min_damage": 7,
+  "max_damage": 16,
+  "hit_bonus": 1,
+  "crit_bonus": 1,
+  "damage_bonus": 2,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The bandit slashes at you with a notched blade for {damage}."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The bandit lunges at you but you sidestep the blow."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The bandit finds an opening and cuts deep for {damage}!"
+    }
+  ]
+}

--- a/data/attacks/attack.rally-cry.json
+++ b/data/attacks/attack.rally-cry.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 2,
+  "id": "attack.rally-cry",
+  "name": "Rally Cry",
+  "min_damage": 20,
+  "max_damage": 34,
+  "hit_bonus": 1,
+  "crit_bonus": 2,
+  "damage_bonus": 5,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The bandit captain lets out a furious rally cry and strikes you for {damage}!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The bandit captain's rally cry rings out, but the wild swing misses you."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The bandit captain's rally cry ends in a savage, crushing blow for {damage}!"
+    }
+  ]
+}

--- a/data/items/bandit-blade.json
+++ b/data/items/bandit-blade.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 3,
+  "id": "bandit-blade",
+  "name": "Bandit Blade",
+  "description": "A notched, poorly-maintained shortsword favored by the ruins' bandits. Battered, but still sharp enough to cut.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [],
+  "messages": [],
+  "weight": 3,
+  "value": 12
+}

--- a/data/items/bandit-captains-seal.json
+++ b/data/items/bandit-captains-seal.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 3,
+  "id": "bandit-captains-seal",
+  "name": "Bandit Captain's Seal",
+  "description": "A tarnished bronze seal bearing a crude sigil, once used to mark the bandit captain's stolen plunder as their own.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [],
+  "messages": [],
+  "weight": 1,
+  "value": 35
+}

--- a/data/mobs/bandit-captain.json
+++ b/data/mobs/bandit-captain.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 2,
+  "id": "bandit-captain",
+  "name": "Bandit Captain",
+  "max_hp": 100,
+  "attack_id": "attack.bandit-captain",
+  "special_attack_id": "attack.rally-cry",
+  "aggressive": true,
+  "spawn_room_id": "bandit-captains-den",
+  "max_count": 1,
+  "respawn_ticks": 60,
+  "loot": [
+    {
+      "item_id": "bandit-captains-seal",
+      "drop_chance": 0.9
+    }
+  ],
+  "gold_drop": {
+    "min": 25,
+    "max": 55
+  }
+}

--- a/data/mobs/bandit.json
+++ b/data/mobs/bandit.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 2,
+  "id": "bandit",
+  "name": "Bandit",
+  "max_hp": 50,
+  "attack_id": "attack.bandit",
+  "aggressive": true,
+  "spawn_room_id": "crumbling-courtyard",
+  "max_count": 2,
+  "respawn_ticks": 30,
+  "loot": [
+    {
+      "item_id": "bandit-blade",
+      "drop_chance": 0.5
+    }
+  ],
+  "gold_drop": {
+    "min": 10,
+    "max": 22
+  }
+}

--- a/data/rooms/bandit-captains-den.json
+++ b/data/rooms/bandit-captains-den.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 2,
+  "id": "bandit-captains-den",
+  "name": "Bandit Captain's Den",
+  "description": "A half-collapsed vault beneath the ruins, lit by guttering torches and stacked with looted crates and stolen goods. A battle-scarred bandit captain holds court here, daring any fool to challenge their claim on the ruins.",
+  "item_ids": [],
+  "exits": {
+    "east": "crumbling-courtyard"
+  }
+}

--- a/data/rooms/collapsed-tower.json
+++ b/data/rooms/collapsed-tower.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 2,
+  "id": "collapsed-tower",
+  "name": "Collapsed Tower",
+  "description": "The upper floors of this watchtower have long since fallen in, leaving a jagged shell open to the sky. Splintered beams jut from the rubble, and crude rope ladders scavenged from the wreckage lead up to makeshift lookout posts.",
+  "item_ids": [],
+  "exits": {
+    "south": "crumbling-courtyard"
+  }
+}

--- a/data/rooms/crumbling-courtyard.json
+++ b/data/rooms/crumbling-courtyard.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 2,
+  "id": "crumbling-courtyard",
+  "name": "Crumbling Courtyard",
+  "description": "Weeds push up through cracked flagstones in what was once an open courtyard. Toppled statues, worn faceless by centuries of rain, lie half-buried in rubble. Rough tents and cookfires suggest the ruins have found new, unwelcome occupants.",
+  "item_ids": [],
+  "exits": {
+    "east": "ruins-gate",
+    "north": "collapsed-tower",
+    "west": "bandit-captains-den"
+  }
+}

--- a/data/rooms/hunters-clearing.json
+++ b/data/rooms/hunters-clearing.json
@@ -6,6 +6,7 @@
   "item_ids": [],
   "exits": {
     "south": "tangled-undergrowth",
-    "east": "trolls-hollow"
+    "east": "trolls-hollow",
+    "west": "ruins-gate"
   }
 }

--- a/data/rooms/ruins-gate.json
+++ b/data/rooms/ruins-gate.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "ruins-gate",
+  "name": "Ruins Gate",
+  "description": "A crumbling stone archway, half-swallowed by creeping vines, marks the boundary between the Darkwood and the wilderness ruins beyond. Broken columns lie scattered in the tall grass, and the wind carries a faint smell of woodsmoke from somewhere deeper in.",
+  "item_ids": [],
+  "exits": {
+    "east": "hunters-clearing",
+    "west": "crumbling-courtyard"
+  }
+}

--- a/src/test/java/io/taanielo/jmud/core/mob/RuinsMobSpawnSmokeTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/RuinsMobSpawnSmokeTest.java
@@ -1,0 +1,90 @@
+package io.taanielo.jmud.core.mob;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.mob.repository.json.JsonMobTemplateRepository;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+
+/**
+ * Integration smoke-test confirming that the two Ruins mob templates
+ * (bandit, bandit-captain) are present and have correct attributes when
+ * loaded from the production data directory.
+ */
+class RuinsMobSpawnSmokeTest {
+
+    @Test
+    void ruins_mobTemplates_arePresent() throws RepositoryException {
+        JsonMobTemplateRepository repo = new JsonMobTemplateRepository(Path.of("data"));
+
+        List<MobTemplate> templates = repo.findAll();
+        Set<String> ids = templates.stream()
+            .map(t -> t.id().getValue())
+            .collect(Collectors.toSet());
+
+        assertTrue(ids.contains("bandit"), "Expected 'bandit' mob template");
+        assertTrue(ids.contains("bandit-captain"), "Expected 'bandit-captain' mob template");
+    }
+
+    @Test
+    void bandit_template_hasCorrectAttributes() throws RepositoryException {
+        JsonMobTemplateRepository repo = new JsonMobTemplateRepository(Path.of("data"));
+
+        MobTemplate bandit = repo.findAll().stream()
+            .filter(t -> "bandit".equals(t.id().getValue()))
+            .findFirst()
+            .orElse(null);
+
+        assertNotNull(bandit, "Bandit template must be present");
+        assertEquals("Bandit", bandit.name());
+        assertEquals(50, bandit.maxHp());
+        assertTrue(bandit.aggressive(), "Bandit should be aggressive");
+        assertEquals("crumbling-courtyard", bandit.spawnRoomId().getValue());
+        assertEquals(2, bandit.maxCount());
+        assertEquals(30, bandit.respawnTicks());
+        assertFalse(bandit.lootTable().isEmpty(), "Bandit should have at least one loot entry");
+        assertNotNull(bandit.goldDrop(), "Bandit should have a gold drop");
+        assertEquals(10, bandit.goldDrop().min());
+        assertEquals(22, bandit.goldDrop().max());
+        // Bandit should be on par with mid-tier Darkwood mobs (Dire Wolf: 55 HP).
+        assertTrue(bandit.maxHp() > 15, "Bandit should be tougher than a Goblin");
+    }
+
+    @Test
+    void banditCaptain_template_hasCorrectAttributes() throws RepositoryException {
+        JsonMobTemplateRepository repo = new JsonMobTemplateRepository(Path.of("data"));
+
+        MobTemplate banditCaptain = repo.findAll().stream()
+            .filter(t -> "bandit-captain".equals(t.id().getValue()))
+            .findFirst()
+            .orElse(null);
+
+        assertNotNull(banditCaptain, "Bandit Captain template must be present");
+        assertEquals("Bandit Captain", banditCaptain.name());
+        assertTrue(banditCaptain.aggressive(), "Bandit Captain should be aggressive");
+        assertEquals("bandit-captains-den", banditCaptain.spawnRoomId().getValue());
+        assertEquals(1, banditCaptain.maxCount(), "Bandit Captain is a unique boss");
+        assertNotNull(banditCaptain.specialAttackId(), "Bandit Captain should have a special attack");
+        assertEquals("attack.rally-cry", banditCaptain.specialAttackId().getValue());
+        assertNotNull(banditCaptain.goldDrop(), "Bandit Captain should have a gold drop");
+
+        MobTemplate bandit = repo.findAll().stream()
+            .filter(t -> "bandit".equals(t.id().getValue()))
+            .findFirst()
+            .orElseThrow();
+
+        assertTrue(banditCaptain.maxHp() > bandit.maxHp(),
+            "Bandit Captain should have more HP than a regular Bandit");
+        assertTrue(banditCaptain.goldDrop().max() > bandit.goldDrop().max(),
+            "Bandit Captain should drop more gold than a regular Bandit");
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/world/RuinsZoneSmokeTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RuinsZoneSmokeTest.java
@@ -1,0 +1,67 @@
+package io.taanielo.jmud.core.world;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.json.JsonItemRepository;
+import io.taanielo.jmud.core.world.repository.json.JsonRoomRepository;
+
+/**
+ * Integration smoke-test confirming that the Ruins zone rooms are present,
+ * connected to each other, and reachable from the existing overworld when
+ * loaded from the production data directory.
+ */
+class RuinsZoneSmokeTest {
+
+    @Test
+    void ruins_zoneIsReachableFromExistingWorld() throws RepositoryException {
+        JsonItemRepository itemRepository = new JsonItemRepository(Path.of("data"));
+        JsonRoomRepository roomRepository = new JsonRoomRepository(itemRepository, Path.of("data"));
+
+        Room huntersClearing = roomRepository.findById(RoomId.of("hunters-clearing"))
+            .orElseThrow(() -> new AssertionError("Hunter's Clearing room must be present"));
+        assertEquals(RoomId.of("ruins-gate"), huntersClearing.getExits().get(Direction.WEST),
+            "Hunter's Clearing should have a 'west' exit into the Ruins");
+
+        Room gate = roomRepository.findById(RoomId.of("ruins-gate"))
+            .orElseThrow(() -> new AssertionError("Ruins Gate room must be present"));
+        assertEquals(RoomId.of("hunters-clearing"), gate.getExits().get(Direction.EAST),
+            "Ruins Gate should lead back east to Hunter's Clearing");
+        assertEquals(RoomId.of("crumbling-courtyard"), gate.getExits().get(Direction.WEST));
+
+        Room courtyard = roomRepository.findById(RoomId.of("crumbling-courtyard"))
+            .orElseThrow(() -> new AssertionError("Crumbling Courtyard room must be present"));
+        assertEquals(RoomId.of("ruins-gate"), courtyard.getExits().get(Direction.EAST));
+        assertEquals(RoomId.of("collapsed-tower"), courtyard.getExits().get(Direction.NORTH));
+        assertEquals(RoomId.of("bandit-captains-den"), courtyard.getExits().get(Direction.WEST));
+
+        Room tower = roomRepository.findById(RoomId.of("collapsed-tower"))
+            .orElseThrow(() -> new AssertionError("Collapsed Tower room must be present"));
+        assertEquals(RoomId.of("crumbling-courtyard"), tower.getExits().get(Direction.SOUTH));
+
+        Room den = roomRepository.findById(RoomId.of("bandit-captains-den"))
+            .orElseThrow(() -> new AssertionError("Bandit Captain's Den room must be present"));
+        assertEquals(RoomId.of("crumbling-courtyard"), den.getExits().get(Direction.EAST));
+    }
+
+    @Test
+    void ruins_roomsHaveDescriptions() throws RepositoryException {
+        JsonItemRepository itemRepository = new JsonItemRepository(Path.of("data"));
+        JsonRoomRepository roomRepository = new JsonRoomRepository(itemRepository, Path.of("data"));
+
+        for (String roomId : new String[] {
+            "ruins-gate", "crumbling-courtyard", "collapsed-tower", "bandit-captains-den"
+        }) {
+            Optional<Room> room = roomRepository.findById(RoomId.of(roomId));
+            assertTrue(room.isPresent(), "Room " + roomId + " must be present");
+            assertTrue(room.get().getDescription() != null && !room.get().getDescription().isBlank(),
+                "Room " + roomId + " must have a description");
+        }
+    }
+}


### PR DESCRIPTION
Closes #233

Adds a new "Ruins" outdoor wilderness zone reachable west of Hunter's Clearing:

- Rooms: ruins-gate, crumbling-courtyard, collapsed-tower, bandit-captain's-den
- hunters-clearing.json updated with a new west exit into the Ruins (with reverse exit)
- Mobs: bandit (50 HP) and bandit-captain (100 HP unique boss with rally-cry special attack)
- Attacks: attack.bandit, attack.bandit-captain, attack.rally-cry
- Items: bandit-blade, bandit-captains-seal
- Tests: RuinsZoneSmokeTest, RuinsMobSpawnSmokeTest
- TODO.md updated

Content-only change; ./gradlew check (compile, tests, spotless, jacoco, ArchUnit) passed.