### PR TITLE
feat(world): warn player when moving into a room above their level

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@
 - [x] Add WRITE and READ commands with scroll items that teach a new ability on use
 - [x] Add The Sewers zone with slimes and plague rats targeting mid-range players
 - [x] Add The Ruins zone with bandits and a bandit captain boss for outdoor wilderness content
-- [ ] Add zone-level entry restriction: show a warning when a player enters a zone above their level
+- [x] Add zone-level entry restriction: show a warning when a player enters a zone above their level
 - [ ] Add SCORE-visible kill counter and a global high-score WHO listing sorted by total kills
 - [ ] Add player title system: automatically grant titles (Rat Slayer, Goblin Crusher) on quest completion
 - [ ] Add GOSSIP channel history: store the last 10 gossip lines and show them on login

--- a/data/rooms/catacombs-entrance.json
+++ b/data/rooms/catacombs-entrance.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "id": "catacombs-entrance",
   "name": "Catacombs Entrance",
   "description": "Crumbling stone steps descend into a cold, musty passage. Ancient runes are carved into the archway above, their meaning long forgotten. The smell of dry bone and stale air drifts upward from below. A heavy iron gate bars the way south.",
@@ -10,5 +10,6 @@
   },
   "locked_exits": {
     "south": "crypt-key"
-  }
+  },
+  "min_level": 5
 }

--- a/docs/schemas/room.v1.json
+++ b/docs/schemas/room.v1.json
@@ -34,6 +34,11 @@
         "type": "string",
         "pattern": "^[a-z0-9-]+$"
       }
+    },
+    "min_level": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional recommended/minimum level to enter this room. Advisory only: it never blocks movement, it only triggers a warning message to players below this level. Omit for no restriction."
     }
   }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import lombok.extern.slf4j.Slf4j;
 
 import io.taanielo.jmud.bootstrap.GameContext;
@@ -720,8 +722,19 @@ class SocketCommandContextImpl implements SocketCommandContext {
         connection.writeLines(result.lines());
         if (result.moved()) {
             writeRoomOccupantLines(result.room());
+            warnIfRoomTooDangerous(player, result.room());
         }
         sendPrompt();
+    }
+
+    /**
+     * Sends an advisory warning if the destination room's recommended level exceeds the player's
+     * current level. Movement itself is never blocked or delayed by this check.
+     */
+    private void warnIfRoomTooDangerous(Player player, @Nullable Room room) {
+        if (room != null && room.exceedsLevel(player.getLevel())) {
+            connection.writeLine("This area seems more dangerous than you are prepared for.");
+        }
     }
 
     @Override

--- a/src/main/java/io/taanielo/jmud/core/world/Room.java
+++ b/src/main/java/io/taanielo/jmud/core/world/Room.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 import lombok.Value;
 
 import io.taanielo.jmud.core.authentication.Username;
@@ -18,6 +20,8 @@ public class Room {
     List<Username> occupants;
     /** Exits that start locked and the key item id required to unlock each one. */
     Map<Direction, ItemId> lockedExits;
+    /** Recommended/minimum level to enter this room, advisory only; {@code null} means no restriction. */
+    @Nullable Integer minLevel;
 
     /**
      * Constructs a room with no locked exits. Existing callsites use this overload.
@@ -30,11 +34,11 @@ public class Room {
         List<Item> items,
         List<Username> occupants
     ) {
-        this(id, name, description, exits, items, occupants, Map.of());
+        this(id, name, description, exits, items, occupants, Map.of(), null);
     }
 
     /**
-     * Constructs a room with the specified locked exits configuration.
+     * Constructs a room with the specified locked exits configuration and no level restriction.
      *
      * @param lockedExits map of direction to required key item id for exits that start locked
      */
@@ -47,6 +51,25 @@ public class Room {
         List<Username> occupants,
         Map<Direction, ItemId> lockedExits
     ) {
+        this(id, name, description, exits, items, occupants, lockedExits, null);
+    }
+
+    /**
+     * Constructs a room with the specified locked exits configuration and advisory minimum level.
+     *
+     * @param lockedExits map of direction to required key item id for exits that start locked
+     * @param minLevel    the recommended/minimum level to enter this room, or {@code null} if none
+     */
+    public Room(
+        RoomId id,
+        String name,
+        String description,
+        Map<Direction, RoomId> exits,
+        List<Item> items,
+        List<Username> occupants,
+        Map<Direction, ItemId> lockedExits,
+        @Nullable Integer minLevel
+    ) {
         this.id = Objects.requireNonNull(id, "Room id is required");
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("Room name must not be blank");
@@ -57,5 +80,18 @@ public class Room {
         this.items = List.copyOf(Objects.requireNonNull(items, "Room items are required"));
         this.occupants = List.copyOf(Objects.requireNonNull(occupants, "Room occupants are required"));
         this.lockedExits = Map.copyOf(Objects.requireNonNull(lockedExits, "Locked exits map is required"));
+        this.minLevel = minLevel;
+    }
+
+    /**
+     * Returns whether this room's recommended/minimum level exceeds the given player level. This
+     * check is advisory only: callers use it to decide whether to show a warning, never to block
+     * or delay movement.
+     *
+     * @param playerLevel the level of the player entering the room
+     * @return {@code true} if this room has a minimum level set and it is higher than {@code playerLevel}
+     */
+    public boolean exceedsLevel(int playerLevel) {
+        return minLevel != null && minLevel > playerLevel;
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/RoomService.java
+++ b/src/main/java/io/taanielo/jmud/core/world/RoomService.java
@@ -254,7 +254,8 @@ public class RoomService {
             room.getExits(),
             items,
             occupants,
-            room.getLockedExits()
+            room.getLockedExits(),
+            room.getMinLevel()
         );
     }
 
@@ -283,7 +284,8 @@ public class RoomService {
             room.getExits(),
             nextItems,
             room.getOccupants(),
-            room.getLockedExits()
+            room.getLockedExits(),
+            room.getMinLevel()
         );
         try {
             roomRepository.save(updated);

--- a/src/main/java/io/taanielo/jmud/core/world/dto/RoomDto.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/RoomDto.java
@@ -3,10 +3,13 @@ package io.taanielo.jmud.core.world.dto;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Data transfer object for room persistence. Schema version 2 adds the {@code exits} field;
- * version 3 adds the optional {@code lockedExits} map.
- * Version 1 and 2 files are still accepted.
+ * version 3 adds the optional {@code lockedExits} map; version 4 adds the optional
+ * {@code minLevel} (serialized as {@code min_level}) field.
+ * Version 1, 2, and 3 files are still accepted.
  */
-public record RoomDto(int schemaVersion, String id, String name, String description, List<String> itemIds, Map<String, String> exits, Map<String, String> lockedExits) {
+public record RoomDto(int schemaVersion, String id, String name, String description, List<String> itemIds, Map<String, String> exits, Map<String, String> lockedExits, @Nullable Integer minLevel) {
 }

--- a/src/main/java/io/taanielo/jmud/core/world/dto/RoomMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/RoomMapper.java
@@ -28,9 +28,15 @@ public class RoomMapper {
         room.getExits().forEach((dir, roomId) -> exits.put(dir.name().toLowerCase(), roomId.getValue()));
         Map<String, String> lockedExits = new HashMap<>();
         room.getLockedExits().forEach((dir, keyId) -> lockedExits.put(dir.name().toLowerCase(), keyId.getValue()));
-        int version = lockedExits.isEmpty() ? SchemaVersions.V2 : SchemaVersions.V3;
+        Integer minLevel = room.getMinLevel();
+        int version;
+        if (minLevel != null) {
+            version = SchemaVersions.V4;
+        } else {
+            version = lockedExits.isEmpty() ? SchemaVersions.V2 : SchemaVersions.V3;
+        }
         return new RoomDto(version, room.getId().getValue(), room.getName(), room.getDescription(), itemIds, exits,
-            lockedExits.isEmpty() ? null : lockedExits);
+            lockedExits.isEmpty() ? null : lockedExits, minLevel);
     }
 
     /**
@@ -62,7 +68,8 @@ public class RoomMapper {
             exits,
             items,
             List.of(),
-            lockedExits
+            lockedExits,
+            dto.minLevel()
         );
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepository.java
@@ -121,7 +121,8 @@ public class JsonRoomRepository implements RoomRepository {
     private void validateSchema(RoomDto dto, Path path) throws RepositoryException {
         if (dto.schemaVersion() != SchemaVersions.V1
                 && dto.schemaVersion() != SchemaVersions.V2
-                && dto.schemaVersion() != SchemaVersions.V3) {
+                && dto.schemaVersion() != SchemaVersions.V3
+                && dto.schemaVersion() != SchemaVersions.V4) {
             throw new RepositoryException("Unsupported room schema version " + dto.schemaVersion() + " in " + path);
         }
     }

--- a/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
@@ -47,6 +47,39 @@ class RoomServiceTest {
     }
 
     @Test
+    void movePreservesDestinationRoomMinLevel() {
+        RoomId roomAId = RoomId.of("a");
+        RoomId roomBId = RoomId.of("b");
+        Room roomA = new Room(
+            roomAId,
+            "Room A",
+            "A quiet room.",
+            Map.of(Direction.NORTH, roomBId),
+            List.of(),
+            List.of()
+        );
+        Room roomB = new Room(
+            roomBId,
+            "Room B",
+            "A dangerous room.",
+            Map.of(Direction.SOUTH, roomAId),
+            List.of(),
+            List.of(),
+            Map.of(),
+            5
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA, roomBId, roomB)), roomAId);
+
+        Username player = Username.of("Bob");
+        service.ensurePlayerLocation(player);
+        RoomService.MoveResult moveResult = service.move(player, Direction.NORTH);
+
+        assertTrue(moveResult.moved());
+        assertTrue(moveResult.room() != null && moveResult.room().exceedsLevel(4));
+        assertFalse(moveResult.room() != null && moveResult.room().exceedsLevel(5));
+    }
+
+    @Test
     void rejectsInvalidMove() {
         RoomId roomAId = RoomId.of("a");
         Room roomA = new Room(

--- a/src/test/java/io/taanielo/jmud/core/world/RoomTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomTest.java
@@ -1,0 +1,54 @@
+package io.taanielo.jmud.core.world;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link Room}, focused on the advisory min-level warning check.
+ */
+class RoomTest {
+
+    private Room roomWithMinLevel(Integer minLevel) {
+        return new Room(
+            RoomId.of("a"),
+            "Room A",
+            "A room.",
+            Map.of(),
+            List.of(),
+            List.of(),
+            Map.of(),
+            minLevel
+        );
+    }
+
+    @Test
+    void hasNoMinLevelByDefault() {
+        Room room = new Room(RoomId.of("a"), "Room A", "A room.", Map.of(), List.of(), List.of());
+
+        assertNull(room.getMinLevel());
+        assertFalse(room.exceedsLevel(1));
+        assertFalse(room.exceedsLevel(100));
+    }
+
+    @Test
+    void doesNotExceedLevelWhenPlayerLevelIsAtOrAboveMinLevel() {
+        Room room = roomWithMinLevel(5);
+
+        assertFalse(room.exceedsLevel(5));
+        assertFalse(room.exceedsLevel(6));
+    }
+
+    @Test
+    void exceedsLevelWhenPlayerLevelIsBelowMinLevel() {
+        Room room = roomWithMinLevel(5);
+
+        assertTrue(room.exceedsLevel(4));
+        assertTrue(room.exceedsLevel(1));
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepositoryTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepositoryTest.java
@@ -1,6 +1,7 @@
 package io.taanielo.jmud.core.world.repository.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -72,6 +73,57 @@ class JsonRoomRepositoryTest {
 
         assertTrue(loaded.isPresent());
         assertEquals(room, loaded.get());
+    }
+
+    @Test
+    void savesAndLoadsRoomWithMinLevel() throws Exception {
+        Path dataRoot = tempDir.resolve("data");
+        JsonItemRepository itemRepository = new JsonItemRepository(dataRoot);
+        JsonRoomRepository roomRepository = new JsonRoomRepository(itemRepository, dataRoot);
+
+        Room room = new Room(
+            RoomId.of("catacombs"),
+            "Catacombs",
+            "A dank, dangerous passage.",
+            Map.of(),
+            List.of(),
+            List.of(),
+            Map.of(),
+            5
+        );
+        roomRepository.save(room);
+
+        // Use a fresh repository instance so the read goes through the JSON file, not the cache.
+        JsonRoomRepository reloadedRepository = new JsonRoomRepository(itemRepository, dataRoot);
+        Optional<Room> loaded = reloadedRepository.findById(RoomId.of("catacombs"));
+
+        assertTrue(loaded.isPresent());
+        assertEquals(Integer.valueOf(5), loaded.get().getMinLevel());
+    }
+
+    @Test
+    void loadsLegacyRoomWithoutMinLevelAsNull() throws Exception {
+        Path dataRoot = tempDir.resolve("data");
+        Path roomsDir = dataRoot.resolve("rooms");
+        Files.createDirectories(roomsDir);
+        Files.writeString(roomsDir.resolve("legacy.json"), """
+            {
+              "schema_version": 2,
+              "id": "legacy",
+              "name": "Legacy Room",
+              "description": "An old room without a min level.",
+              "item_ids": [],
+              "exits": {}
+            }
+            """);
+
+        JsonItemRepository itemRepository = new JsonItemRepository(dataRoot);
+        JsonRoomRepository roomRepository = new JsonRoomRepository(itemRepository, dataRoot);
+
+        Optional<Room> loaded = roomRepository.findById(RoomId.of("legacy"));
+
+        assertTrue(loaded.isPresent());
+        assertNull(loaded.get().getMinLevel());
     }
 
     @Test


### PR DESCRIPTION
Closes #235

Adds a room-level warning when a player moves into a room whose declared
minLevel exceeds their own character level.

- Room.minLevel (nullable) + exceedsLevel(int) domain method
- RoomDto/RoomMapper min_level mapping, schema bumped to v4 when set
- JsonRoomRepository schema validation whitelist extended for v4
- RoomService preserves minLevel when rebuilding Room instances
- SocketCommandContextImpl.sendMove warns after a successful move
- docs/schemas/room.v1.json documents the new optional field
- data/rooms/catacombs-entrance.json example bumped to v4 with min_level: 5
- New/updated tests: RoomTest, RoomServiceTest, JsonRoomRepositoryTest