### PR TITLE
feat(server): add RANK command for global kill-count high scores

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -72,7 +72,7 @@
 - [x] Add The Sewers zone with slimes and plague rats targeting mid-range players
 - [x] Add The Ruins zone with bandits and a bandit captain boss for outdoor wilderness content
 - [x] Add zone-level entry restriction: show a warning when a player enters a zone above their level
-- [ ] Add SCORE-visible kill counter and a global high-score WHO listing sorted by total kills
+- [x] Add SCORE-visible kill counter and a global high-score WHO listing sorted by total kills
 - [ ] Add player title system: automatically grant titles (Rat Slayer, Goblin Crusher) on quest completion
 - [ ] Add GOSSIP channel history: store the last 10 gossip lines and show them on login
 - [ ] Add SAY emote variants: SHOUT broadcasts to adjacent rooms; WHISPER is visible only to one target

--- a/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
@@ -172,7 +172,8 @@ public record GameContext(
         AbilityCostResolver abilityCostResolver = new BasicAbilityCostResolver();
         AbilityTargetResolver abilityTargetResolver = new RoomAbilityTargetResolver(roomService, playerRepository);
 
-        SocketCommandRegistry commandRegistry = SocketCommandRegistry.createDefault(equipmentArmorResolver, raceArmorBonusResolver);
+        SocketCommandRegistry commandRegistry =
+            SocketCommandRegistry.createDefault(equipmentArmorResolver, raceArmorBonusResolver, playerRepository);
 
         PlayerEventBus playerEventBus = new PlayerEventBus();
         MobRegistry mobRegistry = createMobRegistry(

--- a/src/main/java/io/taanielo/jmud/core/player/JsonPlayerRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/player/JsonPlayerRepository.java
@@ -1,14 +1,16 @@
 package io.taanielo.jmud.core.player;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.extern.slf4j.Slf4j;
 
 import io.taanielo.jmud.core.authentication.Username;
@@ -72,6 +74,28 @@ public class JsonPlayerRepository implements PlayerRepository {
             log.error("Failed to load player {}", username, e);
             return Optional.empty();
         }
+    }
+
+    @Override
+    public List<Player> findAll() {
+        if (!Files.exists(playersDirPath)) {
+            return List.of();
+        }
+        List<Player> players = new ArrayList<>();
+        try (var stream = Files.list(playersDirPath)) {
+            for (Path path : stream.filter(p -> p.toString().endsWith(".json")).toList()) {
+                try {
+                    Player player = objectMapper.readValue(path.toFile(), Player.class);
+                    players.add(player);
+                } catch (IOException e) {
+                    log.error("Failed to load player from {}", path, e);
+                }
+            }
+        } catch (IOException e) {
+            log.error("Failed to list players directory {}", playersDirPath, e);
+            return List.of();
+        }
+        return List.copyOf(players);
     }
 
     private Path getPlayerFilePath(Username username) {

--- a/src/main/java/io/taanielo/jmud/core/player/PlayerRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/player/PlayerRepository.java
@@ -1,5 +1,6 @@
 package io.taanielo.jmud.core.player;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.taanielo.jmud.core.authentication.Username;
@@ -21,4 +22,21 @@ public interface PlayerRepository {
     void savePlayer(Player player) throws RepositoryException;
 
     Optional<Player> loadPlayer(Username username);
+
+    /**
+     * Loads every persisted player, including those not currently online.
+     *
+     * <p>This scans persisted storage and is a blocking I/O operation; callers must
+     * never invoke it from code reachable from the tick thread (see AGENTS.md §5).
+     * It is intended for read-only, reader-thread commands such as a global kill
+     * ranking listing.
+     *
+     * <p>The default implementation returns an empty list so existing test doubles
+     * do not need to be updated.
+     *
+     * @return an immutable snapshot of all persisted players
+     */
+    default List<Player> findAll() {
+        return List.of();
+    }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/KillRankingListing.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/KillRankingListing.java
@@ -1,0 +1,76 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import io.taanielo.jmud.core.player.Player;
+
+/**
+ * Pure, network-free helper that formats a global kill-count ranking for the
+ * {@code RANK} command.
+ *
+ * <p>Kept free of any I/O so the ranking, ordering, and pagination logic can be
+ * unit tested in isolation. Players are sorted by {@link Player#getTotalKills()}
+ * descending, with ties broken by username for a stable, deterministic order.
+ */
+public final class KillRankingListing {
+
+    private static final String HEADER = "Kill ranking:";
+    private static final int DEFAULT_LIMIT = 20;
+
+    private KillRankingListing() {
+    }
+
+    /**
+     * Formats the given players into a descending kill-count ranking, capped at
+     * {@value #DEFAULT_LIMIT} entries.
+     *
+     * @param players the persisted players to rank, in any order
+     * @return the lines to render, never empty
+     */
+    public static List<String> format(List<Player> players) {
+        return format(players, DEFAULT_LIMIT);
+    }
+
+    /**
+     * Formats the given players into a descending kill-count ranking, capped at
+     * {@code limit} entries.
+     *
+     * @param players the persisted players to rank, in any order
+     * @param limit   the maximum number of ranked entries to include
+     * @return the lines to render, never empty
+     */
+    public static List<String> format(List<Player> players, int limit) {
+        Objects.requireNonNull(players, "Players are required");
+        List<Player> ranked = new ArrayList<>(players);
+        ranked.sort(
+            Comparator.comparingLong(Player::getTotalKills).reversed()
+                .thenComparing(p -> p.getUsername().getValue()));
+
+        List<String> lines = new ArrayList<>();
+        lines.add(HEADER);
+        int shown = Math.min(ranked.size(), Math.max(0, limit));
+        for (int i = 0; i < shown; i++) {
+            Player player = ranked.get(i);
+            lines.add(String.format("  %2d. %-15s %d kills", i + 1, player.getUsername().getValue(), player.getTotalKills()));
+        }
+        if (ranked.size() > shown) {
+            lines.add("  ... and " + (ranked.size() - shown) + " more.");
+        }
+        lines.add(footer(ranked.size()));
+        return List.copyOf(lines);
+    }
+
+    /**
+     * Builds the count footer line, pluralising "player" as appropriate.
+     *
+     * @param count the total number of ranked players
+     * @return the footer line, e.g. {@code "3 players ranked."}
+     */
+    static String footer(int count) {
+        String noun = count == 1 ? "player" : "players";
+        return count + " " + noun + " ranked.";
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/RankCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/RankCommand.java
@@ -1,0 +1,73 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+
+/**
+ * Handles the {@code RANK} command, listing every persisted player's total
+ * kill count ranked highest-to-lowest, server-wide.
+ *
+ * <p>Unlike {@code WHO}, which only lists players currently online, this
+ * command reads every persisted player via {@link PlayerRepository#findAll()}
+ * so offline players are included too. Reading every player file is a
+ * blocking I/O operation, so this command must only ever run on a reader
+ * thread (never on the tick thread) — it is read-only and performs no
+ * game-state mutation.
+ */
+public class RankCommand extends RegistrableCommand {
+
+    private final PlayerRepository playerRepository;
+
+    /**
+     * Creates a {@code RankCommand} backed by the given player repository.
+     *
+     * @param registry         the command registry to register with
+     * @param playerRepository the repository used to enumerate all persisted players
+     */
+    public RankCommand(SocketCommandRegistry registry, PlayerRepository playerRepository) {
+        super(registry);
+        this.playerRepository = Objects.requireNonNull(playerRepository, "PlayerRepository is required");
+    }
+
+    @Override
+    public String name() {
+        return "rank";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "List all players server-wide ranked by total kills.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: RANK\n"
+             + "  Displays every saved player's total kill count, ranked highest to lowest,\n"
+             + "  including players who are not currently online.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String token = SocketCommandParsing.firstToken(input);
+        if (!"RANK".equals(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(new SocketCommandMatch(this, this::handleRank));
+    }
+
+    private void handleRank(SocketCommandContext context) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to view the kill ranking.");
+            return;
+        }
+        List<Player> players = playerRepository.findAll();
+        for (String line : KillRankingListing.format(players)) {
+            context.writeLineSafe(line);
+        }
+        context.sendPrompt();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 import io.taanielo.jmud.core.combat.EquipmentArmorResolver;
 import io.taanielo.jmud.core.combat.RaceArmorBonusResolver;
+import io.taanielo.jmud.core.player.PlayerRepository;
 
 /**
  * Registry for socket command handlers.
@@ -22,13 +23,16 @@ public class SocketCommandRegistry {
      *
      * @param equipmentArmorResolver resolver for AC contributed by equipped armour
      * @param raceArmorBonusResolver resolver for AC contributed by the player's race
+     * @param playerRepository       repository used to enumerate all persisted players for {@code RANK}
      */
     public static SocketCommandRegistry createDefault(
         EquipmentArmorResolver equipmentArmorResolver,
-        RaceArmorBonusResolver raceArmorBonusResolver
+        RaceArmorBonusResolver raceArmorBonusResolver,
+        PlayerRepository playerRepository
     ) {
         Objects.requireNonNull(equipmentArmorResolver, "Equipment armor resolver is required");
         Objects.requireNonNull(raceArmorBonusResolver, "Race armor bonus resolver is required");
+        Objects.requireNonNull(playerRepository, "Player repository is required");
         SocketCommandRegistry registry = new SocketCommandRegistry();
         new LookCommand(registry);
         new ExamineCommand(registry);
@@ -47,6 +51,7 @@ public class SocketCommandRegistry {
         new TellCommand(registry);
         new GossipCommand(registry);
         new WhoCommand(registry);
+        new RankCommand(registry, playerRepository);
         new ScoreCommand(registry, equipmentArmorResolver, raceArmorBonusResolver);
         new AbilityCommand(registry);
         new CastCommand(registry);

--- a/src/test/java/io/taanielo/jmud/core/player/JsonPlayerRepositoryTest.java
+++ b/src/test/java/io/taanielo/jmud/core/player/JsonPlayerRepositoryTest.java
@@ -12,10 +12,10 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import io.taanielo.jmud.core.ability.AbilityId;
 import io.taanielo.jmud.core.authentication.Password;
 import io.taanielo.jmud.core.authentication.User;
 import io.taanielo.jmud.core.authentication.Username;
-import io.taanielo.jmud.core.ability.AbilityId;
 import io.taanielo.jmud.core.character.ClassId;
 import io.taanielo.jmud.core.character.RaceId;
 import io.taanielo.jmud.core.effects.EffectId;
@@ -92,6 +92,27 @@ class JsonPlayerRepositoryTest {
         assertTrue(loaded.isPresent());
         assertEquals(0, loaded.get().getGold(),
             "Player with no gold field set should load as 0 gold");
+    }
+
+    @Test
+    void findAllReturnsEveryPersistedPlayer() throws Exception {
+        JsonPlayerRepository repository = new JsonPlayerRepository(tempDir);
+        Player alice = Player.of(User.of(Username.of("alice"), Password.hash("pw", 1)), "%hp> ").withTotalKills(10);
+        Player bob = Player.of(User.of(Username.of("bob"), Password.hash("pw", 1)), "%hp> ").withTotalKills(3);
+
+        repository.savePlayer(alice);
+        repository.savePlayer(bob);
+
+        List<Player> all = repository.findAll();
+        assertEquals(2, all.size());
+        assertTrue(all.stream().anyMatch(p -> p.getUsername().getValue().equals("alice") && p.getTotalKills() == 10));
+        assertTrue(all.stream().anyMatch(p -> p.getUsername().getValue().equals("bob") && p.getTotalKills() == 3));
+    }
+
+    @Test
+    void findAllReturnsEmptyListWhenNoPlayersDirectoryExists() {
+        JsonPlayerRepository repository = new JsonPlayerRepository(tempDir.resolve("unused-root"));
+        assertEquals(List.of(), repository.findAll());
     }
 
     @Test

--- a/src/test/java/io/taanielo/jmud/core/server/socket/KillRankingListingTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/KillRankingListingTest.java
@@ -1,0 +1,76 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+
+class KillRankingListingTest {
+
+    @Test
+    void sortsPlayersByKillsDescending() {
+        Player alice = player("alice", 10);
+        Player bob = player("bob", 25);
+        Player carol = player("carol", 3);
+
+        List<String> lines = KillRankingListing.format(List.of(alice, bob, carol));
+
+        assertEquals("Kill ranking:", lines.get(0));
+        assertTrue(lines.get(1).contains("bob"));
+        assertTrue(lines.get(2).contains("alice"));
+        assertTrue(lines.get(3).contains("carol"));
+        assertEquals("3 players ranked.", lines.get(lines.size() - 1));
+    }
+
+    @Test
+    void breaksTiesByUsername() {
+        Player bob = player("bob", 5);
+        Player alice = player("alice", 5);
+
+        List<String> lines = KillRankingListing.format(List.of(bob, alice));
+
+        assertTrue(lines.get(1).contains("alice"));
+        assertTrue(lines.get(2).contains("bob"));
+    }
+
+    @Test
+    void capsAtLimitAndShowsRemainderCount() {
+        List<Player> players = List.of(
+            player("a", 1), player("b", 2), player("c", 3), player("d", 4)
+        );
+
+        List<String> lines = KillRankingListing.format(players, 2);
+
+        assertEquals("Kill ranking:", lines.get(0));
+        assertTrue(lines.get(1).contains("d"));
+        assertTrue(lines.get(2).contains("c"));
+        assertEquals("  ... and 2 more.", lines.get(3));
+        assertEquals("4 players ranked.", lines.get(4));
+    }
+
+    @Test
+    void noPlayersStillRendersHeaderAndZeroCount() {
+        List<String> lines = KillRankingListing.format(List.of());
+
+        assertEquals(List.of("Kill ranking:", "0 players ranked."), lines);
+    }
+
+    @Test
+    void footerPluralisesByCount() {
+        assertEquals("0 players ranked.", KillRankingListing.footer(0));
+        assertEquals("1 player ranked.", KillRankingListing.footer(1));
+        assertEquals("5 players ranked.", KillRankingListing.footer(5));
+    }
+
+    private static Player player(String username, long totalKills) {
+        User user = User.of(Username.of(username), Password.hash("pw", 1));
+        return Player.of(user, "%hp> ").withTotalKills(totalKills);
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/RankCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/RankCommandTest.java
@@ -1,0 +1,137 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.messaging.Message;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+
+/**
+ * Unit tests for {@link RankCommand}, covering matching and output via
+ * {@link SocketCommandContext} (mirroring {@code WhoListingTest} / {@code ScoreCommandTest}).
+ */
+class RankCommandTest {
+
+    @Test
+    void matchesRankToken() {
+        RankCommand cmd = new RankCommand(new SocketCommandRegistry(), new StubPlayerRepository(List.of()));
+        assertTrue(cmd.match("RANK").isPresent());
+        assertTrue(cmd.match("rank").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        RankCommand cmd = new RankCommand(new SocketCommandRegistry(), new StubPlayerRepository(List.of()));
+        assertFalse(cmd.match("WHO").isPresent());
+        assertFalse(cmd.match("").isPresent());
+    }
+
+    @Test
+    void listsAllPersistedPlayersSortedByKills() {
+        Player alice = player("alice", 10);
+        Player bob = player("bob", 25);
+        RankCommand cmd = new RankCommand(new SocketCommandRegistry(), new StubPlayerRepository(List.of(alice, bob)));
+        CapturingContext context = new CapturingContext(alice, true);
+
+        cmd.match("RANK").orElseThrow().execute(context);
+
+        assertTrue(context.lines.get(0).equals("Kill ranking:"));
+        assertTrue(context.lines.stream().anyMatch(l -> l.contains("bob")));
+        assertTrue(context.lines.stream().anyMatch(l -> l.contains("alice")));
+    }
+
+    @Test
+    void unauthenticatedPlayerGetsErrorMessage() {
+        RankCommand cmd = new RankCommand(new SocketCommandRegistry(), new StubPlayerRepository(List.of()));
+        CapturingContext context = new CapturingContext(null, false);
+
+        cmd.match("RANK").orElseThrow().execute(context);
+
+        assertTrue(context.lines.isEmpty(), "No safe-written lines expected for unauthed player");
+        assertTrue(context.promptMessage != null, "Prompt error message expected");
+    }
+
+    private static Player player(String username, long totalKills) {
+        User user = User.of(Username.of(username), Password.hash("pw", 1));
+        return Player.of(user, "%hp> ").withTotalKills(totalKills);
+    }
+
+    private static class StubPlayerRepository implements PlayerRepository {
+        private final List<Player> players;
+
+        StubPlayerRepository(List<Player> players) {
+            this.players = players;
+        }
+
+        @Override
+        public void savePlayer(Player player) throws RepositoryException {
+        }
+
+        @Override
+        public Optional<Player> loadPlayer(Username username) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Player> findAll() {
+            return players;
+        }
+    }
+
+    private static class CapturingContext implements SocketCommandContext {
+        private final Player player;
+        private final boolean authenticated;
+        final List<String> lines = new ArrayList<>();
+        String promptMessage;
+
+        CapturingContext(Player player, boolean authenticated) {
+            this.player = player;
+            this.authenticated = authenticated;
+        }
+
+        @Override public boolean isAuthenticated() { return authenticated; }
+        @Override public Player getPlayer() { return player; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) { promptMessage = m; }
+        @Override public void writeLineSafe(String m) { lines.add(m); }
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) {}
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void readItem(String a) {}
+        @Override public void writeItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}

--- a/src/test/resources/archunit_store/236c68c0-eb56-4db5-9f62-dab33747c056
+++ b/src/test/resources/archunit_store/236c68c0-eb56-4db5-9f62-dab33747c056
@@ -56,6 +56,7 @@ Method <io.taanielo.jmud.core.effects.EffectInstance.stacks()> is annotated with
 Method <io.taanielo.jmud.core.mob.MobId.jsonValue()> is annotated with <com.fasterxml.jackson.annotation.JsonValue> in (MobId.java:0)
 Method <io.taanielo.jmud.core.mob.MobId.of(java.lang.String)> has annotation member of type <com.fasterxml.jackson.annotation.JsonCreator$Mode> in (MobId.java:0)
 Method <io.taanielo.jmud.core.mob.MobId.of(java.lang.String)> is annotated with <com.fasterxml.jackson.annotation.JsonCreator> in (MobId.java:0)
+Method <io.taanielo.jmud.core.player.JsonPlayerRepository.findAll()> calls method <com.fasterxml.jackson.databind.ObjectMapper.readValue(java.io.File, java.lang.Class)> in (JsonPlayerRepository.java:88)
 Method <io.taanielo.jmud.core.player.JsonPlayerRepository.loadPlayer(io.taanielo.jmud.core.authentication.Username)> calls method <com.fasterxml.jackson.databind.ObjectMapper.readValue(java.io.File, java.lang.Class)> in (JsonPlayerRepository.java:68)
 Method <io.taanielo.jmud.core.player.JsonPlayerRepository.savePlayer(io.taanielo.jmud.core.player.Player)> calls method <com.fasterxml.jackson.databind.ObjectMapper.writeValue(java.io.File, java.lang.Object)> in (JsonPlayerRepository.java:49)
 Method <io.taanielo.jmud.core.player.Player.getActiveQuest()> has annotation member of type <com.fasterxml.jackson.annotation.JsonProperty$Access> in (Player.java:0)


### PR DESCRIPTION
Closes #237

Adds a global kill-count high-score listing via a new RANK command.

- `PlayerRepository.findAll()` default method (empty by default)
- `JsonPlayerRepository.findAll()` scans the `players/` directory
- `KillRankingListing`: pure formatter, sorts by totalKills desc, caps at 20 with "and N more"
- `RankCommand`: read-only SocketCommand, constructor-injected PlayerRepository
- `SocketCommandRegistry.createDefault()` gained a PlayerRepository parameter; GameContext call site updated
- Tests: JsonPlayerRepositoryTest findAll cases, KillRankingListingTest, RankCommandTest
- ArchUnit violations store updated to record that JsonPlayerRepository.findAll() extends the same pre-existing Jackson-containment debt already present for loadPlayer/savePlayer in that class
- TODO.md item checked off

Build verified: `./gradlew check` (compile, tests, spotless, jacoco coverage, ArchUnit) and `scripts/smoke-test.sh` both passed.