### PR TITLE
feat(messaging): add GOSSIP channel history shown on login

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -74,7 +74,7 @@
 - [x] Add zone-level entry restriction: show a warning when a player enters a zone above their level
 - [x] Add SCORE-visible kill counter and a global high-score WHO listing sorted by total kills
 - [x] Add player title system: automatically grant titles (Rat Slayer, Goblin Crusher) on quest completion
-- [ ] Add GOSSIP channel history: store the last 10 gossip lines and show them on login
+- [x] Add GOSSIP channel history: store the last 10 gossip lines and show them on login
 - [ ] Add SAY emote variants: SHOUT broadcasts to adjacent rooms; WHISPER is visible only to one target
 - [ ] Add GIVE command so players can hand items to other players or NPCs in the same room
 - [ ] Add time-of-day tick cycle (day/night) that changes room descriptions and affects mob spawn rates

--- a/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
@@ -41,6 +41,7 @@ import io.taanielo.jmud.core.effects.EffectRepositoryException;
 import io.taanielo.jmud.core.effects.repository.json.JsonEffectRepository;
 import io.taanielo.jmud.core.healing.HealingBaseResolver;
 import io.taanielo.jmud.core.healing.HealingEngine;
+import io.taanielo.jmud.core.messaging.GossipHistory;
 import io.taanielo.jmud.core.messaging.MessageBroadcaster;
 import io.taanielo.jmud.core.messaging.MessageBroadcasterImpl;
 import io.taanielo.jmud.core.mob.MobRegistry;
@@ -109,7 +110,8 @@ public record GameContext(
     QuestRepository questRepository,
     PartyService partyService,
     BankService bankService,
-    MessageBroadcaster messageBroadcaster
+    MessageBroadcaster messageBroadcaster,
+    GossipHistory gossipHistory
 ) {
 
     /**
@@ -198,6 +200,7 @@ public record GameContext(
         }
 
         MessageBroadcaster messageBroadcaster = new MessageBroadcasterImpl(clientPool, roomService);
+        GossipHistory gossipHistory = new GossipHistory();
 
         gameMetrics.bindGlobalGauges(tickRegistry, clientPool);
 
@@ -230,7 +233,8 @@ public record GameContext(
             questRepository,
             partyService,
             bankService,
-            messageBroadcaster
+            messageBroadcaster,
+            gossipHistory
         );
     }
 

--- a/src/main/java/io/taanielo/jmud/core/messaging/GossipHistory.java
+++ b/src/main/java/io/taanielo/jmud/core/messaging/GossipHistory.java
@@ -1,0 +1,71 @@
+package io.taanielo.jmud.core.messaging;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Bounded, thread-safe, in-memory ring buffer of the most recent {@code GOSSIP} lines
+ * broadcast on the server.
+ *
+ * <p>This is ephemeral chat history only: it is never persisted to {@code data/} and is
+ * lost on server restart (see the GOSSIP history feature request). It holds at most
+ * {@value #MAX_ENTRIES} entries, evicting the oldest line first once full, and is safe to
+ * call from any thread — recording happens alongside the existing synchronous
+ * {@link MessageBroadcaster#broadcastGlobal} call, and rendering happens on a
+ * newly-connected player's own reader thread during login (AGENTS.md §5). The narrow
+ * {@code synchronized} scope here guards only this buffer, not any game state.
+ */
+public class GossipHistory {
+
+    private static final int MAX_ENTRIES = 10;
+
+    private final Deque<String> lines = new ArrayDeque<>(MAX_ENTRIES);
+
+    /**
+     * Records a formatted gossip line, evicting the oldest entry if the buffer is already
+     * at capacity. Blank or {@code null} lines are ignored.
+     *
+     * @param line the fully formatted line as broadcast to other players
+     *             (e.g. {@code "Alice gossips: hello"})
+     */
+    public synchronized void record(String line) {
+        if (line == null || line.isBlank()) {
+            return;
+        }
+        if (lines.size() >= MAX_ENTRIES) {
+            lines.removeFirst();
+        }
+        lines.addLast(line);
+    }
+
+    /**
+     * Returns the recorded gossip lines, oldest first.
+     *
+     * @return an immutable snapshot of the current history; empty when no gossip has been
+     *         recorded yet
+     */
+    public synchronized List<String> recentLines() {
+        return List.copyOf(lines);
+    }
+
+    /**
+     * Renders the history for display to a player right after login: a {@code "Recent
+     * gossip:"} header followed by each recorded line, oldest first. Returns an empty list
+     * (nothing to display) when no gossip has been recorded yet.
+     *
+     * @return the lines to write to the connecting player, or an empty list when history is
+     *         empty
+     */
+    public List<String> renderForLogin() {
+        List<String> history = recentLines();
+        if (history.isEmpty()) {
+            return List.of();
+        }
+        List<String> rendered = new ArrayList<>(history.size() + 1);
+        rendered.add("Recent gossip:");
+        rendered.addAll(history);
+        return List.copyOf(rendered);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
@@ -988,9 +988,11 @@ class SocketCommandContextImpl implements SocketCommandContext {
 
     @Override
     public void gossip(String senderName, String message) {
+        String line = senderName + " gossips: " + message;
+        context.gossipHistory().record(line);
         // Skip the sender — they already see "You gossip: ..." from GossipCommand.
         context.messageBroadcaster().broadcastGlobal(
-            new PlainTextMessage(senderName + " gossips: " + message),
+            new PlainTextMessage(line),
             Set.of(Username.of(senderName))
         );
     }
@@ -1925,6 +1927,8 @@ class SocketCommandContextImpl implements SocketCommandContext {
         session.registerHealing(this::applyHealingUpdate);
         // Enqueue death-state check
         session.enqueueCommand(session::handleDeathState);
+        // Show recent gossip history exactly once, before any other post-login output.
+        sendGossipHistory();
         // Start character creation for brand-new players; dispatch look for returning ones
         if (isNew && context.characterCreationService() != null) {
             client.beginCharacterCreation();
@@ -1932,5 +1936,14 @@ class SocketCommandContextImpl implements SocketCommandContext {
             String correlationId = auditService.newCorrelationId();
             session.enqueueCommand(() -> dispatcher.dispatch(this, "look", correlationId));
         }
+    }
+
+    /**
+     * Shows the server-wide {@link io.taanielo.jmud.core.messaging.GossipHistory} to the
+     * connecting player exactly once, oldest-first, before any other post-login output.
+     * Does nothing when the history is empty.
+     */
+    private void sendGossipHistory() {
+        connection.writeLines(context.gossipHistory().renderForLogin());
     }
 }

--- a/src/test/java/io/taanielo/jmud/core/messaging/GossipHistoryTest.java
+++ b/src/test/java/io/taanielo/jmud/core/messaging/GossipHistoryTest.java
@@ -1,0 +1,93 @@
+package io.taanielo.jmud.core.messaging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link GossipHistory}: recording, bounded eviction, and rendering to a
+ * newly logged-in player without any networking (AGENTS.md §10).
+ */
+class GossipHistoryTest {
+
+    @Test
+    void startsEmpty() {
+        GossipHistory history = new GossipHistory();
+
+        assertTrue(history.recentLines().isEmpty());
+    }
+
+    @Test
+    void recordsLinesInOrder() {
+        GossipHistory history = new GossipHistory();
+
+        history.record("Alice gossips: hello");
+        history.record("Bob gossips: hi there");
+
+        assertEquals(
+            List.of("Alice gossips: hello", "Bob gossips: hi there"),
+            history.recentLines()
+        );
+    }
+
+    @Test
+    void evictsOldestEntryBeyondTenLines() {
+        GossipHistory history = new GossipHistory();
+
+        for (int i = 1; i <= 12; i++) {
+            history.record("Player gossips: line " + i);
+        }
+
+        List<String> lines = history.recentLines();
+        assertEquals(10, lines.size());
+        // Lines 1 and 2 should have been evicted; oldest remaining is line 3.
+        assertEquals("Player gossips: line 3", lines.get(0));
+        assertEquals("Player gossips: line 12", lines.get(9));
+    }
+
+    @Test
+    void ignoresBlankAndNullLines() {
+        GossipHistory history = new GossipHistory();
+
+        history.record(null);
+        history.record("");
+        history.record("   ");
+        history.record("Alice gossips: hello");
+
+        assertEquals(List.of("Alice gossips: hello"), history.recentLines());
+    }
+
+    @Test
+    void recentLinesReturnsImmutableSnapshot() {
+        GossipHistory history = new GossipHistory();
+        history.record("Alice gossips: hello");
+
+        List<String> snapshot = history.recentLines();
+        history.record("Bob gossips: hi");
+
+        assertEquals(1, snapshot.size(), "Previously returned snapshot must not change");
+        assertEquals(2, history.recentLines().size());
+    }
+
+    @Test
+    void renderForLoginReturnsEmptyWhenNoGossipRecorded() {
+        GossipHistory history = new GossipHistory();
+
+        assertTrue(history.renderForLogin().isEmpty());
+    }
+
+    @Test
+    void renderForLoginShowsHeaderThenLinesOldestFirst() {
+        GossipHistory history = new GossipHistory();
+        history.record("Alice gossips: hello");
+        history.record("Bob gossips: hi there");
+
+        assertEquals(
+            List.of("Recent gossip:", "Alice gossips: hello", "Bob gossips: hi there"),
+            history.renderForLogin()
+        );
+    }
+}


### PR DESCRIPTION
Closes #241

Adds a bounded 10-entry GossipHistory ring buffer (io.taanielo.jmud.core.messaging), wires it into GameContext, records broadcast-formatted gossip lines alongside the existing broadcast, and replays the history once on login (no-op if empty).