### PR TITLE
feat(commands): add shout and whisper commands

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,7 +75,7 @@
 - [x] Add SCORE-visible kill counter and a global high-score WHO listing sorted by total kills
 - [x] Add player title system: automatically grant titles (Rat Slayer, Goblin Crusher) on quest completion
 - [x] Add GOSSIP channel history: store the last 10 gossip lines and show them on login
-- [ ] Add SAY emote variants: SHOUT broadcasts to adjacent rooms; WHISPER is visible only to one target
+- [x] Add SAY emote variants: SHOUT broadcasts to adjacent rooms; WHISPER is visible only to one target
 - [ ] Add GIVE command so players can hand items to other players or NPCs in the same room
 - [ ] Add time-of-day tick cycle (day/night) that changes room descriptions and affects mob spawn rates
 - [ ] Add player alias system: ALIAS command lets players bind short custom strings to longer commands

--- a/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
@@ -144,6 +144,7 @@ public record GameContext(
             new PlayerLocationService(roomRepository, RoomId.of("training-yard"));
         RoomService roomService = new RoomService(
             playerLocationService, roomItemService, new RoomRenderer(), roomRepository);
+        MessageBroadcaster messageBroadcaster = new MessageBroadcasterImpl(clientPool, roomService);
 
         TickRegistry tickRegistry = new TickRegistry();
         TickClock tickClock = new TickClock();
@@ -174,8 +175,8 @@ public record GameContext(
         AbilityCostResolver abilityCostResolver = new BasicAbilityCostResolver();
         AbilityTargetResolver abilityTargetResolver = new RoomAbilityTargetResolver(roomService, playerRepository);
 
-        SocketCommandRegistry commandRegistry =
-            SocketCommandRegistry.createDefault(equipmentArmorResolver, raceArmorBonusResolver, playerRepository);
+        SocketCommandRegistry commandRegistry = SocketCommandRegistry.createDefault(
+            equipmentArmorResolver, raceArmorBonusResolver, playerRepository, roomService, messageBroadcaster);
 
         PlayerEventBus playerEventBus = new PlayerEventBus();
         MobRegistry mobRegistry = createMobRegistry(
@@ -199,7 +200,6 @@ public record GameContext(
             mobRegistry.setPartyService(partyService);
         }
 
-        MessageBroadcaster messageBroadcaster = new MessageBroadcasterImpl(clientPool, roomService);
         GossipHistory gossipHistory = new GossipHistory();
 
         gameMetrics.bindGlobalGauges(tickRegistry, clientPool);

--- a/src/main/java/io/taanielo/jmud/core/server/socket/ShoutCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/ShoutCommand.java
@@ -1,0 +1,107 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.messaging.MessageBroadcaster;
+import io.taanielo.jmud.core.messaging.PlainTextMessage;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+
+/**
+ * Handles the {@code SHOUT} command, which is like {@link SayCommand} but is also
+ * audible in every room directly adjacent to the speaker's current room (i.e. reachable
+ * via a single exit), in addition to the speaker's own room.
+ *
+ * <p>Usage: {@code SHOUT <message>}
+ *
+ * <p>Occupants of the speaker's own room see: {@code <Name> shouts "<message>"}
+ * <br>Occupants of adjacent rooms see: {@code You hear <Name> shout "<message>" from nearby.}
+ *
+ * <p>Delivery is fanned out via {@link MessageBroadcaster#broadcastToRoom}, the single
+ * sanctioned multi-recipient delivery path (AGENTS.md §3.3), once per room (the speaker's
+ * own room plus each adjacent room resolved from {@code Room.getExits()}).
+ */
+public class ShoutCommand extends RegistrableCommand {
+
+    private final RoomService roomService;
+    private final MessageBroadcaster messageBroadcaster;
+
+    /**
+     * Creates a {@code ShoutCommand} and registers it with the given registry.
+     *
+     * @param registry           the registry to register this command with
+     * @param roomService        service used to resolve the speaker's room and its exits
+     * @param messageBroadcaster scoped delivery service used to fan out to each room
+     */
+    public ShoutCommand(SocketCommandRegistry registry, RoomService roomService, MessageBroadcaster messageBroadcaster) {
+        super(registry);
+        this.roomService = Objects.requireNonNull(roomService, "Room service is required");
+        this.messageBroadcaster = Objects.requireNonNull(messageBroadcaster, "Message broadcaster is required");
+    }
+
+    @Override
+    public String name() {
+        return "shout";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Speak to your room and every adjacent room.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: SHOUT <message>\n"
+             + "  Sends a message to everyone in your current room, and to everyone in\n"
+             + "  every room reachable via one exit from your room.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"SHOUT".equals(parts[0])) {
+            return Optional.empty();
+        }
+        String message = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> handleShout(context, message)));
+    }
+
+    private void handleShout(SocketCommandContext context, String message) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to speak.");
+            return;
+        }
+        if (message.isEmpty()) {
+            context.writeLineWithPrompt("Shout what?");
+            return;
+        }
+        Player player = context.getPlayer();
+        Username speaker = player.getUsername();
+        String senderName = speaker.getValue();
+
+        Optional<RoomId> currentRoomId = roomService.findPlayerLocation(speaker);
+        if (currentRoomId.isPresent()) {
+            RoomId roomId = currentRoomId.get();
+            Set<Username> exclude = Set.of(speaker);
+            messageBroadcaster.broadcastToRoom(
+                roomId, new PlainTextMessage(senderName + " shouts \"" + message + "\""), exclude);
+
+            Set<RoomId> adjacentRoomIds = new LinkedHashSet<>(roomService.getExits(roomId).values());
+            adjacentRoomIds.remove(roomId);
+            for (RoomId adjacentRoomId : adjacentRoomIds) {
+                messageBroadcaster.broadcastToRoom(
+                    adjacentRoomId,
+                    new PlainTextMessage("You hear " + senderName + " shout \"" + message + "\" from nearby."),
+                    exclude);
+            }
+        }
+
+        context.writeLineSafe("You shout \"" + message + "\"");
+        context.sendPrompt();
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -6,7 +6,9 @@ import java.util.Objects;
 
 import io.taanielo.jmud.core.combat.EquipmentArmorResolver;
 import io.taanielo.jmud.core.combat.RaceArmorBonusResolver;
+import io.taanielo.jmud.core.messaging.MessageBroadcaster;
 import io.taanielo.jmud.core.player.PlayerRepository;
+import io.taanielo.jmud.core.world.RoomService;
 
 /**
  * Registry for socket command handlers.
@@ -24,15 +26,21 @@ public class SocketCommandRegistry {
      * @param equipmentArmorResolver resolver for AC contributed by equipped armour
      * @param raceArmorBonusResolver resolver for AC contributed by the player's race
      * @param playerRepository       repository used to enumerate all persisted players for {@code RANK}
+     * @param roomService            service used to resolve room exits/occupancy for {@code SHOUT}/{@code WHISPER}
+     * @param messageBroadcaster     scoped delivery service used to fan out {@code SHOUT} to nearby rooms
      */
     public static SocketCommandRegistry createDefault(
         EquipmentArmorResolver equipmentArmorResolver,
         RaceArmorBonusResolver raceArmorBonusResolver,
-        PlayerRepository playerRepository
+        PlayerRepository playerRepository,
+        RoomService roomService,
+        MessageBroadcaster messageBroadcaster
     ) {
         Objects.requireNonNull(equipmentArmorResolver, "Equipment armor resolver is required");
         Objects.requireNonNull(raceArmorBonusResolver, "Race armor bonus resolver is required");
         Objects.requireNonNull(playerRepository, "Player repository is required");
+        Objects.requireNonNull(roomService, "Room service is required");
+        Objects.requireNonNull(messageBroadcaster, "Message broadcaster is required");
         SocketCommandRegistry registry = new SocketCommandRegistry();
         new LookCommand(registry);
         new ExamineCommand(registry);
@@ -49,6 +57,8 @@ public class SocketCommandRegistry {
         new SayCommand(registry);
         new EmoteCommand(registry);
         new TellCommand(registry);
+        new WhisperCommand(registry, roomService);
+        new ShoutCommand(registry, roomService, messageBroadcaster);
         new GossipCommand(registry);
         new WhoCommand(registry);
         new RankCommand(registry, playerRepository);

--- a/src/main/java/io/taanielo/jmud/core/server/socket/WhisperCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/WhisperCommand.java
@@ -1,0 +1,109 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+
+/**
+ * Handles the {@code WHISPER} command, which is like {@link TellCommand} but restricted
+ * to a single named target who must currently be in the same room as the sender.
+ *
+ * <p>Usage: {@code WHISPER <playername> <message>}
+ *
+ * <p>The sender sees: {@code You whisper to <Name>: <message>}
+ * <br>The recipient sees: {@code <Name> whispers to you: <message>}
+ *
+ * <p>Errors are reported to the sender when the target player is not online, or is
+ * online but not currently in the same room, or when the command is invoked without
+ * sufficient arguments.
+ */
+public class WhisperCommand extends RegistrableCommand {
+
+    private final RoomService roomService;
+
+    /**
+     * Creates a {@code WhisperCommand} and registers it with the given registry.
+     *
+     * @param registry    the registry to register this command with
+     * @param roomService service used to verify the sender and target share a room
+     */
+    public WhisperCommand(SocketCommandRegistry registry, RoomService roomService) {
+        super(registry);
+        this.roomService = Objects.requireNonNull(roomService, "Room service is required");
+    }
+
+    @Override
+    public String name() {
+        return "whisper";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Send a private message to a player in your room.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: WHISPER <playername> <message>\n"
+             + "  Sends a private message to the named player, who must be in your\n"
+             + "  current room.\n"
+             + "  The recipient sees: <YourName> whispers to you: <message>";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"WHISPER".equals(parts[0])) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> handleWhisper(context, args)));
+    }
+
+    private void handleWhisper(SocketCommandContext context, String args) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to whisper.");
+            return;
+        }
+        if (args.isBlank()) {
+            context.writeLineWithPrompt("Usage: WHISPER <playername> <message>");
+            return;
+        }
+        String[] argParts = args.split("\\s+", 2);
+        String targetName = argParts[0];
+        if (argParts.length < 2 || argParts[1].isBlank()) {
+            context.writeLineWithPrompt("Usage: WHISPER <playername> <message>");
+            return;
+        }
+        String message = argParts[1].trim();
+
+        Player sender = context.getPlayer();
+        String senderName = sender.getUsername().getValue();
+
+        // Find the target among online players (case-insensitive).
+        Username targetUsername = context.onlinePlayerNames().stream()
+                .filter(u -> u.equals(Username.of(targetName)))
+                .findFirst()
+                .orElse(null);
+
+        if (targetUsername == null) {
+            context.writeLineWithPrompt(targetName + " is not here.");
+            return;
+        }
+
+        Optional<RoomId> senderRoom = roomService.findPlayerLocation(sender.getUsername());
+        Optional<RoomId> targetRoom = roomService.findPlayerLocation(targetUsername);
+        if (senderRoom.isEmpty() || targetRoom.isEmpty() || !senderRoom.get().equals(targetRoom.get())) {
+            context.writeLineWithPrompt(targetName + " is not here.");
+            return;
+        }
+
+        context.sendToUsername(targetUsername, senderName + " whispers to you: " + message);
+        context.writeLineSafe("You whisper to " + targetUsername.getValue() + ": " + message);
+        context.sendPrompt();
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/ShoutCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/ShoutCommandTest.java
@@ -1,0 +1,297 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.messaging.Message;
+import io.taanielo.jmud.core.messaging.MessageBroadcaster;
+import io.taanielo.jmud.core.messaging.MessageBroadcasterImpl;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.server.ClientPool;
+import io.taanielo.jmud.core.world.Direction;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Unit tests for {@link ShoutCommand}, exercising real {@link RoomService} and
+ * {@link MessageBroadcaster} wiring so room-adjacency fan-out is verified end to end.
+ */
+class ShoutCommandTest {
+
+    private static final RoomId ROOM_ONE = RoomId.of("room-one");
+    private static final RoomId ROOM_TWO = RoomId.of("room-two");
+    private static final RoomId ROOM_THREE = RoomId.of("room-three");
+    private static final RoomId ROOM_FAR = RoomId.of("room-far");
+
+    // --- token matching ---
+
+    @Test
+    void matchesShoutToken() {
+        RoomService roomService = threeRoomService();
+        MessageBroadcaster broadcaster = new MessageBroadcasterImpl(new FakeClientPool(List.of()), roomService);
+        ShoutCommand cmd = new ShoutCommand(new SocketCommandRegistry(), roomService, broadcaster);
+        assertTrue(cmd.match("SHOUT hello").isPresent());
+        assertTrue(cmd.match("shout hello").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        RoomService roomService = threeRoomService();
+        MessageBroadcaster broadcaster = new MessageBroadcasterImpl(new FakeClientPool(List.of()), roomService);
+        ShoutCommand cmd = new ShoutCommand(new SocketCommandRegistry(), roomService, broadcaster);
+        assertFalse(cmd.match("SAY hello").isPresent());
+        assertFalse(cmd.match("").isPresent());
+    }
+
+    // --- delivery ---
+
+    @Test
+    void deliversToOwnRoomAndAdjacentRooms() {
+        RoomService roomService = threeRoomService();
+        FakeClient speaker = fakeClient("Speaker");
+        FakeClient roommate = fakeClient("Roommate");
+        FakeClient neighbor = fakeClient("Neighbor");
+        FakeClient distant = fakeClient("Distant");
+        roomService.ensurePlayerLocation(speaker.player.getUsername());
+        roomService.ensurePlayerLocation(roommate.player.getUsername());
+        roomService.ensurePlayerLocation(neighbor.player.getUsername());
+        roomService.move(neighbor.player.getUsername(), Direction.NORTH);
+        roomService.ensurePlayerLocation(distant.player.getUsername());
+        roomService.move(distant.player.getUsername(), Direction.EAST);
+        roomService.move(distant.player.getUsername(), Direction.NORTH);
+
+        MessageBroadcaster broadcaster =
+            new MessageBroadcasterImpl(new FakeClientPool(List.of(speaker, roommate, neighbor, distant)), roomService);
+        ShoutCommand cmd = new ShoutCommand(new SocketCommandRegistry(), roomService, broadcaster);
+
+        CapturingContext context = new CapturingContext(speaker.player);
+        cmd.match("SHOUT hello everyone").get().execute(context);
+
+        assertTrue(speaker.received.isEmpty(), "Speaker must not receive their own broadcast");
+        assertEquals(1, roommate.received.size());
+        assertEquals("Speaker shouts \"hello everyone\"", textOf(roommate.received.get(0)));
+        assertEquals(1, neighbor.received.size());
+        assertEquals("You hear Speaker shout \"hello everyone\" from nearby.", textOf(neighbor.received.get(0)));
+        assertTrue(distant.received.isEmpty(), "A room two hops away must not receive the shout");
+    }
+
+    @Test
+    void senderSeesConfirmation() {
+        RoomService roomService = threeRoomService();
+        FakeClient speaker = fakeClient("Speaker");
+        roomService.ensurePlayerLocation(speaker.player.getUsername());
+        MessageBroadcaster broadcaster =
+            new MessageBroadcasterImpl(new FakeClientPool(List.of(speaker)), roomService);
+        ShoutCommand cmd = new ShoutCommand(new SocketCommandRegistry(), roomService, broadcaster);
+
+        CapturingContext context = new CapturingContext(speaker.player);
+        cmd.match("SHOUT hello").get().execute(context);
+
+        assertTrue(context.lines.contains("You shout \"hello\""));
+    }
+
+    @Test
+    void missingMessageReturnsError() {
+        RoomService roomService = threeRoomService();
+        MessageBroadcaster broadcaster = new MessageBroadcasterImpl(new FakeClientPool(List.of()), roomService);
+        ShoutCommand cmd = new ShoutCommand(new SocketCommandRegistry(), roomService, broadcaster);
+
+        CapturingContext context = new CapturingContext(stubPlayer("Speaker"));
+        cmd.match("SHOUT").get().execute(context);
+
+        assertTrue(context.promptMessage.contains("Shout what"));
+    }
+
+    @Test
+    void unauthenticatedUseIsRejected() {
+        RoomService roomService = threeRoomService();
+        MessageBroadcaster broadcaster = new MessageBroadcasterImpl(new FakeClientPool(List.of()), roomService);
+        ShoutCommand cmd = new ShoutCommand(new SocketCommandRegistry(), roomService, broadcaster);
+
+        CapturingContext context = new CapturingContext(null);
+        cmd.match("SHOUT hello").get().execute(context);
+
+        assertTrue(context.promptMessage.contains("logged in"));
+    }
+
+    // --- helpers ---
+
+    private static String textOf(Message message) {
+        StringBuilder captured = new StringBuilder();
+        try {
+            message.send(captured::append);
+        } catch (java.io.IOException e) {
+            throw new AssertionError(e);
+        }
+        return captured.toString().replace("\r\n", "");
+    }
+
+    /** Room one has two adjacent rooms (two/north, three/east) plus a far room two hops away. */
+    private static RoomService threeRoomService() {
+        Room roomOne = new Room(
+            ROOM_ONE,
+            "Room One",
+            "The first room.",
+            Map.of(Direction.NORTH, ROOM_TWO, Direction.EAST, ROOM_THREE),
+            List.of(),
+            List.of()
+        );
+        Room roomTwo = new Room(
+            ROOM_TWO, "Room Two", "The second room.", Map.of(Direction.SOUTH, ROOM_ONE), List.of(), List.of());
+        Room roomThree = new Room(
+            ROOM_THREE,
+            "Room Three",
+            "The third room.",
+            Map.of(Direction.WEST, ROOM_ONE, Direction.NORTH, ROOM_FAR),
+            List.of(),
+            List.of()
+        );
+        Room roomFar = new Room(
+            ROOM_FAR, "Room Far", "A distant room.", Map.of(Direction.SOUTH, ROOM_THREE), List.of(), List.of());
+        RoomRepository repository = new InMemoryRoomRepository(
+            Map.of(ROOM_ONE, roomOne, ROOM_TWO, roomTwo, ROOM_THREE, roomThree, ROOM_FAR, roomFar));
+        return new RoomService(repository, ROOM_ONE);
+    }
+
+    private static FakeClient fakeClient(String username) {
+        return new FakeClient(stubPlayer(username));
+    }
+
+    private static Player stubPlayer(String name) {
+        User user = User.of(Username.of(name), Password.hash("secret"));
+        return Player.of(user, "%h/%H hp>");
+    }
+
+    private static final class FakeClient implements Client {
+        private final Player player;
+        private final List<Message> received = new ArrayList<>();
+
+        private FakeClient(Player player) {
+            this.player = player;
+        }
+
+        @Override
+        public void sendMessage(Message message) {
+            received.add(message);
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public Optional<Player> currentPlayer() {
+            return Optional.of(player);
+        }
+
+        @Override
+        public void run() {
+        }
+    }
+
+    private static final class FakeClientPool implements ClientPool {
+        private final List<Client> clients;
+
+        private FakeClientPool(List<Client> clients) {
+            this.clients = new CopyOnWriteArrayList<>(clients);
+        }
+
+        @Override
+        public void add(Client client) {
+            clients.add(client);
+        }
+
+        @Override
+        public void remove(Client client) {
+            clients.remove(client);
+        }
+
+        @Override
+        public int getNextId() {
+            return clients.size();
+        }
+
+        @Override
+        public List<Client> clients() {
+            return List.copyOf(clients);
+        }
+    }
+
+    private static final class InMemoryRoomRepository implements RoomRepository {
+        private final Map<RoomId, Room> rooms;
+
+        private InMemoryRoomRepository(Map<RoomId, Room> rooms) {
+            this.rooms = rooms;
+        }
+
+        @Override
+        public void save(Room room) throws RepositoryException {
+            // not needed for these tests
+        }
+
+        @Override
+        public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return Optional.ofNullable(rooms.get(id));
+        }
+    }
+
+    private static final class CapturingContext implements SocketCommandContext {
+        final List<String> lines = new ArrayList<>();
+        String promptMessage = "";
+        final Map<String, String> sentToUsername = new HashMap<>();
+        private final Player player;
+
+        CapturingContext(Player player) {
+            this.player = player;
+        }
+
+        @Override public boolean isAuthenticated() { return player != null; }
+        @Override public Player getPlayer() { return player; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) { promptMessage = m; }
+        @Override public void writeLineSafe(String m) { lines.add(m); }
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) { sentToUsername.put(u.getValue().toLowerCase(), m); }
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void readItem(String a) {}
+        @Override public void writeItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/WhisperCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/WhisperCommandTest.java
@@ -1,0 +1,234 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Unit tests for {@link WhisperCommand}.
+ */
+class WhisperCommandTest {
+
+    private static final RoomId ROOM_ONE = RoomId.of("room-one");
+    private static final RoomId ROOM_TWO = RoomId.of("room-two");
+
+    // --- token matching ---
+
+    @Test
+    void matchesWhisperToken() {
+        WhisperCommand cmd = new WhisperCommand(new SocketCommandRegistry(), twoRoomService());
+        assertTrue(cmd.match("WHISPER taaniel hello").isPresent());
+        assertTrue(cmd.match("whisper taaniel hello").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        WhisperCommand cmd = new WhisperCommand(new SocketCommandRegistry(), twoRoomService());
+        assertFalse(cmd.match("TELL hello").isPresent());
+        assertFalse(cmd.match("WHO").isPresent());
+        assertFalse(cmd.match("").isPresent());
+    }
+
+    // --- delivery ---
+
+    @Test
+    void deliversWhisperToRecipientInSameRoom() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext("Sender");
+        context.addOnlinePlayer("Recipient");
+        roomService.ensurePlayerLocation(Username.of("Sender"));
+        roomService.ensurePlayerLocation(Username.of("Recipient"));
+
+        WhisperCommand cmd = new WhisperCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("WHISPER Recipient hello there").get().execute(context);
+
+        assertEquals("Sender whispers to you: hello there",
+                context.sentToUsername.get("recipient"),
+                "Recipient should receive the formatted whisper message");
+    }
+
+    @Test
+    void senderSeesConfirmation() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext("Sender");
+        context.addOnlinePlayer("Recipient");
+        roomService.ensurePlayerLocation(Username.of("Sender"));
+        roomService.ensurePlayerLocation(Username.of("Recipient"));
+
+        WhisperCommand cmd = new WhisperCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("WHISPER Recipient hello there").get().execute(context);
+
+        assertTrue(context.lines.stream().anyMatch(l -> l.equals("You whisper to Recipient: hello there")),
+                "Sender should see confirmation line");
+    }
+
+    @Test
+    void targetNotOnlineReturnsError() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext("Sender");
+        roomService.ensurePlayerLocation(Username.of("Sender"));
+        // No players added — target is offline.
+
+        WhisperCommand cmd = new WhisperCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("WHISPER Ghost hello").get().execute(context);
+
+        assertTrue(context.promptMessage.contains("Ghost") && context.promptMessage.contains("not here"),
+                "Error message should name the missing player");
+    }
+
+    @Test
+    void targetInDifferentRoomReturnsError() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext("Sender");
+        context.addOnlinePlayer("Recipient");
+        roomService.ensurePlayerLocation(Username.of("Sender"));
+        roomService.ensurePlayerLocation(Username.of("Recipient"));
+        roomService.move(Username.of("Recipient"), Direction.NORTH);
+
+        WhisperCommand cmd = new WhisperCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("WHISPER Recipient hello").get().execute(context);
+
+        assertTrue(context.promptMessage.contains("Recipient") && context.promptMessage.contains("not here"),
+                "Error message should indicate the target is not in this room");
+        assertTrue(context.sentToUsername.isEmpty(), "Message must not be delivered across rooms");
+    }
+
+    @Test
+    void missingMessageReturnsUsageError() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext("Sender");
+        context.addOnlinePlayer("Recipient");
+
+        WhisperCommand cmd = new WhisperCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("WHISPER Recipient").get().execute(context);
+
+        assertFalse(context.promptMessage.isBlank(), "Usage error should be written via writeLineWithPrompt");
+        assertTrue(context.promptMessage.contains("Usage"), "Error should mention usage");
+    }
+
+    @Test
+    void missingAllArgsReturnsUsageError() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext("Sender");
+
+        WhisperCommand cmd = new WhisperCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("WHISPER").get().execute(context);
+
+        assertFalse(context.promptMessage.isBlank(), "Usage error should be written via writeLineWithPrompt");
+        assertTrue(context.promptMessage.contains("Usage"), "Error should mention usage");
+    }
+
+    @Test
+    void unauthenticatedUseIsRejected() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext(null);
+
+        WhisperCommand cmd = new WhisperCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("WHISPER Recipient hello").get().execute(context);
+
+        assertTrue(context.promptMessage.contains("logged in"));
+    }
+
+    // --- helpers ---
+
+    /** Two adjacent rooms (ROOM_ONE --north--> ROOM_TWO), starting room is ROOM_ONE. */
+    private static RoomService twoRoomService() {
+        Room roomOne = new Room(
+            ROOM_ONE, "Room One", "The first room.", Map.of(Direction.NORTH, ROOM_TWO), List.of(), List.of());
+        Room roomTwo = new Room(
+            ROOM_TWO, "Room Two", "The second room.", Map.of(Direction.SOUTH, ROOM_ONE), List.of(), List.of());
+        RoomRepository repository = new InMemoryRoomRepository(Map.of(ROOM_ONE, roomOne, ROOM_TWO, roomTwo));
+        return new RoomService(repository, ROOM_ONE);
+    }
+
+    private static Player stubPlayer(String name) {
+        User user = User.of(Username.of(name), Password.hash("secret"));
+        return Player.of(user, "%h/%H hp>");
+    }
+
+    private static final class InMemoryRoomRepository implements RoomRepository {
+        private final Map<RoomId, Room> rooms;
+
+        private InMemoryRoomRepository(Map<RoomId, Room> rooms) {
+            this.rooms = rooms;
+        }
+
+        @Override
+        public void save(Room room) throws RepositoryException {
+            // not needed for these tests
+        }
+
+        @Override
+        public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return Optional.ofNullable(rooms.get(id));
+        }
+    }
+
+    private static final class CapturingContext implements SocketCommandContext {
+        final List<String> lines = new ArrayList<>();
+        String promptMessage = "";
+        final Map<String, String> sentToUsername = new HashMap<>();
+        private final List<Username> onlinePlayers = new ArrayList<>();
+        private final Player player;
+
+        CapturingContext(String senderName) {
+            this.player = senderName == null ? null : stubPlayer(senderName);
+        }
+
+        void addOnlinePlayer(String name) {
+            onlinePlayers.add(Username.of(name));
+        }
+
+        @Override public boolean isAuthenticated() { return player != null; }
+        @Override public Player getPlayer() { return player; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.copyOf(onlinePlayers); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) { promptMessage = m; }
+        @Override public void writeLineSafe(String m) { lines.add(m); }
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) { sentToUsername.put(u.getValue().toLowerCase(), m); }
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void readItem(String a) {}
+        @Override public void writeItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}


### PR DESCRIPTION
Closes #243

Implements SHOUT (room + adjacent rooms broadcast) and WHISPER (same-room private message) commands.

- New `ShoutCommand` and `WhisperCommand` (`io.taanielo.jmud.core.server.socket`), constructor-injected with `RoomService`/`MessageBroadcaster`.
- `SocketCommandRegistry.createDefault(...)` gained `RoomService` and `MessageBroadcaster` parameters.
- `GameContext` reorders `MessageBroadcaster` construction earlier and removes a duplicate later construction.
- New tests: `ShoutCommandTest`, `WhisperCommandTest`.
- `TODO.md` line 78 checked off.

Verified with `./gradlew check` (compile, tests, spotless, jacoco coverage, ArchUnit) and the e2e smoke test (`scripts/smoke-test.sh`).