### PR TITLE
feat(command): add GIVE command to hand items to another player

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -76,6 +76,6 @@
 - [x] Add player title system: automatically grant titles (Rat Slayer, Goblin Crusher) on quest completion
 - [x] Add GOSSIP channel history: store the last 10 gossip lines and show them on login
 - [x] Add SAY emote variants: SHOUT broadcasts to adjacent rooms; WHISPER is visible only to one target
-- [ ] Add GIVE command so players can hand items to other players or NPCs in the same room
+- [x] Add GIVE command so players can hand items to other players or NPCs in the same room
 - [ ] Add time-of-day tick cycle (day/night) that changes room descriptions and affects mob spawn rates
 - [ ] Add player alias system: ALIAS command lets players bind short custom strings to longer commands

--- a/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
+++ b/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
@@ -314,6 +314,63 @@ public class GameActionService {
     }
 
     /**
+     * Gives an item from the source player's inventory to another player in the same room.
+     *
+     * <p>The item is removed from the source's inventory (unequipping it first if worn, matching
+     * {@link #dropItem}'s behavior) and added to the recipient's inventory. Fails without any
+     * state change if the item is not in the source's inventory, or if giving it would leave the
+     * recipient {@linkplain EncumbranceService#isOverburdened(Player) overburdened}.
+     *
+     * @param source the player giving the item
+     * @param target the recipient player, already confirmed to be online and in the same room
+     * @param itemInput the item name or id to give
+     * @return result with updated source and target inventories
+     */
+    public GameActionResult giveItem(Player source, Player target, String itemInput) {
+        if (target == null) {
+            return GameActionResult.error("That player is not here.");
+        }
+        String normalized = itemInput == null ? "" : itemInput.trim();
+        if (normalized.isEmpty()) {
+            return GameActionResult.error("Give what?");
+        }
+        if (target.getUsername().equals(source.getUsername())) {
+            return GameActionResult.error("You cannot give an item to yourself.");
+        }
+        Item item = findInventoryItem(source, normalized);
+        if (item == null) {
+            return GameActionResult.error("You aren't carrying that.");
+        }
+        Player updatedTarget = target.addItem(item);
+        if (encumbranceService.isOverburdened(updatedTarget)) {
+            return GameActionResult.error(target.getUsername().getValue() + " cannot carry any more.");
+        }
+        PlayerEquipment equipment = source.getEquipment();
+        if (equipment.isEquipped(item.getId())) {
+            EquipmentSlot slot = equipment.equippedSlot(item.getId());
+            if (slot != null) {
+                equipment = equipment.unequip(slot);
+            }
+        }
+        Player updatedSource = source.removeItem(item).withEquipment(equipment);
+
+        String targetName = target.getUsername().getValue();
+        List<GameMessage> messages = new ArrayList<>();
+        messages.add(GameMessage.toSource("You give " + item.getName() + " to " + targetName + "."));
+        messages.add(GameMessage.toPlayer(
+            target.getUsername(),
+            source.getUsername().getValue() + " gives you " + item.getName() + "."
+        ));
+        messages.add(GameMessage.toRoom(
+            source.getUsername(),
+            target.getUsername(),
+            source.getUsername().getValue() + " gives " + item.getName() + " to " + targetName + "."
+        ));
+
+        return new GameActionResult(updatedSource, updatedTarget, messages);
+    }
+
+    /**
      * Consumes an item from inventory, applying its hp stat and any item effects to the player.
      *
      * <p>A positive {@code hp} stat in {@link io.taanielo.jmud.core.world.ItemAttributes} heals

--- a/src/main/java/io/taanielo/jmud/core/server/socket/GiveCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/GiveCommand.java
@@ -1,0 +1,104 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+
+/**
+ * Handles the {@code GIVE} command, which hands an item from the player's inventory to another
+ * player currently in the same room.
+ *
+ * <p>Usage: {@code GIVE <playername> <itemname>}
+ *
+ * <p>The target player must be online and in the sender's current room (the same same-room check
+ * pattern used by {@link WhisperCommand}), otherwise the sender sees {@code <name> is not here.}
+ * The actual item transfer (removing the item from the sender's inventory, unequipping it first
+ * if worn, and adding it to the recipient's inventory) is delegated to
+ * {@code GameActionService.giveItem} via {@link SocketCommandContext#giveItem}.
+ */
+public class GiveCommand extends RegistrableCommand {
+
+    private final RoomService roomService;
+
+    /**
+     * Creates a {@code GiveCommand} and registers it with the given registry.
+     *
+     * @param registry    the registry to register this command with
+     * @param roomService service used to verify the sender and target share a room
+     */
+    public GiveCommand(SocketCommandRegistry registry, RoomService roomService) {
+        super(registry);
+        this.roomService = Objects.requireNonNull(roomService, "Room service is required");
+    }
+
+    @Override
+    public String name() {
+        return "give";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Give an item from your inventory to a player in your room.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: GIVE <playername> <itemname>\n"
+             + "  Hands the named item from your inventory to the named player, who\n"
+             + "  must be in your current room.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String[] parts = SocketCommandParsing.splitInput(input);
+        if (!"GIVE".equals(parts[0])) {
+            return Optional.empty();
+        }
+        String args = parts[1];
+        return Optional.of(new SocketCommandMatch(this, context -> handleGive(context, args)));
+    }
+
+    private void handleGive(SocketCommandContext context, String args) {
+        if (!context.isAuthenticated() || context.getPlayer() == null) {
+            context.writeLineWithPrompt("You must be logged in to give items.");
+            return;
+        }
+        if (args.isBlank()) {
+            context.writeLineWithPrompt("Usage: GIVE <playername> <itemname>");
+            return;
+        }
+        String[] argParts = args.split("\\s+", 2);
+        String targetName = argParts[0];
+        if (argParts.length < 2 || argParts[1].isBlank()) {
+            context.writeLineWithPrompt("Usage: GIVE <playername> <itemname>");
+            return;
+        }
+        String itemInput = argParts[1].trim();
+
+        Player sender = context.getPlayer();
+
+        // Find the target among online players (case-insensitive).
+        Username targetUsername = context.onlinePlayerNames().stream()
+                .filter(u -> u.equals(Username.of(targetName)))
+                .findFirst()
+                .orElse(null);
+
+        if (targetUsername == null) {
+            context.writeLineWithPrompt(targetName + " is not here.");
+            return;
+        }
+
+        Optional<RoomId> senderRoom = roomService.findPlayerLocation(sender.getUsername());
+        Optional<RoomId> targetRoom = roomService.findPlayerLocation(targetUsername);
+        if (senderRoom.isEmpty() || targetRoom.isEmpty() || !senderRoom.get().equals(targetRoom.get())) {
+            context.writeLineWithPrompt(targetName + " is not here.");
+            return;
+        }
+
+        context.giveItem(targetUsername, itemInput);
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -126,6 +126,23 @@ public interface SocketCommandContext extends Client {
     void dropItem(String args);
 
     /**
+     * Gives an item from the player's inventory to an already-resolved target player.
+     *
+     * <p>The caller ({@link GiveCommand}) is responsible for confirming the target is online
+     * and currently in the same room before calling this method; this method resolves the
+     * target's live in-session state, hands off to {@code GameActionService.giveItem}, and
+     * delivers the resulting messages/state updates. Fails with an explanatory message if the
+     * named item is not in the giver's inventory, or if the recipient would become overburdened.
+     *
+     * <p>The default implementation is a no-op so that existing test stubs do not need to be
+     * updated.
+     *
+     * @param targetUsername the recipient, already confirmed online and in the same room
+     * @param itemInput the item name or id to give
+     */
+    default void giveItem(Username targetUsername, String itemInput) {}
+
+    /**
      * Executes a quaff command with the provided arguments.
      */
     void quaffItem(String args);

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
@@ -846,6 +846,41 @@ class SocketCommandContextImpl implements SocketCommandContext {
     }
 
     @Override
+    public void giveItem(Username targetUsername, String itemInput) {
+        if (!session.isAuthenticated() || session.getPlayer() == null) {
+            writeLineWithPrompt("You must be logged in to give items.");
+            return;
+        }
+        cancelRestIfActive();
+        Player source = session.getPlayer();
+        Player target = findOnlinePlayer(targetUsername);
+        if (target == null) {
+            writeLineWithPrompt(targetUsername.getValue() + " is not here.");
+            return;
+        }
+
+        GameActionResult result = gameActionService.giveItem(source, target, itemInput);
+        deliverResult(result);
+        sendPrompt();
+    }
+
+    /**
+     * Looks up the live in-session {@link Player} for a connected username, searching the
+     * client pool rather than the repository so the caller sees the most current state.
+     *
+     * @param username the username to look up
+     * @return the connected player, or {@code null} if no client is authenticated as that user
+     */
+    private @Nullable Player findOnlinePlayer(Username username) {
+        for (Client c : clientPool.clients()) {
+            if (c instanceof SocketClient sc && sc.isAuthenticatedUser(username)) {
+                return sc.session().getPlayer();
+            }
+        }
+        return null;
+    }
+
+    @Override
     public void quaffItem(String args) {
         if (!session.isAuthenticated() || session.getPlayer() == null) {
             writeLineWithPrompt("You must be logged in to quaff.");

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -47,6 +47,7 @@ public class SocketCommandRegistry {
         new MoveCommand(registry);
         new GetCommand(registry);
         new DropCommand(registry);
+        new GiveCommand(registry, roomService);
         new QuaffCommand(registry);
         new ReadCommand(registry);
         new WriteCommand(registry);

--- a/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
@@ -1,6 +1,7 @@
 package io.taanielo.jmud.core.action;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -256,6 +257,113 @@ class GameActionServiceTest {
                 && message.text().equals("attacker drops Torch.")
         ));
         assertTrue(result.updatedSource().getInventory().isEmpty());
+    }
+
+    @Test
+    void giveItemReturnsErrorWhenTargetIsNull() {
+        GameActionResult result = service.giveItem(attacker, null, "torch");
+        assertEquals("That player is not here.", result.messages().getFirst().text());
+    }
+
+    @Test
+    void giveItemReturnsErrorOnEmptyInput() {
+        GameActionResult result = service.giveItem(attacker, target, "");
+        assertEquals("Give what?", result.messages().getFirst().text());
+    }
+
+    @Test
+    void giveItemReturnsErrorWhenNotCarrying() {
+        GameActionResult result = service.giveItem(attacker, target, "torch");
+        assertEquals("You aren't carrying that.", result.messages().getFirst().text());
+    }
+
+    @Test
+    void giveItemReturnsErrorOnSelfTarget() {
+        Item torch = torchItem();
+        Player withItem = attacker.addItem(torch);
+
+        GameActionResult result = service.giveItem(withItem, withItem, "torch");
+        assertEquals("You cannot give an item to yourself.", result.messages().getFirst().text());
+    }
+
+    @Test
+    void giveItemTransfersItemBetweenPlayers() {
+        Item torch = torchItem();
+        Player withItem = attacker.addItem(torch);
+
+        GameActionResult result = service.giveItem(withItem, target, "torch");
+
+        assertEquals("You give Torch to target.", result.messages().getFirst().text());
+        assertTrue(result.messages().stream().anyMatch(message ->
+            message.type() == GameMessage.Type.PLAYER
+                && message.text().equals("attacker gives you Torch.")
+        ));
+        assertTrue(result.messages().stream().anyMatch(message ->
+            message.type() == GameMessage.Type.ROOM
+                && message.text().equals("attacker gives Torch to target.")
+        ));
+        assertTrue(result.updatedSource().getInventory().isEmpty());
+        assertTrue(result.updatedTarget().getInventory().stream()
+            .anyMatch(i -> i.getId().equals(ItemId.of("torch"))));
+    }
+
+    @Test
+    void giveItemUnequipsWornItemBeforeGiving() {
+        Item torch = torchItem();
+        Player withItem = attacker.addItem(torch);
+        Player equipped = withItem.withEquipment(
+            withItem.getEquipment().equip(io.taanielo.jmud.core.world.EquipmentSlot.WEAPON, torch.getId())
+        );
+        assertTrue(equipped.getEquipment().isEquipped(torch.getId()));
+
+        GameActionResult result = service.giveItem(equipped, target, "torch");
+
+        assertTrue(result.updatedSource().getInventory().isEmpty());
+        assertFalse(result.updatedSource().getEquipment().isEquipped(torch.getId()));
+    }
+
+    @Test
+    void giveItemFailsWhenRecipientWouldBeOverburdened() {
+        Item torch = torchItem();
+        Player withItem = attacker.addItem(torch);
+        service = new GameActionService(
+            testAbilityRegistry(), new BasicAbilityCostResolver(),
+            new EffectEngine(new StubEffectRepository(Map.of())),
+            new CombatEngine(
+                new StubAttackRepository(Map.of()),
+                new CombatModifierResolver(new StubEffectRepository(Map.of())),
+                new FixedCombatRandom(1)
+            ),
+            roomService,
+            (source, input) -> Optional.empty(),
+            new TestCooldowns(),
+            new EncumbranceService(new StubRaceRepository(), new StubClassRepository()) {
+                @Override
+                public boolean isOverburdened(Player player) {
+                    return player.getUsername().equals(target.getUsername());
+                }
+            }
+        );
+
+        GameActionResult result = service.giveItem(withItem, target, "torch");
+
+        assertEquals("target cannot carry any more.", result.messages().getFirst().text());
+        assertTrue(withItem.getInventory().stream().anyMatch(i -> i.getId().equals(ItemId.of("torch"))));
+    }
+
+    private static Item torchItem() {
+        return new Item(
+            ItemId.of("torch"),
+            "Torch",
+            "A warm torch.",
+            ItemAttributes.empty(),
+            List.of(),
+            List.of(),
+            io.taanielo.jmud.core.world.EquipmentSlot.WEAPON,
+            1,
+            5,
+            null
+        );
     }
 
     @Test

--- a/src/test/java/io/taanielo/jmud/core/server/socket/GiveCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/GiveCommandTest.java
@@ -1,0 +1,224 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Password;
+import io.taanielo.jmud.core.authentication.User;
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+import io.taanielo.jmud.core.world.Room;
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.repository.RepositoryException;
+import io.taanielo.jmud.core.world.repository.RoomRepository;
+
+/**
+ * Unit tests for {@link GiveCommand}.
+ */
+class GiveCommandTest {
+
+    private static final RoomId ROOM_ONE = RoomId.of("room-one");
+    private static final RoomId ROOM_TWO = RoomId.of("room-two");
+
+    // --- token matching ---
+
+    @Test
+    void matchesGiveToken() {
+        GiveCommand cmd = new GiveCommand(new SocketCommandRegistry(), twoRoomService());
+        assertTrue(cmd.match("GIVE taaniel torch").isPresent());
+        assertTrue(cmd.match("give taaniel torch").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        GiveCommand cmd = new GiveCommand(new SocketCommandRegistry(), twoRoomService());
+        assertFalse(cmd.match("DROP torch").isPresent());
+        assertFalse(cmd.match("WHO").isPresent());
+        assertFalse(cmd.match("").isPresent());
+    }
+
+    // --- resolution / delegation ---
+
+    @Test
+    void delegatesToContextWhenTargetOnlineAndInSameRoom() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext("Sender");
+        context.addOnlinePlayer("Recipient");
+        roomService.ensurePlayerLocation(Username.of("Sender"));
+        roomService.ensurePlayerLocation(Username.of("Recipient"));
+
+        GiveCommand cmd = new GiveCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("GIVE Recipient a torch").get().execute(context);
+
+        assertEquals(Username.of("Recipient"), context.givenTo);
+        assertEquals("a torch", context.givenItem);
+    }
+
+    @Test
+    void targetNotOnlineReturnsError() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext("Sender");
+        roomService.ensurePlayerLocation(Username.of("Sender"));
+        // No players added — target is offline.
+
+        GiveCommand cmd = new GiveCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("GIVE Ghost torch").get().execute(context);
+
+        assertTrue(context.promptMessage.contains("Ghost") && context.promptMessage.contains("not here"),
+                "Error message should name the missing player");
+        assertNull(context.givenTo, "Item transfer must not be delegated when target is offline");
+    }
+
+    @Test
+    void targetInDifferentRoomReturnsError() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext("Sender");
+        context.addOnlinePlayer("Recipient");
+        roomService.ensurePlayerLocation(Username.of("Sender"));
+        roomService.ensurePlayerLocation(Username.of("Recipient"));
+        roomService.move(Username.of("Recipient"), Direction.NORTH);
+
+        GiveCommand cmd = new GiveCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("GIVE Recipient torch").get().execute(context);
+
+        assertTrue(context.promptMessage.contains("Recipient") && context.promptMessage.contains("not here"),
+                "Error message should indicate the target is not in this room");
+        assertNull(context.givenTo, "Item transfer must not be delegated across rooms");
+    }
+
+    @Test
+    void missingItemNameReturnsUsageError() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext("Sender");
+        context.addOnlinePlayer("Recipient");
+
+        GiveCommand cmd = new GiveCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("GIVE Recipient").get().execute(context);
+
+        assertFalse(context.promptMessage.isBlank(), "Usage error should be written via writeLineWithPrompt");
+        assertTrue(context.promptMessage.contains("Usage"), "Error should mention usage");
+    }
+
+    @Test
+    void missingAllArgsReturnsUsageError() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext("Sender");
+
+        GiveCommand cmd = new GiveCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("GIVE").get().execute(context);
+
+        assertFalse(context.promptMessage.isBlank(), "Usage error should be written via writeLineWithPrompt");
+        assertTrue(context.promptMessage.contains("Usage"), "Error should mention usage");
+    }
+
+    @Test
+    void unauthenticatedUseIsRejected() {
+        RoomService roomService = twoRoomService();
+        CapturingContext context = new CapturingContext(null);
+
+        GiveCommand cmd = new GiveCommand(new SocketCommandRegistry(), roomService);
+        cmd.match("GIVE Recipient torch").get().execute(context);
+
+        assertTrue(context.promptMessage.contains("logged in"));
+    }
+
+    // --- helpers ---
+
+    /** Two adjacent rooms (ROOM_ONE --north--> ROOM_TWO), starting room is ROOM_ONE. */
+    private static RoomService twoRoomService() {
+        Room roomOne = new Room(
+            ROOM_ONE, "Room One", "The first room.", Map.of(Direction.NORTH, ROOM_TWO), List.of(), List.of());
+        Room roomTwo = new Room(
+            ROOM_TWO, "Room Two", "The second room.", Map.of(Direction.SOUTH, ROOM_ONE), List.of(), List.of());
+        RoomRepository repository = new InMemoryRoomRepository(Map.of(ROOM_ONE, roomOne, ROOM_TWO, roomTwo));
+        return new RoomService(repository, ROOM_ONE);
+    }
+
+    private static Player stubPlayer(String name) {
+        User user = User.of(Username.of(name), Password.hash("secret"));
+        return Player.of(user, "%h/%H hp>");
+    }
+
+    private static final class InMemoryRoomRepository implements RoomRepository {
+        private final Map<RoomId, Room> rooms;
+
+        private InMemoryRoomRepository(Map<RoomId, Room> rooms) {
+            this.rooms = rooms;
+        }
+
+        @Override
+        public void save(Room room) throws RepositoryException {
+            // not needed for these tests
+        }
+
+        @Override
+        public Optional<Room> findById(RoomId id) throws RepositoryException {
+            return Optional.ofNullable(rooms.get(id));
+        }
+    }
+
+    private static final class CapturingContext implements SocketCommandContext {
+        final List<String> lines = new ArrayList<>();
+        String promptMessage = "";
+        Username givenTo;
+        String givenItem;
+        private final List<Username> onlinePlayers = new ArrayList<>();
+        private final Player player;
+
+        CapturingContext(String senderName) {
+            this.player = senderName == null ? null : stubPlayer(senderName);
+        }
+
+        void addOnlinePlayer(String name) {
+            onlinePlayers.add(Username.of(name));
+        }
+
+        @Override public boolean isAuthenticated() { return player != null; }
+        @Override public Player getPlayer() { return player; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.copyOf(onlinePlayers); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) { promptMessage = m; }
+        @Override public void writeLineSafe(String m) { lines.add(m); }
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) {}
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void giveItem(Username targetUsername, String itemInput) {
+            this.givenTo = targetUsername;
+            this.givenItem = itemInput;
+        }
+        @Override public void quaffItem(String a) {}
+        @Override public void readItem(String a) {}
+        @Override public void writeItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}


### PR DESCRIPTION
Closes #245

Adds a GIVE command allowing a player to hand a carried item to another player in the same room.

- New `GiveCommand` (constructor-injects `RoomService`, mirroring `WhisperCommand`)
- `SocketCommandContext.giveItem(Username, String)` default no-op method
- `SocketCommandContextImpl.giveItem` implementation using existing `deliverResult(...)` machinery
- `SocketCommandRegistry` registers `GiveCommand`
- `GameActionService.giveItem(Player source, Player target, String itemInput)` validates the carried item, checks recipient encumbrance, unequips if worn, and returns a `GameActionResult`
- New tests: `GiveCommandTest`, plus `GameActionServiceTest` cases for successful give, self-target, not-carrying, unequip-on-give, and recipient-overburdened
- `TODO.md` line checked off

`./gradlew check` and `scripts/smoke-test.sh` both pass.