### PR TITLE
feat(world): add tick-based day/night world clock

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -77,5 +77,5 @@
 - [x] Add GOSSIP channel history: store the last 10 gossip lines and show them on login
 - [x] Add SAY emote variants: SHOUT broadcasts to adjacent rooms; WHISPER is visible only to one target
 - [x] Add GIVE command so players can hand items to other players or NPCs in the same room
-- [ ] Add time-of-day tick cycle (day/night) that changes room descriptions and affects mob spawn rates
+- [x] Add time-of-day tick cycle (day/night) that changes room descriptions and affects mob spawn rates
 - [ ] Add player alias system: ALIAS command lets players bind short custom strings to longer commands

--- a/data/mobs/bandit-captain.json
+++ b/data/mobs/bandit-captain.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "bandit-captain",
   "name": "Bandit Captain",
   "max_hp": 100,

--- a/data/mobs/bandit.json
+++ b/data/mobs/bandit.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "bandit",
   "name": "Bandit",
   "max_hp": 50,

--- a/data/mobs/crypt-warden.json
+++ b/data/mobs/crypt-warden.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "crypt-warden",
   "name": "Crypt Warden",
   "max_hp": 40,

--- a/data/mobs/dire-wolf.json
+++ b/data/mobs/dire-wolf.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "dire-wolf",
   "name": "Dire Wolf",
   "max_hp": 55,

--- a/data/mobs/forest-troll.json
+++ b/data/mobs/forest-troll.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "forest-troll",
   "name": "Forest Troll",
   "max_hp": 90,

--- a/data/mobs/giant-spider.json
+++ b/data/mobs/giant-spider.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "giant-spider",
   "name": "Giant Spider",
   "max_hp": 14,

--- a/data/mobs/goblin.json
+++ b/data/mobs/goblin.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "goblin",
   "name": "Goblin",
   "max_hp": 15,

--- a/data/mobs/kobold.json
+++ b/data/mobs/kobold.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "kobold",
   "name": "Kobold",
   "max_hp": 12,

--- a/data/mobs/plague-rat.json
+++ b/data/mobs/plague-rat.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "plague-rat",
   "name": "Plague Rat",
   "max_hp": 38,

--- a/data/mobs/rat.json
+++ b/data/mobs/rat.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "rat",
   "name": "Giant Rat",
   "max_hp": 8,

--- a/data/mobs/skeleton.json
+++ b/data/mobs/skeleton.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "skeleton",
   "name": "Skeleton",
   "max_hp": 20,

--- a/data/mobs/slime.json
+++ b/data/mobs/slime.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "slime",
   "name": "Slime",
   "max_hp": 48,

--- a/data/mobs/trainer.json
+++ b/data/mobs/trainer.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "trainer",
   "name": "Master Trainer",
   "max_hp": 9999,

--- a/data/mobs/training-dummy.json
+++ b/data/mobs/training-dummy.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "training-dummy",
   "name": "Training Dummy",
   "max_hp": 100,

--- a/data/mobs/wolf.json
+++ b/data/mobs/wolf.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "id": "wolf",
   "name": "Wolf",
   "max_hp": 30,
@@ -8,6 +8,7 @@
   "spawn_room_id": "hunters-clearing",
   "max_count": 3,
   "respawn_ticks": 20,
+  "night_respawn_ticks": 10,
   "loot": [
     {
       "item_id": "wolf-pelt",

--- a/docs/schemas/mob.v3.json
+++ b/docs/schemas/mob.v3.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "jmud:mob:v3",
+  "title": "Mob template (v3)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "name",
+    "max_hp",
+    "spawn_room_id",
+    "max_count",
+    "respawn_ticks"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 3
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "max_hp": {
+      "type": "integer",
+      "exclusiveMinimum": 0
+    },
+    "attack_id": {
+      "type": ["string", "null"]
+    },
+    "special_attack_id": {
+      "type": ["string", "null"],
+      "description": "Optional rarer/harder-hitting attack usable at most once per combat encounter."
+    },
+    "aggressive": {
+      "type": "boolean",
+      "default": true
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "loot": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["item_id", "drop_chance"],
+        "properties": {
+          "item_id": { "type": "string" },
+          "drop_chance": { "type": "number", "minimum": 0, "maximum": 1 }
+        }
+      }
+    },
+    "spawn_room_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "max_count": {
+      "type": "integer",
+      "exclusiveMinimum": 0
+    },
+    "respawn_ticks": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "night_respawn_ticks": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional respawn delay (in ticks) used instead of 'respawn_ticks' while the world clock is at night. Omit for no change at night."
+    },
+    "xp_reward": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "gold_drop": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "min": { "type": "integer", "minimum": 0 },
+        "max": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "wanders": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true the mob may randomly wander between linked rooms each tick. NPCs (tag 'npc') never wander."
+    }
+  }
+}

--- a/docs/schemas/room.v5.json
+++ b/docs/schemas/room.v5.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "jmud:room:v5",
+  "title": "Room (v5)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "name",
+    "description",
+    "item_ids"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 5
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "item_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9-]+$"
+      }
+    },
+    "exits": {
+      "type": "object",
+      "description": "Optional map of direction (north/south/east/west/up/down) to destination room id.",
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[a-z0-9-]+$"
+      }
+    },
+    "locked_exits": {
+      "type": "object",
+      "description": "Optional map of direction to the item id of the key required to unlock that exit.",
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[a-z0-9-]+$"
+      }
+    },
+    "min_level": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional recommended/minimum level to enter this room. Advisory only: it never blocks movement, it only triggers a warning message to players below this level. Omit for no restriction."
+    },
+    "night_description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional alternate description shown instead of 'description' when the world clock is at night. Omit for no change at night."
+    }
+  }
+}

--- a/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
@@ -71,6 +71,8 @@ import io.taanielo.jmud.core.world.RoomId;
 import io.taanielo.jmud.core.world.RoomItemService;
 import io.taanielo.jmud.core.world.RoomRenderer;
 import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.WorldClock;
+import io.taanielo.jmud.core.world.WorldClockSettings;
 import io.taanielo.jmud.core.world.repository.ItemRepository;
 import io.taanielo.jmud.core.world.repository.RepositoryException;
 import io.taanielo.jmud.core.world.repository.RoomRepository;
@@ -111,7 +113,8 @@ public record GameContext(
     PartyService partyService,
     BankService bankService,
     MessageBroadcaster messageBroadcaster,
-    GossipHistory gossipHistory
+    GossipHistory gossipHistory,
+    WorldClock worldClock
 ) {
 
     /**
@@ -153,6 +156,9 @@ public record GameContext(
             roomItemService,
             java.time.Duration.ofSeconds(DeathSettings.corpseDecaySeconds())
         ));
+        WorldClock worldClock = new WorldClock(WorldClockSettings.ticksPerPhase());
+        tickRegistry.register(worldClock);
+        roomService.setWorldClock(worldClock);
         FixedRateTickScheduler tickScheduler = new FixedRateTickScheduler(tickRegistry, gameMetrics.registry());
 
         AbilityRegistry abilityRegistry = loadAbilities();
@@ -183,6 +189,7 @@ public record GameContext(
                 playerEventBus, roomService, playerRepository, persistenceQueue, itemRepository, attackRepository);
         if (mobRegistry != null) {
             mobRegistry.setEffectEngine(effectEngine);
+            mobRegistry.setWorldClock(worldClock);
             mobRegistry.init();
             tickRegistry.register(mobRegistry);
         }
@@ -234,7 +241,8 @@ public record GameContext(
             partyService,
             bankService,
             messageBroadcaster,
-            gossipHistory
+            gossipHistory,
+            worldClock
         );
     }
 

--- a/src/main/java/io/taanielo/jmud/core/mob/MobInstance.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobInstance.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.taanielo.jmud.core.authentication.Username;
 import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.TimeOfDay;
 
 /**
  * A live mob instance in the world.
@@ -80,9 +81,14 @@ public class MobInstance {
         return hp.updateAndGet(current -> Math.max(0, current - amount));
     }
 
-    /** Called once when the mob dies — starts the respawn countdown. */
-    public void scheduleRespawn() {
-        respawnTicksRemaining.set(template.respawnTicks());
+    /**
+     * Called once when the mob dies — starts the respawn countdown, using the day or night
+     * respawn delay from {@link MobTemplate#respawnTicks(TimeOfDay)} as appropriate.
+     *
+     * @param timeOfDay the current time of day, used to pick the respawn delay
+     */
+    public void scheduleRespawn(TimeOfDay timeOfDay) {
+        respawnTicksRemaining.set(template.respawnTicks(timeOfDay));
     }
 
     /**

--- a/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobRegistry.java
@@ -44,6 +44,8 @@ import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.RoomId;
 import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.TimeOfDay;
+import io.taanielo.jmud.core.world.WorldClock;
 import io.taanielo.jmud.core.world.repository.ItemRepository;
 import io.taanielo.jmud.core.world.repository.RepositoryException;
 
@@ -71,6 +73,8 @@ public class MobRegistry implements Tickable {
     private PartyService partyService;
     /** Optional effect engine used to apply on-hit status effects (e.g. poison); may be null when disabled. */
     private EffectEngine effectEngine;
+    /** Optional world clock used to pick day/night respawn delays; may be null when disabled. */
+    private WorldClock worldClock;
 
     private final ConcurrentHashMap<UUID, MobInstance> instances = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Username, UUID> playerCombatTargets = new ConcurrentHashMap<>();
@@ -119,6 +123,20 @@ public class MobRegistry implements Tickable {
      */
     public void setPartyService(PartyService partyService) {
         this.partyService = partyService;
+    }
+
+    /**
+     * Registers the world clock consulted to pick day/night respawn delays
+     * (see {@link MobTemplate#respawnTicks(TimeOfDay)}).
+     *
+     * @param worldClock the world clock; may be null to disable the day/night cycle
+     */
+    public void setWorldClock(WorldClock worldClock) {
+        this.worldClock = worldClock;
+    }
+
+    private TimeOfDay currentTimeOfDay() {
+        return worldClock != null ? worldClock.timeOfDay() : TimeOfDay.DAY;
     }
 
     /**
@@ -269,7 +287,7 @@ public class MobRegistry implements Tickable {
                 messages.add(GameMessage.toSource(
                     "A " + dropped.getName() + " drops to the ground."));
             }
-            mob.scheduleRespawn();
+            mob.scheduleRespawn(currentTimeOfDay());
             endCombatForMob(mob);
 
             // Determine XP share: split equally among party members in the same room.
@@ -547,7 +565,7 @@ public class MobRegistry implements Tickable {
                     messages.add(GameMessage.toSource(
                         "A " + dropped.getName() + " drops to the ground."));
                 }
-                mob.scheduleRespawn();
+                mob.scheduleRespawn(currentTimeOfDay());
                 endCombatForMob(mob);
 
                 // Determine XP share: split equally among party members in the same room.

--- a/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/MobTemplate.java
@@ -2,8 +2,11 @@ package io.taanielo.jmud.core.mob;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import io.taanielo.jmud.core.combat.AttackId;
 import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.TimeOfDay;
 
 /**
  * Immutable definition of a mob type loaded from data files.
@@ -38,7 +41,13 @@ public record MobTemplate(
      * NPCs (tag {@code "npc"}) never wander regardless of this flag.
      * Defaults to {@code false}.
      */
-    boolean wanders
+    boolean wanders,
+    /**
+     * Optional respawn delay (in ticks) used instead of {@link #respawnTicks} when the world is
+     * in {@link TimeOfDay#NIGHT}; {@code null} means the mob respawns at the same rate day and
+     * night.
+     */
+    @Nullable Integer nightRespawnTicks
 ) {
     public MobTemplate {
         if (maxHp <= 0) {
@@ -53,12 +62,54 @@ public record MobTemplate(
         if (xpReward < 0) {
             throw new IllegalArgumentException("Mob xpReward must be non-negative");
         }
+        if (nightRespawnTicks != null && nightRespawnTicks < 0) {
+            throw new IllegalArgumentException("Mob nightRespawnTicks must be non-negative");
+        }
         lootTable = List.copyOf(lootTable);
         tags = tags == null ? List.of() : List.copyOf(tags);
+    }
+
+    /**
+     * Convenience constructor for callers that don't need a night-specific respawn rate; defaults
+     * {@link #nightRespawnTicks()} to {@code null} (same respawn rate day and night).
+     */
+    public MobTemplate(
+        MobId id,
+        String name,
+        int maxHp,
+        AttackId attackId,
+        AttackId specialAttackId,
+        boolean aggressive,
+        List<LootEntry> lootTable,
+        RoomId spawnRoomId,
+        int maxCount,
+        int respawnTicks,
+        int xpReward,
+        GoldDrop goldDrop,
+        List<String> tags,
+        boolean wanders
+    ) {
+        this(id, name, maxHp, attackId, specialAttackId, aggressive, lootTable, spawnRoomId, maxCount,
+            respawnTicks, xpReward, goldDrop, tags, wanders, null);
     }
 
     /** Returns {@code true} when this mob carries the given tag (case-sensitive). */
     public boolean hasTag(String tag) {
         return tags.contains(tag);
+    }
+
+    /**
+     * Returns the respawn delay (in ticks) that applies for the given time of day: uses
+     * {@link #nightRespawnTicks} when {@code timeOfDay} is {@link TimeOfDay#NIGHT} and one is
+     * configured, otherwise falls back to {@link #respawnTicks}.
+     *
+     * @param timeOfDay the current time of day
+     * @return the respawn delay in ticks to use
+     */
+    public int respawnTicks(TimeOfDay timeOfDay) {
+        if (timeOfDay == TimeOfDay.NIGHT && nightRespawnTicks != null) {
+            return nightRespawnTicks;
+        }
+        return respawnTicks;
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDto.java
@@ -17,6 +17,7 @@ public record MobTemplateDto(
     int respawnTicks,
     Integer xpReward,
     GoldDropDto goldDrop,
-    Boolean wanders
+    Boolean wanders,
+    Integer nightRespawnTicks
 ) {
 }

--- a/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/dto/MobTemplateDtoMapper.java
@@ -41,7 +41,8 @@ public class MobTemplateDtoMapper {
             xpReward,
             goldDrop,
             tags,
-            wanders
+            wanders,
+            dto.nightRespawnTicks()
         );
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/mob/repository/json/JsonMobTemplateRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/mob/repository/json/JsonMobTemplateRepository.java
@@ -17,7 +17,7 @@ import io.taanielo.jmud.core.world.repository.RepositoryException;
 
 public class JsonMobTemplateRepository implements MobTemplateRepository {
 
-    private static final int SCHEMA_VERSION = 2;
+    private static final int SCHEMA_VERSION = 3;
     private static final String MOBS_DIR = "mobs";
 
     private final ObjectMapper objectMapper;

--- a/src/main/java/io/taanielo/jmud/core/world/Room.java
+++ b/src/main/java/io/taanielo/jmud/core/world/Room.java
@@ -22,6 +22,11 @@ public class Room {
     Map<Direction, ItemId> lockedExits;
     /** Recommended/minimum level to enter this room, advisory only; {@code null} means no restriction. */
     @Nullable Integer minLevel;
+    /**
+     * Optional alternate description shown instead of {@link #description} when the world is in
+     * {@link TimeOfDay#NIGHT}; {@code null} means the room looks the same at night.
+     */
+    @Nullable String nightDescription;
 
     /**
      * Constructs a room with no locked exits. Existing callsites use this overload.
@@ -55,7 +60,8 @@ public class Room {
     }
 
     /**
-     * Constructs a room with the specified locked exits configuration and advisory minimum level.
+     * Constructs a room with the specified locked exits configuration and advisory minimum level,
+     * with no alternate night description.
      *
      * @param lockedExits map of direction to required key item id for exits that start locked
      * @param minLevel    the recommended/minimum level to enter this room, or {@code null} if none
@@ -70,6 +76,29 @@ public class Room {
         Map<Direction, ItemId> lockedExits,
         @Nullable Integer minLevel
     ) {
+        this(id, name, description, exits, items, occupants, lockedExits, minLevel, null);
+    }
+
+    /**
+     * Constructs a room with the specified locked exits configuration, advisory minimum level, and
+     * alternate night description.
+     *
+     * @param lockedExits       map of direction to required key item id for exits that start locked
+     * @param minLevel          the recommended/minimum level to enter this room, or {@code null} if none
+     * @param nightDescription  the description shown at night instead of {@code description}, or
+     *                          {@code null} if the room looks the same at night
+     */
+    public Room(
+        RoomId id,
+        String name,
+        String description,
+        Map<Direction, RoomId> exits,
+        List<Item> items,
+        List<Username> occupants,
+        Map<Direction, ItemId> lockedExits,
+        @Nullable Integer minLevel,
+        @Nullable String nightDescription
+    ) {
         this.id = Objects.requireNonNull(id, "Room id is required");
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("Room name must not be blank");
@@ -81,6 +110,7 @@ public class Room {
         this.occupants = List.copyOf(Objects.requireNonNull(occupants, "Room occupants are required"));
         this.lockedExits = Map.copyOf(Objects.requireNonNull(lockedExits, "Locked exits map is required"));
         this.minLevel = minLevel;
+        this.nightDescription = nightDescription;
     }
 
     /**
@@ -93,5 +123,20 @@ public class Room {
      */
     public boolean exceedsLevel(int playerLevel) {
         return minLevel != null && minLevel > playerLevel;
+    }
+
+    /**
+     * Returns the description to show for the given time of day: {@link #nightDescription} when
+     * {@code timeOfDay} is {@link TimeOfDay#NIGHT} and one is defined, otherwise {@link #description}.
+     *
+     * @param timeOfDay the current time of day
+     * @return the description text to render
+     */
+    public String describeFor(TimeOfDay timeOfDay) {
+        Objects.requireNonNull(timeOfDay, "Time of day is required");
+        if (timeOfDay == TimeOfDay.NIGHT && nightDescription != null) {
+            return nightDescription;
+        }
+        return description;
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/RoomRenderer.java
+++ b/src/main/java/io/taanielo/jmud/core/world/RoomRenderer.java
@@ -20,7 +20,7 @@ import io.taanielo.jmud.core.authentication.Username;
 public class RoomRenderer {
 
     /**
-     * Returns the rendered look description lines for the given room.
+     * Returns the rendered look description lines for the given room at {@link TimeOfDay#DAY}.
      *
      * @param room        the room to describe (with occupants and merged items already embedded)
      * @param viewer      the player requesting the description (excluded from the occupants list)
@@ -28,12 +28,28 @@ public class RoomRenderer {
      * @return the list of output lines (name, description, exits, items, occupants)
      */
     public List<String> describeRoom(Room room, Username viewer, Set<Direction> lockedExits) {
+        return describeRoom(room, viewer, lockedExits, TimeOfDay.DAY);
+    }
+
+    /**
+     * Returns the rendered look description lines for the given room, selecting the room's
+     * alternate night description (see {@link Room#describeFor(TimeOfDay)}) when {@code timeOfDay}
+     * is {@link TimeOfDay#NIGHT} and one is defined.
+     *
+     * @param room        the room to describe (with occupants and merged items already embedded)
+     * @param viewer      the player requesting the description (excluded from the occupants list)
+     * @param lockedExits the set of currently locked exit directions in this room
+     * @param timeOfDay   the current time of day, used to pick the day or night description
+     * @return the list of output lines (name, description, exits, items, occupants)
+     */
+    public List<String> describeRoom(Room room, Username viewer, Set<Direction> lockedExits, TimeOfDay timeOfDay) {
         Objects.requireNonNull(room, "Room is required");
         Objects.requireNonNull(viewer, "Viewer is required");
         Objects.requireNonNull(lockedExits, "Locked exits set is required");
+        Objects.requireNonNull(timeOfDay, "Time of day is required");
         List<String> lines = new ArrayList<>();
         lines.add(room.getName());
-        lines.add(room.getDescription());
+        lines.add(room.describeFor(timeOfDay));
         lines.add("Exits: " + formatExits(room.getExits(), lockedExits));
         lines.add("Items: " + formatItems(room.getItems()));
         lines.add("Occupants: " + formatOccupants(room.getOccupants(), viewer));

--- a/src/main/java/io/taanielo/jmud/core/world/RoomService.java
+++ b/src/main/java/io/taanielo/jmud/core/world/RoomService.java
@@ -44,6 +44,11 @@ public class RoomService {
     private final RoomItemService itemService;
     private final RoomRenderer renderer;
     private final RoomRepository roomRepository;
+    /**
+     * Optional world clock used to select day/night room descriptions; {@code null} means the
+     * cycle is disabled and rooms always render their day description.
+     */
+    private @Nullable WorldClock worldClock;
 
     /**
      * Creates a room service façade wrapping the three focused services.
@@ -81,6 +86,15 @@ public class RoomService {
             new RoomRenderer(),
             roomRepository
         );
+    }
+
+    /**
+     * Registers the world clock consulted to pick day/night room descriptions.
+     *
+     * @param worldClock the world clock; may be null to disable the day/night cycle
+     */
+    public void setWorldClock(@Nullable WorldClock worldClock) {
+        this.worldClock = worldClock;
     }
 
     // ── Location delegation ──────────────────────────────────────────────────
@@ -185,7 +199,7 @@ public class RoomService {
         Room room = roomOpt.get();
         Room enriched = enrichRoom(room);
         Set<Direction> lockedExits = locationService.getLockedExits(room.getId());
-        return new LookResult(renderer.describeRoom(enriched, username, lockedExits), enriched);
+        return new LookResult(renderer.describeRoom(enriched, username, lockedExits, currentTimeOfDay()), enriched);
     }
 
     /**
@@ -203,7 +217,7 @@ public class RoomService {
                 Set<Direction> lockedExits = locationService.getLockedExits(enriched.getId());
                 List<String> lines = new ArrayList<>();
                 lines.add("You move " + direction.label() + ".");
-                lines.addAll(renderer.describeRoom(enriched, username, lockedExits));
+                lines.addAll(renderer.describeRoom(enriched, username, lockedExits, currentTimeOfDay()));
                 yield new MoveResult(true, lines, enriched);
             }
         };
@@ -244,6 +258,10 @@ public class RoomService {
 
     // ── Private helpers ──────────────────────────────────────────────────────
 
+    private TimeOfDay currentTimeOfDay() {
+        return worldClock != null ? worldClock.timeOfDay() : TimeOfDay.DAY;
+    }
+
     private Room enrichRoom(Room room) {
         List<Username> occupants = locationService.getPlayersInRoom(room.getId());
         List<Item> items = itemService.mergeItems(room);
@@ -255,7 +273,8 @@ public class RoomService {
             items,
             occupants,
             room.getLockedExits(),
-            room.getMinLevel()
+            room.getMinLevel(),
+            room.getNightDescription()
         );
     }
 
@@ -285,7 +304,8 @@ public class RoomService {
             nextItems,
             room.getOccupants(),
             room.getLockedExits(),
-            room.getMinLevel()
+            room.getMinLevel(),
+            room.getNightDescription()
         );
         try {
             roomRepository.save(updated);

--- a/src/main/java/io/taanielo/jmud/core/world/TimeOfDay.java
+++ b/src/main/java/io/taanielo/jmud/core/world/TimeOfDay.java
@@ -1,0 +1,16 @@
+package io.taanielo.jmud.core.world;
+
+/**
+ * The two phases of the deterministic, tick-driven day/night cycle tracked by {@link WorldClock}.
+ */
+public enum TimeOfDay {
+    DAY,
+    NIGHT;
+
+    /**
+     * Returns the other phase of the cycle (the phase this one transitions into).
+     */
+    public TimeOfDay opposite() {
+        return this == DAY ? NIGHT : DAY;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/WorldClock.java
+++ b/src/main/java/io/taanielo/jmud/core/world/WorldClock.java
@@ -1,0 +1,71 @@
+package io.taanielo.jmud.core.world;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.taanielo.jmud.core.tick.Tickable;
+
+/**
+ * A deterministic, tick-count-driven world clock that flips between {@link TimeOfDay#DAY} and
+ * {@link TimeOfDay#NIGHT} every {@code ticksPerPhase} ticks.
+ *
+ * <p>Follows the same pattern as {@link io.taanielo.jmud.core.tick.TickClock}: an atomic counter
+ * incremented in {@link #tick()} (called once per tick, on the tick thread only, via
+ * {@link io.taanielo.jmud.core.tick.TickRegistry}) with pure query methods that are safe to read
+ * as a snapshot from any thread. Never reads the wall clock, so it stays deterministic across
+ * runs and tick rates, per AGENTS.md §5.
+ */
+public class WorldClock implements Tickable {
+
+    private final int ticksPerPhase;
+    private final AtomicLong ticksSinceTransition = new AtomicLong();
+    private final AtomicReference<TimeOfDay> timeOfDay = new AtomicReference<>(TimeOfDay.DAY);
+
+    /**
+     * Creates a world clock that transitions every {@code ticksPerPhase} ticks, starting at
+     * {@link TimeOfDay#DAY}.
+     *
+     * @param ticksPerPhase the number of ticks each phase (day or night) lasts; must be positive
+     */
+    public WorldClock(int ticksPerPhase) {
+        if (ticksPerPhase <= 0) {
+            throw new IllegalArgumentException("ticksPerPhase must be positive");
+        }
+        this.ticksPerPhase = ticksPerPhase;
+    }
+
+    /**
+     * Advances the clock by one tick, flipping {@link #timeOfDay()} when the current phase has
+     * lasted {@code ticksPerPhase} ticks. Must only be called from the tick thread.
+     */
+    @Override
+    public void tick() {
+        long elapsed = ticksSinceTransition.incrementAndGet();
+        if (elapsed >= ticksPerPhase) {
+            timeOfDay.updateAndGet(TimeOfDay::opposite);
+            ticksSinceTransition.set(0);
+        }
+    }
+
+    /**
+     * Returns the current phase of the day/night cycle. Safe to call from any thread as a
+     * point-in-time snapshot.
+     */
+    public TimeOfDay timeOfDay() {
+        return timeOfDay.get();
+    }
+
+    /**
+     * Returns the number of ticks elapsed since the last day/night transition.
+     */
+    public long ticksSinceTransition() {
+        return ticksSinceTransition.get();
+    }
+
+    /**
+     * Returns the configured number of ticks per phase.
+     */
+    public int ticksPerPhase() {
+        return ticksPerPhase;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/WorldClockSettings.java
+++ b/src/main/java/io/taanielo/jmud/core/world/WorldClockSettings.java
@@ -1,0 +1,29 @@
+package io.taanielo.jmud.core.world;
+
+import io.taanielo.jmud.core.config.GameConfig;
+
+/**
+ * Configuration for {@link WorldClock}'s day/night period length. Follows the same
+ * config-key-with-default pattern as {@code DeathSettings}.
+ */
+public final class WorldClockSettings {
+
+    public static final int DEFAULT_TICKS_PER_PHASE = 50;
+
+    private static final GameConfig CONFIG = GameConfig.load();
+
+    private WorldClockSettings() {
+    }
+
+    /**
+     * Returns the number of ticks each day/night phase lasts, read from
+     * {@code jmud.world.ticks_per_phase} (defaulting to {@link #DEFAULT_TICKS_PER_PHASE}).
+     */
+    public static int ticksPerPhase() {
+        int ticks = CONFIG.getInt("jmud.world.ticks_per_phase", DEFAULT_TICKS_PER_PHASE);
+        if (ticks <= 0) {
+            throw new IllegalArgumentException("Ticks per phase must be positive");
+        }
+        return ticks;
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/world/dto/RoomDto.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/RoomDto.java
@@ -8,8 +8,19 @@ import org.jspecify.annotations.Nullable;
 /**
  * Data transfer object for room persistence. Schema version 2 adds the {@code exits} field;
  * version 3 adds the optional {@code lockedExits} map; version 4 adds the optional
- * {@code minLevel} (serialized as {@code min_level}) field.
- * Version 1, 2, and 3 files are still accepted.
+ * {@code minLevel} (serialized as {@code min_level}) field; version 5 adds the optional
+ * {@code nightDescription} (serialized as {@code night_description}) field.
+ * Version 1, 2, 3, and 4 files are still accepted.
  */
-public record RoomDto(int schemaVersion, String id, String name, String description, List<String> itemIds, Map<String, String> exits, Map<String, String> lockedExits, @Nullable Integer minLevel) {
+public record RoomDto(
+    int schemaVersion,
+    String id,
+    String name,
+    String description,
+    List<String> itemIds,
+    Map<String, String> exits,
+    Map<String, String> lockedExits,
+    @Nullable Integer minLevel,
+    @Nullable String nightDescription
+) {
 }

--- a/src/main/java/io/taanielo/jmud/core/world/dto/RoomMapper.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/RoomMapper.java
@@ -29,14 +29,17 @@ public class RoomMapper {
         Map<String, String> lockedExits = new HashMap<>();
         room.getLockedExits().forEach((dir, keyId) -> lockedExits.put(dir.name().toLowerCase(), keyId.getValue()));
         Integer minLevel = room.getMinLevel();
+        String nightDescription = room.getNightDescription();
         int version;
-        if (minLevel != null) {
+        if (nightDescription != null) {
+            version = SchemaVersions.V5;
+        } else if (minLevel != null) {
             version = SchemaVersions.V4;
         } else {
             version = lockedExits.isEmpty() ? SchemaVersions.V2 : SchemaVersions.V3;
         }
         return new RoomDto(version, room.getId().getValue(), room.getName(), room.getDescription(), itemIds, exits,
-            lockedExits.isEmpty() ? null : lockedExits, minLevel);
+            lockedExits.isEmpty() ? null : lockedExits, minLevel, nightDescription);
     }
 
     /**
@@ -69,7 +72,8 @@ public class RoomMapper {
             items,
             List.of(),
             lockedExits,
-            dto.minLevel()
+            dto.minLevel(),
+            dto.nightDescription()
         );
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/world/dto/SchemaVersions.java
+++ b/src/main/java/io/taanielo/jmud/core/world/dto/SchemaVersions.java
@@ -5,6 +5,7 @@ public final class SchemaVersions {
     public static final int V2 = 2;
     public static final int V3 = 3;
     public static final int V4 = 4;
+    public static final int V5 = 5;
 
     private SchemaVersions() {
     }

--- a/src/main/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepository.java
+++ b/src/main/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepository.java
@@ -122,7 +122,8 @@ public class JsonRoomRepository implements RoomRepository {
         if (dto.schemaVersion() != SchemaVersions.V1
                 && dto.schemaVersion() != SchemaVersions.V2
                 && dto.schemaVersion() != SchemaVersions.V3
-                && dto.schemaVersion() != SchemaVersions.V4) {
+                && dto.schemaVersion() != SchemaVersions.V4
+                && dto.schemaVersion() != SchemaVersions.V5) {
             throw new RepositoryException("Unsupported room schema version " + dto.schemaVersion() + " in " + path);
         }
     }

--- a/src/main/resources/jmud.properties
+++ b/src/main/resources/jmud.properties
@@ -16,6 +16,8 @@ jmud.combat.rng=seeded
 # Set explicitly (e.g. jmud.world.seed=12345) to make every run identical.
 jmud.world.seed=
 jmud.tick.interval.ms=1000
+# Number of ticks each day/night phase lasts (the world clock flips DAY/NIGHT after this many ticks).
+jmud.world.ticks_per_phase=50
 jmud.output.ansi.enabled=false
 jmud.audit.enabled=true
 jmud.audit.path=logs/audit.jsonl

--- a/src/test/java/io/taanielo/jmud/core/mob/MobInstanceRespawnTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobInstanceRespawnTest.java
@@ -1,0 +1,74 @@
+package io.taanielo.jmud.core.mob;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.TimeOfDay;
+
+/**
+ * Unit tests for {@link MobInstance#scheduleRespawn(TimeOfDay)} and
+ * {@link MobInstance#tickRespawn()}, verifying that the day or night respawn delay from
+ * {@link MobTemplate} is honored depending on the current {@link TimeOfDay}.
+ */
+class MobInstanceRespawnTest {
+
+    private static final RoomId SPAWN_ROOM = RoomId.of("spawn");
+
+    private MobTemplate templateWithNightRespawn(int dayTicks, int nightTicks) {
+        return new MobTemplate(
+            MobId.of("mob.wolf"),
+            "Wolf",
+            20,
+            null,
+            null,
+            false,
+            List.of(),
+            SPAWN_ROOM,
+            1,
+            dayTicks,
+            5,
+            null,
+            List.of(),
+            false,
+            nightTicks
+        );
+    }
+
+    @Test
+    void respawnsAfterDayRespawnTicksWhenScheduledDuringDay() {
+        MobInstance mob = new MobInstance(templateWithNightRespawn(5, 2));
+        mob.scheduleRespawn(TimeOfDay.DAY);
+
+        for (int i = 0; i < 4; i++) {
+            assertFalse(mob.tickRespawn(), "Should not be ready to respawn before day's respawn ticks elapse");
+        }
+        assertTrue(mob.tickRespawn(), "Should be ready to respawn once day's respawn ticks elapse");
+    }
+
+    @Test
+    void respawnsAfterNightRespawnTicksWhenScheduledDuringNight() {
+        MobInstance mob = new MobInstance(templateWithNightRespawn(5, 2));
+        mob.scheduleRespawn(TimeOfDay.NIGHT);
+
+        assertFalse(mob.tickRespawn(), "Should not be ready to respawn before night's shorter respawn ticks elapse");
+        assertTrue(mob.tickRespawn(), "Should be ready to respawn once night's respawn ticks elapse");
+    }
+
+    @Test
+    void usesDayRespawnTicksAtNightWhenNoNightRespawnTicksConfigured() {
+        MobTemplate template = new MobTemplate(
+            MobId.of("mob.rat"), "Rat", 20, null, null, false,
+            List.of(), SPAWN_ROOM, 1, 3, 5, null, List.of(), false);
+        MobInstance mob = new MobInstance(template);
+        mob.scheduleRespawn(TimeOfDay.NIGHT);
+
+        assertFalse(mob.tickRespawn());
+        assertFalse(mob.tickRespawn());
+        assertTrue(mob.tickRespawn());
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/mob/MobRegistryWanderTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobRegistryWanderTest.java
@@ -25,6 +25,7 @@ import io.taanielo.jmud.core.world.ItemId;
 import io.taanielo.jmud.core.world.Room;
 import io.taanielo.jmud.core.world.RoomId;
 import io.taanielo.jmud.core.world.RoomService;
+import io.taanielo.jmud.core.world.TimeOfDay;
 import io.taanielo.jmud.core.world.repository.ItemRepository;
 import io.taanielo.jmud.core.world.repository.RepositoryException;
 import io.taanielo.jmud.core.world.repository.RoomRepository;
@@ -198,7 +199,7 @@ class MobRegistryWanderTest {
 
         // Kill it and run the respawn countdown
         mob.takeDamage(Integer.MAX_VALUE);
-        mob.scheduleRespawn();
+        mob.scheduleRespawn(TimeOfDay.DAY);
 
         // Tick through respawn countdown (10 ticks configured)
         for (int i = 0; i < 10; i++) {

--- a/src/test/java/io/taanielo/jmud/core/mob/MobTemplateTest.java
+++ b/src/test/java/io/taanielo/jmud/core/mob/MobTemplateTest.java
@@ -1,0 +1,77 @@
+package io.taanielo.jmud.core.mob;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.world.RoomId;
+import io.taanielo.jmud.core.world.TimeOfDay;
+
+/**
+ * Unit tests for {@link MobTemplate}'s day/night respawn rate selection.
+ */
+class MobTemplateTest {
+
+    private static final RoomId SPAWN_ROOM = RoomId.of("spawn");
+
+    private MobTemplate template(int respawnTicks, Integer nightRespawnTicks) {
+        return new MobTemplate(
+            MobId.of("mob.rat"),
+            "Giant Rat",
+            20,
+            null,
+            null,
+            false,
+            List.of(),
+            SPAWN_ROOM,
+            1,
+            respawnTicks,
+            5,
+            null,
+            List.of(),
+            false,
+            nightRespawnTicks
+        );
+    }
+
+    @Test
+    void nightRespawnTicksDefaultsToNullViaLegacyConstructor() {
+        MobTemplate mobTemplate = new MobTemplate(
+            MobId.of("mob.rat"), "Giant Rat", 20, null, null, false,
+            List.of(), SPAWN_ROOM, 1, 30, 5, null, List.of(), false);
+
+        assertNull(mobTemplate.nightRespawnTicks());
+        assertEquals(30, mobTemplate.respawnTicks(TimeOfDay.DAY));
+        assertEquals(30, mobTemplate.respawnTicks(TimeOfDay.NIGHT));
+    }
+
+    @Test
+    void usesDayRespawnTicksDuringDayEvenWhenNightRespawnTicksConfigured() {
+        MobTemplate mobTemplate = template(30, 10);
+
+        assertEquals(30, mobTemplate.respawnTicks(TimeOfDay.DAY));
+    }
+
+    @Test
+    void usesNightRespawnTicksAtNightWhenConfigured() {
+        MobTemplate mobTemplate = template(30, 10);
+
+        assertEquals(10, mobTemplate.respawnTicks(TimeOfDay.NIGHT));
+    }
+
+    @Test
+    void fallsBackToDayRespawnTicksAtNightWhenNightRespawnTicksNotConfigured() {
+        MobTemplate mobTemplate = template(30, null);
+
+        assertEquals(30, mobTemplate.respawnTicks(TimeOfDay.NIGHT));
+    }
+
+    @Test
+    void rejectsNegativeNightRespawnTicks() {
+        assertThrows(IllegalArgumentException.class, () -> template(30, -1));
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/world/RoomRendererTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomRendererTest.java
@@ -123,4 +123,41 @@ class RoomRendererTest {
         int westIdx = exitsLine.indexOf("west");
         assertTrue(eastIdx < westIdx, "Exits should be sorted alphabetically (east before west)");
     }
+
+    @Test
+    void rendersDayDescriptionWhenTimeOfDayIsDay() {
+        Room room = new Room(ROOM_ID, "Town Square", "A busy square by day.",
+            Map.of(), List.of(), List.of(), Map.of(), null, "A quiet square by night.");
+        List<String> lines = RENDERER.describeRoom(room, Username.of("alice"), Set.of(), TimeOfDay.DAY);
+
+        assertTrue(lines.get(1).equals("A busy square by day."), "Day time should render the day description");
+    }
+
+    @Test
+    void rendersNightDescriptionWhenTimeOfDayIsNightAndOneIsDefined() {
+        Room room = new Room(ROOM_ID, "Town Square", "A busy square by day.",
+            Map.of(), List.of(), List.of(), Map.of(), null, "A quiet square by night.");
+        List<String> lines = RENDERER.describeRoom(room, Username.of("alice"), Set.of(), TimeOfDay.NIGHT);
+
+        assertTrue(lines.get(1).equals("A quiet square by night."), "Night time should render the night description");
+    }
+
+    @Test
+    void fallsBackToDayDescriptionAtNightWhenNoNightDescriptionIsDefined() {
+        Room room = new Room(ROOM_ID, "Cave", "Dark and quiet.", Map.of(), List.of(), List.of());
+        List<String> lines = RENDERER.describeRoom(room, Username.of("alice"), Set.of(), TimeOfDay.NIGHT);
+
+        assertTrue(lines.get(1).equals("Dark and quiet."),
+            "Rooms without a night description should render the day description at night");
+    }
+
+    @Test
+    void threeArgOverloadAlwaysRendersDayDescription() {
+        Room room = new Room(ROOM_ID, "Town Square", "A busy square by day.",
+            Map.of(), List.of(), List.of(), Map.of(), null, "A quiet square by night.");
+        List<String> lines = RENDERER.describeRoom(room, Username.of("alice"), Set.of());
+
+        assertTrue(lines.get(1).equals("A busy square by day."),
+            "The three-arg overload should default to the day description");
+    }
 }

--- a/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomServiceTest.java
@@ -80,6 +80,58 @@ class RoomServiceTest {
     }
 
     @Test
+    void lookShowsDayDescriptionWhenNoWorldClockIsRegistered() {
+        RoomId roomAId = RoomId.of("a");
+        Room roomA = new Room(
+            roomAId, "Room A", "A quiet room by day.", Map.of(), List.of(), List.of(),
+            Map.of(), null, "A dark room by night."
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA)), roomAId);
+
+        Username player = Username.of("Bob");
+        service.ensurePlayerLocation(player);
+        RoomService.LookResult lookResult = service.look(player);
+
+        assertTrue(lookResult.lines().get(1).equals("A quiet room by day."));
+    }
+
+    @Test
+    void lookShowsDayDescriptionWhenWorldClockIsDay() {
+        RoomId roomAId = RoomId.of("a");
+        Room roomA = new Room(
+            roomAId, "Room A", "A quiet room by day.", Map.of(), List.of(), List.of(),
+            Map.of(), null, "A dark room by night."
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA)), roomAId);
+        service.setWorldClock(new WorldClock(100));
+
+        Username player = Username.of("Bob");
+        service.ensurePlayerLocation(player);
+        RoomService.LookResult lookResult = service.look(player);
+
+        assertTrue(lookResult.lines().get(1).equals("A quiet room by day."));
+    }
+
+    @Test
+    void lookShowsNightDescriptionWhenWorldClockIsNight() {
+        RoomId roomAId = RoomId.of("a");
+        Room roomA = new Room(
+            roomAId, "Room A", "A quiet room by day.", Map.of(), List.of(), List.of(),
+            Map.of(), null, "A dark room by night."
+        );
+        RoomService service = new RoomService(new TestRoomRepository(Map.of(roomAId, roomA)), roomAId);
+        WorldClock worldClock = new WorldClock(1);
+        worldClock.tick(); // flips to NIGHT after 1 tick
+        service.setWorldClock(worldClock);
+
+        Username player = Username.of("Bob");
+        service.ensurePlayerLocation(player);
+        RoomService.LookResult lookResult = service.look(player);
+
+        assertTrue(lookResult.lines().get(1).equals("A dark room by night."));
+    }
+
+    @Test
     void rejectsInvalidMove() {
         RoomId roomAId = RoomId.of("a");
         Room roomA = new Room(

--- a/src/test/java/io/taanielo/jmud/core/world/RoomTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/RoomTest.java
@@ -1,5 +1,6 @@
 package io.taanielo.jmud.core.world;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,5 +51,34 @@ class RoomTest {
 
         assertTrue(room.exceedsLevel(4));
         assertTrue(room.exceedsLevel(1));
+    }
+
+    @Test
+    void hasNoNightDescriptionByDefault() {
+        Room room = new Room(RoomId.of("a"), "Room A", "A room.", Map.of(), List.of(), List.of());
+
+        assertNull(room.getNightDescription());
+        assertEquals("A room.", room.describeFor(TimeOfDay.DAY));
+        assertEquals("A room.", room.describeFor(TimeOfDay.NIGHT));
+    }
+
+    @Test
+    void describeForReturnsDayDescriptionAtDayEvenWhenNightDescriptionIsDefined() {
+        Room room = new Room(
+            RoomId.of("a"), "Room A", "A room by day.", Map.of(), List.of(), List.of(),
+            Map.of(), null, "A room by night."
+        );
+
+        assertEquals("A room by day.", room.describeFor(TimeOfDay.DAY));
+    }
+
+    @Test
+    void describeForReturnsNightDescriptionAtNightWhenDefined() {
+        Room room = new Room(
+            RoomId.of("a"), "Room A", "A room by day.", Map.of(), List.of(), List.of(),
+            Map.of(), null, "A room by night."
+        );
+
+        assertEquals("A room by night.", room.describeFor(TimeOfDay.NIGHT));
     }
 }

--- a/src/test/java/io/taanielo/jmud/core/world/WorldClockTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/WorldClockTest.java
@@ -1,0 +1,84 @@
+package io.taanielo.jmud.core.world;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link WorldClock}'s deterministic, tick-count-driven day/night transitions.
+ */
+class WorldClockTest {
+
+    @Test
+    void startsAtDay() {
+        WorldClock clock = new WorldClock(5);
+
+        assertEquals(TimeOfDay.DAY, clock.timeOfDay());
+        assertEquals(0, clock.ticksSinceTransition());
+    }
+
+    @Test
+    void staysDayBeforePhaseLengthElapses() {
+        WorldClock clock = new WorldClock(5);
+
+        for (int i = 0; i < 4; i++) {
+            clock.tick();
+        }
+
+        assertEquals(TimeOfDay.DAY, clock.timeOfDay());
+        assertEquals(4, clock.ticksSinceTransition());
+    }
+
+    @Test
+    void transitionsToNightExactlyAtPhaseLength() {
+        WorldClock clock = new WorldClock(5);
+
+        for (int i = 0; i < 5; i++) {
+            clock.tick();
+        }
+
+        assertEquals(TimeOfDay.NIGHT, clock.timeOfDay());
+        assertEquals(0, clock.ticksSinceTransition());
+    }
+
+    @Test
+    void transitionsBackToDayAfterTwoFullPhases() {
+        WorldClock clock = new WorldClock(5);
+
+        for (int i = 0; i < 10; i++) {
+            clock.tick();
+        }
+
+        assertEquals(TimeOfDay.DAY, clock.timeOfDay());
+        assertEquals(0, clock.ticksSinceTransition());
+    }
+
+    @Test
+    void keepsAlternatingDeterministicallyOverManyPhases() {
+        WorldClock clock = new WorldClock(3);
+        TimeOfDay[] expected = {
+            TimeOfDay.DAY, TimeOfDay.DAY, TimeOfDay.DAY,
+            TimeOfDay.NIGHT, TimeOfDay.NIGHT, TimeOfDay.NIGHT,
+            TimeOfDay.DAY, TimeOfDay.DAY, TimeOfDay.DAY
+        };
+
+        for (TimeOfDay expectedPhase : expected) {
+            assertEquals(expectedPhase, clock.timeOfDay());
+            clock.tick();
+        }
+    }
+
+    @Test
+    void rejectsNonPositiveTicksPerPhase() {
+        assertThrows(IllegalArgumentException.class, () -> new WorldClock(0));
+        assertThrows(IllegalArgumentException.class, () -> new WorldClock(-1));
+    }
+
+    @Test
+    void exposesConfiguredTicksPerPhase() {
+        WorldClock clock = new WorldClock(42);
+
+        assertEquals(42, clock.ticksPerPhase());
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepositoryTest.java
+++ b/src/test/java/io/taanielo/jmud/core/world/repository/json/JsonRoomRepositoryTest.java
@@ -102,6 +102,34 @@ class JsonRoomRepositoryTest {
     }
 
     @Test
+    void savesAndLoadsRoomWithNightDescription() throws Exception {
+        Path dataRoot = tempDir.resolve("data");
+        JsonItemRepository itemRepository = new JsonItemRepository(dataRoot);
+        JsonRoomRepository roomRepository = new JsonRoomRepository(itemRepository, dataRoot);
+
+        Room room = new Room(
+            RoomId.of("moonlit-glade"),
+            "Moonlit Glade",
+            "Sunlight dapples the grass.",
+            Map.of(),
+            List.of(),
+            List.of(),
+            Map.of(),
+            null,
+            "Moonlight dapples the grass."
+        );
+        roomRepository.save(room);
+
+        // Use a fresh repository instance so the read goes through the JSON file, not the cache.
+        JsonRoomRepository reloadedRepository = new JsonRoomRepository(itemRepository, dataRoot);
+        Optional<Room> loaded = reloadedRepository.findById(RoomId.of("moonlit-glade"));
+
+        assertTrue(loaded.isPresent());
+        assertEquals("Moonlight dapples the grass.", loaded.get().getNightDescription());
+        assertEquals("Sunlight dapples the grass.", loaded.get().getDescription());
+    }
+
+    @Test
     void loadsLegacyRoomWithoutMinLevelAsNull() throws Exception {
         Path dataRoot = tempDir.resolve("data");
         Path roomsDir = dataRoot.resolve("rooms");


### PR DESCRIPTION
Closes #247

Implements a tick-based day/night world clock:

- New `WorldClock` (Tickable), configured via `WorldClockSettings`/`jmud.properties` (`jmud.world.ticks_per_phase`, default 50), registered in `TickRegistry` only from `GameContext`.
- Wired via optional setters `RoomService.setWorldClock(...)` / `MobRegistry.setWorldClock(...)`.
- `Room` gained nullable `nightDescription` via constructor overload (`Room.describeFor(TimeOfDay)`); `RoomDto`/`RoomMapper`/`JsonRoomRepository` bumped to schema V5; new `docs/schemas/room.v5.json`.
- `RoomRenderer.describeRoom` gained a TimeOfDay-aware overload; `RoomService.look`/`move` use it.
- `MobTemplate` gained nullable `nightRespawnTicks`/`respawnTicks(TimeOfDay)`; `MobInstance.scheduleRespawn` now takes `TimeOfDay`; `MobRegistry` passes `currentTimeOfDay()` at death call sites.
- `MobTemplateDto`/mapper updated; `JsonMobTemplateRepository` schema bumped to exact-match V3 — all 15 `data/mobs/*.json` files bumped from 2 to 3.
- New `docs/schemas/mob.v3.json`; `wolf.json` demonstrates `night_respawn_ticks`.
- New/updated tests: `WorldClockTest`, `RoomTest`/`RoomRendererTest`/`RoomServiceTest`, `JsonRoomRepositoryTest`, `MobTemplateTest`, `MobInstanceRespawnTest`, `MobRegistryWanderTest`.
- `TODO.md` line marked done.

`./gradlew check` (720 tests) and `scripts/smoke-test.sh` both pass, verified by build-verifier.