### PR TITLE
feat(command): add RECALL command to teleport to starting town room

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
+++ b/src/main/java/io/taanielo/jmud/core/action/GameActionService.java
@@ -73,6 +73,11 @@ public class GameActionService {
     private final MessageEmitter messageEmitter = new MessageEmitter();
     private final AtomicLong scrollCounter = new AtomicLong();
 
+    /** Cooldown key used to rate-limit {@link #recall}. Not a real ability id, but reuses the tracker. */
+    private static final AbilityId RECALL_COOLDOWN_KEY = AbilityId.of("recall");
+    /** Number of ticks a player must wait between successful recalls. */
+    private static final int RECALL_COOLDOWN_TICKS = 30;
+
     /**
      * Creates a game action service with the given domain dependencies.
      * The in-combat check defaults to {@code false} (never in combat), which disables
@@ -120,6 +125,50 @@ public class GameActionService {
         this.cooldownTracker = Objects.requireNonNull(cooldownTracker, "Cooldown tracker is required");
         this.encumbranceService = Objects.requireNonNull(encumbranceService, "Encumbrance service is required");
         this.inCombatCheck = Objects.requireNonNull(inCombatCheck, "In-combat check is required");
+    }
+
+    /**
+     * Teleports the player back to the starting/town room used by {@link RoomService} for
+     * new-character placement and respawn.
+     *
+     * <p>Fails without teleporting if the player is currently in combat (mirrors the
+     * {@code inCombatCheck} used by {@link #useAbility}; the player should FLEE first) or if
+     * recall is still on cooldown from a previous use. On success, starts a fixed-length
+     * cooldown so recall cannot be spammed as a defensive teleport, and returns a departure
+     * message for the old room and an arrival message for the destination room, in addition to
+     * a confirmation message to the player. The result's metadata contains a {@code "recalled"}
+     * entry on success so callers can distinguish it from a rejected attempt.
+     *
+     * @param source the player attempting to recall
+     * @return result with recall messages; {@link GameActionResult#updatedSource()} is always
+     *         {@code null} since recall does not otherwise modify the player
+     */
+    public GameActionResult recall(Player source) {
+        Objects.requireNonNull(source, "Source is required");
+        if (inCombatCheck.test(source)) {
+            return GameActionResult.error("You are in combat! You must FLEE before you can recall.");
+        }
+        if (cooldownTracker.isOnCooldown(RECALL_COOLDOWN_KEY)) {
+            int remaining = cooldownTracker.remainingTicks(RECALL_COOLDOWN_KEY);
+            return GameActionResult.error(
+                "You are still recovering from your last recall (" + remaining + " ticks remaining).");
+        }
+        RoomService.LookResult currentLook = roomService.look(source.getUsername());
+        Room oldRoom = currentLook.room();
+        var destinationId = roomService.respawnPlayer(source.getUsername());
+        cooldownTracker.startCooldown(RECALL_COOLDOWN_KEY, RECALL_COOLDOWN_TICKS);
+
+        List<GameMessage> messages = new ArrayList<>();
+        messages.add(GameMessage.toSource("You recall to town in a flash of light."));
+        String playerName = source.getUsername().getValue();
+        if (oldRoom != null && !oldRoom.getId().equals(destinationId)) {
+            messages.add(GameMessage.toRoomAt(
+                oldRoom.getId(), source.getUsername(), playerName + " vanishes in a flash of light."));
+        }
+        messages.add(GameMessage.toRoomAt(
+            destinationId, source.getUsername(), playerName + " arrives in a flash of light."));
+
+        return new GameActionResult(null, null, messages, Map.of("recalled", Boolean.TRUE));
     }
 
     /**

--- a/src/main/java/io/taanielo/jmud/core/action/GameMessage.java
+++ b/src/main/java/io/taanielo/jmud/core/action/GameMessage.java
@@ -2,16 +2,27 @@ package io.taanielo.jmud.core.action;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.world.RoomId;
 
 /**
  * A message produced by a game action, tagged with its intended delivery target.
  *
  * <p>Messages are classified by {@link Type}: directed at the acting player
- * ({@code SOURCE}), a specific other player ({@code PLAYER}), or broadcast
- * to room occupants ({@code ROOM}).
+ * ({@code SOURCE}), a specific other player ({@code PLAYER}), room occupants
+ * resolved from the acting player's current room ({@code ROOM}), or room
+ * occupants of an explicitly named room ({@code ROOM_AT}) — used when the
+ * acting player's room has already changed by delivery time (e.g. recall).
  */
-public record GameMessage(Type type, Username sourceExclude, Username targetExclude, String text) {
+public record GameMessage(
+    Type type,
+    @Nullable Username sourceExclude,
+    @Nullable Username targetExclude,
+    String text,
+    @Nullable RoomId roomId
+) {
 
     /** Delivery target for a game message. */
     public enum Type {
@@ -20,7 +31,9 @@ public record GameMessage(Type type, Username sourceExclude, Username targetExcl
         /** Message to a specific other player identified by {@link #targetExclude}. */
         PLAYER,
         /** Message to room occupants, excluding source and target. */
-        ROOM
+        ROOM,
+        /** Message to occupants of an explicit room, excluding {@link #targetExclude}. */
+        ROOM_AT
     }
 
     public GameMessage {
@@ -30,17 +43,34 @@ public record GameMessage(Type type, Username sourceExclude, Username targetExcl
 
     /** Creates a message directed at the acting player. */
     public static GameMessage toSource(String text) {
-        return new GameMessage(Type.SOURCE, null, null, text);
+        return new GameMessage(Type.SOURCE, null, null, text, null);
     }
 
     /** Creates a message directed at a specific player. */
     public static GameMessage toPlayer(Username target, String text) {
         Objects.requireNonNull(target, "Target username is required");
-        return new GameMessage(Type.PLAYER, null, target, text);
+        return new GameMessage(Type.PLAYER, null, target, text, null);
     }
 
     /** Creates a message to room occupants, excluding source and target. */
     public static GameMessage toRoom(Username sourceExclude, Username targetExclude, String text) {
-        return new GameMessage(Type.ROOM, sourceExclude, targetExclude, text);
+        return new GameMessage(Type.ROOM, sourceExclude, targetExclude, text, null);
+    }
+
+    /**
+     * Creates a message to the occupants of an explicit room, excluding the given player.
+     *
+     * <p>Unlike {@link #toRoom}, the target room is resolved at message-construction time
+     * rather than from the acting player's current location at delivery time. This is
+     * required when the acting player has already moved out of that room (e.g. a recall
+     * departure message, or an arrival message for a room the player already occupies).
+     *
+     * @param roomId the room whose occupants should receive the message
+     * @param exclude the player to exclude from delivery (typically the acting player)
+     * @param text the message text
+     */
+    public static GameMessage toRoomAt(RoomId roomId, Username exclude, String text) {
+        Objects.requireNonNull(roomId, "Room id is required");
+        return new GameMessage(Type.ROOM_AT, null, exclude, text, roomId);
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/RecallCommand.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/RecallCommand.java
@@ -1,0 +1,43 @@
+package io.taanielo.jmud.core.server.socket;
+
+import java.util.Optional;
+
+/**
+ * Handles the {@code RECALL} command, teleporting the player back to the starting/town room.
+ *
+ * <p>Recall is blocked while the player is in active combat (use FLEE first) and is subject to a
+ * short cooldown so it cannot be used as a spammable escape/travel tool.
+ */
+public class RecallCommand extends RegistrableCommand {
+
+    public RecallCommand(SocketCommandRegistry registry) {
+        super(registry);
+    }
+
+    @Override
+    public String name() {
+        return "recall";
+    }
+
+    @Override
+    public String shortDescription() {
+        return "Teleport back to town. No target, out-of-combat only, has a cooldown.";
+    }
+
+    @Override
+    public String longDescription() {
+        return "Usage: RECALL\n"
+             + "  Teleports you back to the starting/town room. You cannot recall while in\n"
+             + "  active combat — use FLEE first. Recall also has a short cooldown after each\n"
+             + "  use, so it cannot be used repeatedly as an escape button.";
+    }
+
+    @Override
+    public Optional<SocketCommandMatch> match(String input) {
+        String token = SocketCommandParsing.splitInput(input)[0];
+        if (!"RECALL".equals(token)) {
+            return Optional.empty();
+        }
+        return Optional.of(new SocketCommandMatch(this, SocketCommandContext::recall));
+    }
+}

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContext.java
@@ -204,6 +204,18 @@ public interface SocketCommandContext extends Client {
     void fleeCombat();
 
     /**
+     * Attempts to teleport the player back to the starting/town room.
+     *
+     * <p>Blocked while the player is in active combat (use FLEE first) or while recall is on
+     * cooldown; on success, departure and arrival messages are broadcast to the old and new
+     * rooms respectively.
+     *
+     * <p>The default implementation is a no-op so that existing test stubs
+     * do not need to be updated.
+     */
+    default void recall() {}
+
+    /**
      * Assesses the danger of a mob in the same room and prints a qualitative tier message.
      *
      * <p>The default implementation is a no-op so that existing test stubs

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
@@ -249,6 +249,11 @@ class SocketCommandContextImpl implements SocketCommandContext {
                 case SOURCE -> connection.writeLine(msg.text());
                 case PLAYER -> sendToUsername(msg.targetExclude(), msg.text());
                 case ROOM -> deliverRoomMessage(msg.sourceExclude(), msg.targetExclude(), msg.text());
+                case ROOM_AT -> {
+                    Set<Username> excludeSet = msg.targetExclude() == null ? Set.of() : Set.of(msg.targetExclude());
+                    context.messageBroadcaster().broadcastToRoom(
+                        msg.roomId(), new PlainTextMessage(msg.text()), excludeSet);
+                }
             }
         }
     }
@@ -993,6 +998,23 @@ class SocketCommandContextImpl implements SocketCommandContext {
         connection.writeLine("You flee to the " + chosen.label() + "!");
         context.mobRegistry().fleeCombat(player.getUsername());
         sendMove(chosen);
+    }
+
+    @Override
+    public void recall() {
+        if (!session.isAuthenticated() || session.getPlayer() == null) {
+            writeLineWithPrompt("You must be logged in to recall.");
+            return;
+        }
+        Player player = session.getPlayer();
+        GameActionResult result = gameActionService.recall(player);
+        deliverResult(result);
+        if (result.metadata().containsKey("recalled")) {
+            RoomService.LookResult look = roomService.look(player.getUsername());
+            connection.writeLines(look.lines());
+            writeRoomOccupantLines(look.room());
+        }
+        sendPrompt();
     }
 
     @Override

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandRegistry.java
@@ -71,6 +71,7 @@ public class SocketCommandRegistry {
         new KillCommand(registry);
         new ConsiderCommand(registry);
         new FleeCommand(registry);
+        new RecallCommand(registry);
         new RestCommand(registry);
         new WakeCommand(registry);
         new AnsiCommand(registry);

--- a/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
+++ b/src/test/java/io/taanielo/jmud/core/action/GameActionServiceTest.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import io.taanielo.jmud.core.ability.Ability;
@@ -29,6 +30,7 @@ import io.taanielo.jmud.core.ability.AbilityTargetResolver;
 import io.taanielo.jmud.core.ability.AbilityTargeting;
 import io.taanielo.jmud.core.ability.AbilityType;
 import io.taanielo.jmud.core.ability.BasicAbilityCostResolver;
+import io.taanielo.jmud.core.ability.CooldownTracker;
 import io.taanielo.jmud.core.authentication.Password;
 import io.taanielo.jmud.core.authentication.User;
 import io.taanielo.jmud.core.authentication.Username;
@@ -55,6 +57,8 @@ import io.taanielo.jmud.core.effects.EffectStacking;
 import io.taanielo.jmud.core.player.EncumbranceService;
 import io.taanielo.jmud.core.player.Player;
 import io.taanielo.jmud.core.player.PlayerVitals;
+import io.taanielo.jmud.core.tick.system.CooldownSystem;
+import io.taanielo.jmud.core.world.Direction;
 import io.taanielo.jmud.core.world.Item;
 import io.taanielo.jmud.core.world.ItemAttributes;
 import io.taanielo.jmud.core.world.ItemId;
@@ -906,6 +910,111 @@ class GameActionServiceTest {
         GameActionResult result = service.resolveDeathIfNeeded(alreadyDead, attacker);
 
         assertTrue(result.messages().isEmpty());
+    }
+
+    // ── recall ───────────────────────────────────────────────────────────
+
+    @Nested
+    class RecallTests {
+
+        private static final RoomId ROOM_TOWN = RoomId.of("town");
+        private static final RoomId ROOM_DUNGEON = RoomId.of("dungeon");
+
+        private RoomService recallRoomService;
+        private CooldownSystem cooldownSystem;
+        private boolean inCombat;
+        private GameActionService recallService;
+        private Player player;
+
+        @BeforeEach
+        void setUpRecall() {
+            Room town = new Room(
+                ROOM_TOWN, "Town Square", "The town square.",
+                Map.of(Direction.NORTH, ROOM_DUNGEON), List.of(), List.of()
+            );
+            Room dungeon = new Room(
+                ROOM_DUNGEON, "Dungeon", "A dark dungeon.",
+                Map.of(Direction.SOUTH, ROOM_TOWN), List.of(), List.of()
+            );
+            recallRoomService = new RoomService(
+                new TestRoomRepository(Map.of(ROOM_TOWN, town, ROOM_DUNGEON, dungeon)), ROOM_TOWN
+            );
+            cooldownSystem = new CooldownSystem();
+            inCombat = false;
+
+            player = player("wanderer");
+            recallRoomService.ensurePlayerLocation(player.getUsername());
+            recallRoomService.move(player.getUsername(), Direction.NORTH);
+            assertEquals(ROOM_DUNGEON, recallRoomService.findPlayerLocation(player.getUsername()).orElseThrow());
+
+            recallService = new GameActionService(
+                testAbilityRegistry(), new BasicAbilityCostResolver(),
+                new EffectEngine(new StubEffectRepository(Map.of())),
+                new CombatEngine(
+                    new StubAttackRepository(Map.of()),
+                    new CombatModifierResolver(new StubEffectRepository(Map.of())),
+                    new FixedCombatRandom(10, 3, 100)
+                ),
+                recallRoomService,
+                (source, input) -> Optional.empty(),
+                new CooldownTracker(cooldownSystem),
+                testEncumbranceService(),
+                p -> inCombat
+            );
+        }
+
+        @Test
+        void successfulRecallTeleportsPlayerToStartingRoom() {
+            GameActionResult result = recallService.recall(player);
+
+            assertEquals(ROOM_TOWN, recallRoomService.findPlayerLocation(player.getUsername()).orElseThrow());
+            assertTrue(result.metadata().containsKey("recalled"));
+            assertTrue(result.messages().stream().anyMatch(m -> m.type() == GameMessage.Type.SOURCE));
+            long roomAtMessages = result.messages().stream()
+                .filter(m -> m.type() == GameMessage.Type.ROOM_AT)
+                .count();
+            assertEquals(2, roomAtMessages, "Expected a departure message to the dungeon and an arrival message to town");
+        }
+
+        @Test
+        void recallIsBlockedWhileInCombat() {
+            inCombat = true;
+
+            GameActionResult result = recallService.recall(player);
+
+            assertEquals(ROOM_DUNGEON, recallRoomService.findPlayerLocation(player.getUsername()).orElseThrow());
+            assertEquals(1, result.messages().size());
+            assertTrue(result.messages().getFirst().text().contains("FLEE"));
+            assertFalse(result.metadata().containsKey("recalled"));
+        }
+
+        @Test
+        void recallIsBlockedOnCooldown() {
+            recallService.recall(player);
+            recallRoomService.move(player.getUsername(), Direction.NORTH);
+
+            GameActionResult result = recallService.recall(player);
+
+            assertEquals(ROOM_DUNGEON, recallRoomService.findPlayerLocation(player.getUsername()).orElseThrow());
+            assertEquals(1, result.messages().size());
+            assertTrue(result.messages().getFirst().text().contains("recovering"));
+            assertFalse(result.metadata().containsKey("recalled"));
+        }
+
+        @Test
+        void recallSucceedsAgainAfterCooldownExpires() {
+            recallService.recall(player);
+            recallRoomService.move(player.getUsername(), Direction.NORTH);
+
+            for (int i = 0; i < 30; i++) {
+                cooldownSystem.tick();
+            }
+
+            GameActionResult result = recallService.recall(player);
+
+            assertEquals(ROOM_TOWN, recallRoomService.findPlayerLocation(player.getUsername()).orElseThrow());
+            assertTrue(result.metadata().containsKey("recalled"));
+        }
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/test/java/io/taanielo/jmud/core/server/socket/RecallCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/RecallCommandTest.java
@@ -1,0 +1,123 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.authentication.Username;
+import io.taanielo.jmud.core.player.Player;
+import io.taanielo.jmud.core.server.Client;
+import io.taanielo.jmud.core.world.Direction;
+
+/**
+ * Unit tests for {@link RecallCommand}.
+ *
+ * <p>Guard logic (in-combat, cooldown) and the actual teleport live in
+ * {@link io.taanielo.jmud.core.action.GameActionService#recall} and are covered by
+ * {@code GameActionServiceTest}. These tests verify token matching, command metadata, and that a
+ * successful match delegates to {@link SocketCommandContext#recall()}.
+ */
+class RecallCommandTest {
+
+    @Test
+    void matchesRecallToken() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        RecallCommand command = new RecallCommand(registry);
+
+        assertTrue(command.match("RECALL").isPresent());
+        assertTrue(command.match("recall").isPresent());
+        assertTrue(command.match("Recall").isPresent());
+    }
+
+    @Test
+    void doesNotMatchOtherTokens() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        RecallCommand command = new RecallCommand(registry);
+
+        assertFalse(command.match("look").isPresent());
+        assertFalse(command.match("flee").isPresent());
+        assertFalse(command.match("").isPresent());
+        assertFalse(command.match("recal").isPresent());
+    }
+
+    @Test
+    void successfulMatchDelegatesToRecall() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        RecallCommand command = new RecallCommand(registry);
+
+        TrackingContext context = new TrackingContext();
+        command.match("RECALL").get().execute(context);
+
+        assertTrue(context.recallCalled, "A matched RECALL command must delegate to context.recall()");
+    }
+
+    @Test
+    void hasShortAndLongDescriptions() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        RecallCommand command = new RecallCommand(registry);
+
+        assertFalse(command.shortDescription().isBlank(), "shortDescription must not be blank");
+        assertFalse(command.longDescription().isBlank(), "longDescription must not be blank");
+    }
+
+    @Test
+    void nameIsCorrect() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        RecallCommand command = new RecallCommand(registry);
+
+        assertTrue(command.name().equalsIgnoreCase("recall"),
+                "Command name should be 'recall'");
+    }
+
+    @Test
+    void registersItselfWithRegistry() {
+        SocketCommandRegistry registry = new SocketCommandRegistry();
+        new RecallCommand(registry);
+
+        assertTrue(registry.commands().stream().anyMatch(c -> c instanceof RecallCommand),
+                "RecallCommand should register itself with the registry");
+    }
+
+    // --- helpers ---
+
+    private static class TrackingContext implements SocketCommandContext {
+        boolean recallCalled = false;
+
+        @Override public boolean isAuthenticated() { return true; }
+        @Override public Player getPlayer() { return null; }
+        @Override public List<Client> clients() { return List.of(); }
+        @Override public List<Username> onlinePlayerNames() { return List.of(); }
+        @Override public void sendLook() {}
+        @Override public void sendLookAt(String t) {}
+        @Override public void sendMove(Direction d) {}
+        @Override public void useAbility(String a) {}
+        @Override public void updateAnsi(String a) {}
+        @Override public void writeLineWithPrompt(String m) {}
+        @Override public void writeLineSafe(String m) {}
+        @Override public void sendPrompt() {}
+        @Override public void sendToUsername(Username u, String m) {}
+        @Override public void sendToRoom(Player s, Player t, String m) {}
+        @Override public void sendToRoom(Player s, String m) {}
+        @Override public Optional<Player> resolveTarget(Player s, String i) { return Optional.empty(); }
+        @Override public void executeAttack(String a) {}
+        @Override public void getItem(String a) {}
+        @Override public void dropItem(String a) {}
+        @Override public void quaffItem(String a) {}
+        @Override public void readItem(String a) {}
+        @Override public void writeItem(String a) {}
+        @Override public void equipItem(String a) {}
+        @Override public void unequipItem(String a) {}
+        @Override public void killMob(String a) {}
+        @Override public void fleeCombat() {}
+        @Override public void recall() { recallCalled = true; }
+        @Override public void sendInventory() {}
+        @Override public void sendEquipment() {}
+        @Override public void sendMessage(io.taanielo.jmud.core.messaging.Message m) {}
+        @Override public void close() {}
+        @Override public void run() {}
+    }
+}


### PR DESCRIPTION
Closes #251

Adds a RECALL command that teleports the player to the starting town room, following the existing SocketCommand/GameActionService pattern.