### PR TITLE
fix(messaging): stop broadcasting chat to clients in character creation

### DIFF
--- a/src/main/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImpl.java
+++ b/src/main/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImpl.java
@@ -63,6 +63,9 @@ public class MessageBroadcasterImpl implements MessageBroadcaster {
         Objects.requireNonNull(message, "Message is required");
         Set<Username> excluded = exclude == null ? Set.of() : exclude;
         for (Client client : clientPool.clients()) {
+            if (!client.isInWorld()) {
+                continue;
+            }
             client.currentPlayer()
                 .map(Player::getUsername)
                 .filter(username -> !excluded.contains(username))
@@ -72,6 +75,7 @@ public class MessageBroadcasterImpl implements MessageBroadcaster {
 
     private Optional<Client> findClient(Username username) {
         return clientPool.clients().stream()
+            .filter(Client::isInWorld)
             .filter(client -> client.currentPlayer()
                 .map(player -> player.getUsername().equals(username))
                 .orElse(false))

--- a/src/main/java/io/taanielo/jmud/core/server/Client.java
+++ b/src/main/java/io/taanielo/jmud/core/server/Client.java
@@ -22,4 +22,18 @@ public interface Client extends Runnable {
     default Optional<Player> currentPlayer() {
         return Optional.empty();
     }
+
+    /**
+     * Returns whether this connection currently has a player fully in the game world and
+     * eligible to receive game broadcasts (room, GOSSIP, and similar channels).
+     *
+     * <p>A connection that is authenticated but still mid character-creation (race/class
+     * selection) has {@link #currentPlayer()} populated but must not receive broadcasts
+     * until creation completes and it enters the world. Defaults to mirroring
+     * {@link #currentPlayer()} presence so implementations without a creation flow are
+     * unaffected.
+     */
+    default boolean isInWorld() {
+        return currentPlayer().isPresent();
+    }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -162,6 +162,11 @@ public class SocketClient implements Client {
     }
 
     @Override
+    public boolean isInWorld() {
+        return creationState == null && currentPlayer().isPresent();
+    }
+
+    @Override
     public void close() {
         if (!closed.compareAndSet(false, true)) {
             return;

--- a/src/test/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImplTest.java
+++ b/src/test/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImplTest.java
@@ -108,6 +108,39 @@ class MessageBroadcasterImplTest {
         assertEquals(List.of(message), carol.received);
     }
 
+    @Test
+    void broadcastGlobalSkipsConnectionsStillInCharacterCreation() {
+        FakeClient bob = fakeClient("Bob");
+        FakeClient dave = fakeClient("Dave");
+        dave.inWorld = false;
+        MessageBroadcaster broadcaster = broadcaster(List.of(bob, dave), twoRoomService());
+
+        Message message = new PlainTextMessage("gossip: hi everyone");
+        broadcaster.broadcastGlobal(message, Set.of());
+
+        assertEquals(List.of(message), bob.received);
+        assertTrue(dave.received.isEmpty(),
+            "A connection still in character creation must not receive a GOSSIP broadcast");
+    }
+
+    @Test
+    void broadcastToRoomSkipsConnectionsStillInCharacterCreation() {
+        RoomService roomService = twoRoomService();
+        FakeClient alice = fakeClient("Alice");
+        FakeClient dave = fakeClient("Dave");
+        dave.inWorld = false;
+        roomService.ensurePlayerLocation(alice.player.getUsername());
+        roomService.ensurePlayerLocation(dave.player.getUsername());
+        MessageBroadcaster broadcaster = broadcaster(List.of(alice, dave), roomService);
+
+        Message message = new PlainTextMessage("Alice says hi");
+        broadcaster.broadcastToRoom(ROOM_ONE, message, Set.of());
+
+        assertEquals(List.of(message), alice.received);
+        assertTrue(dave.received.isEmpty(),
+            "A connection still in character creation must not receive a room broadcast");
+    }
+
     // --- helpers ---
 
     private static MessageBroadcaster broadcaster(List<Client> clients, RoomService roomService) {
@@ -146,6 +179,7 @@ class MessageBroadcasterImplTest {
     private static final class FakeClient implements Client {
         private final Player player;
         private final List<Message> received = new ArrayList<>();
+        private boolean inWorld = true;
 
         private FakeClient(Player player) {
             this.player = player;
@@ -163,6 +197,11 @@ class MessageBroadcasterImplTest {
         @Override
         public Optional<Player> currentPlayer() {
             return Optional.of(player);
+        }
+
+        @Override
+        public boolean isInWorld() {
+            return inWorld;
         }
 
         @Override


### PR DESCRIPTION
Closes #253

Room/GOSSIP and other message broadcasts now skip connections that are authenticated but still mid character-creation flow (race/class selection). Previously such clients had `currentPlayer()` populated and were included in broadcast delivery even though they have no in-world presence yet.

- `Client.isInWorld()` new default method (mirrors `currentPlayer()` presence for implementations without a creation flow)
- `SocketClient.isInWorld()` returns false while `creationState != null`
- `MessageBroadcasterImpl` filters clients on `isInWorld()` for both global and room broadcasts
- Added regression tests covering both broadcast paths

Verified with `./gradlew check` and `scripts/smoke-test.sh`.