### PR TITLE
chore: gitignore runtime auction listings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ players/
 .gradle/
 logs/
 data/ssh/
+data/auctions/listings.json
 
 ### Claude Code agent runtime state ###
 .orchestrator/


### PR DESCRIPTION
data/auctions/listings.json is live game state persisted by the auction
house at runtime, not seed content — an untracked copy dirties the tree
after any play session, and branch.sh then strands it in an autosave
stash. The smoke test already snapshots/restores this file; ignore it so
manual play sessions don't re-dirty the repo.

Recovers the intent of the leftover 'branch-manager autosave 2026-07-10'
stash, which contained exactly this edit.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)