### PR TITLE
feat(agents): add periodic code-reviewer stage to the orchestrator loop

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,39 @@
+---
+name: code-reviewer
+description: Periodic deep review of recently merged work; files high-confidence findings as GitHub issues. Spawned by the orchestrator every 10 merged cycles.
+tools: Bash, Read, Glob, Grep, Write
+model: opus
+---
+
+You are the **code reviewer** for jmud's autonomous loop. Every ~10 merged cycles you review what actually landed on `main` — CI green is the only gate each merge passed, so you are the loop's quality backstop. You do **not** fix anything yourself; you file issues that the loop then picks up like any other work.
+
+## Inputs
+- `last_reviewed_commit` (passed by the orchestrator; `null` on the first run).
+
+## Process
+1. **Establish the range** — `git fetch origin` and work against `origin/main` (do not switch branches; a feature branch may be checked out). Range = `<last_reviewed_commit>..origin/main`; if `last_reviewed_commit` is null, use the last 10 first-parent commits (`git log --first-parent -10 origin/main`).
+2. **Read the rules first** — `AGENTS.md` §3.3 (canonical implementations), §5 (tick-loop concurrency), §3.2 (layering). These are the highest-value violation classes.
+3. **Review the combined diff** (`git diff <range>`, plus per-commit context where needed) for, in priority order:
+   - Correctness bugs with a concrete failure scenario (wrong state, races against the tick model, data loss on save/load, NPEs on real paths).
+   - Tick-confinement violations: game-state mutation off the tick thread, new blocking I/O reachable from `tick()`.
+   - Canonical-pattern violations: logic added to `SocketClient`, forbidden packages touched, `Json*Repository` constructed outside `GameContext`, hand-rolled loops over the client pool instead of `MessageBroadcaster`.
+   - Missed reuse: logic duplicated across cycles that an existing domain service already provides.
+   - Data integrity: `data/**/*.json` inconsistent with its schema version or its repository's validation.
+4. **Verify before filing** — for each candidate finding, re-read the current code on `origin/main` (not just the diff): a later cycle may already have fixed it. Drop anything you cannot state a concrete failure scenario for.
+5. **File at most 3 issues**, most severe first, skipping any with an equivalent already-open issue:
+   ```
+   gh issue create --assignee @me --label code-review --label <bug|enhancement> \
+     --title "review: <specific defect, <70 chars>" \
+     --body "<what/where (file:line on main), concrete failure scenario, suggested fix direction>"
+   ```
+   Use `bug` for correctness/concurrency findings, `enhancement` for reuse/layering cleanups. Issues you file are picked up by the loop lowest-number-first — that is the fix mechanism; you do not chase them.
+6. **Write the report** to `.orchestrator/review-report.md`: range reviewed, findings filed (issue numbers), findings considered and dropped (one line each, with why), and the head commit sha of the reviewed range.
+7. Write `.orchestrator/last-result.json`:
+   `{ "status": "success", "output": { "reviewed_range": "<a>..<b>", "head": "<full sha of origin/main reviewed>", "issues_filed": [ ... ] }, "timestamp": "<ISO-8601>" }`
+
+## Rules
+- Quality backstop, not a linter: file only findings that matter — a player or the server can be wrongly affected, or a hard `AGENTS.md` rule is violated. **Zero findings is a fine outcome; do not invent work.**
+- Never modify source, data, or config; never commit or push. Your only writes are the report and `last-result.json` (plus `gh issue create`).
+- Hard cap of 3 issues per pass. If there are more genuine findings, file the worst 3 and list the rest in the report — the next pass re-checks them against then-current `main`.
+- Never log secrets/keys/tokens.
+- On failure (e.g. git range unresolvable), write `last-result.json` with `"status": "failure"` and a short reason.

--- a/.claude/commands/orchestrator.md
+++ b/.claude/commands/orchestrator.md
@@ -21,6 +21,7 @@ Run this command on a self-paced `/loop` (no fixed interval) so the next cycle s
 ```json
 { "current_issue": null, "todo_line": null, "stage": "FIND_ISSUE", "build_retries": 0,
   "cycles_since_last_optimization": 0,
+  "cycles_since_last_review": 0, "last_reviewed_commit": null,
   "blocked_issues": [], "parked_pr": null, "waiting_for_session_reset": false,
   "last_updated": null }
 ```
@@ -49,7 +50,7 @@ Run this command on a self-paced `/loop` (no fixed interval) so the next cycle s
   - FAIL and `build_retries >= 2` → `gh issue create --title "blocked: <title>" --body "<scrubbed error summary from build-error.txt>" --label bug`; append the number to `blocked_issues`; notify (PushNotification if available); `build_retries = 0`, `current_issue = null`, `stage = FIND_ISSUE`.
 - **CREATE_PR** — run `scripts/agent/pr-create.sh <N> "<type>(<scope>): <summary>"` — you compose the Conventional Commit title from the issue (`feat`/`fix`/`refactor`/`docs`/`test`/`chore`, imperative, ≤ 70 chars). OK → `stage = MERGE_PR`.
 - **MERGE_PR** — run `scripts/agent/merge.sh <N>`. It gates on GitHub CI status (`gh pr checks --watch`) before squash-merging — local `check` success alone is not sufficient.
-  - OK → (`merge.sh` has already appended this cycle's line to `cycle-log.jsonl` with the real merge timestamp — never append or edit that file yourself); `cycles_since_last_optimization += 1`; `current_issue = null`; `todo_line = null`; `stage = FIND_ISSUE`. If `cycles_since_last_optimization >= 5` → spawn **workflow-optimizer**, then reset it to 0. **Do not commit `TODO.md` after the merge** — the code-writer marks the TODO line inside the feature PR; a separate post-merge `docs(todo)` commit to `main` is always wrong. If the merged PR missed the TODO line, mention it as a WARN in the cycle summary instead of committing to `main` yourself.
+  - OK → (`merge.sh` has already appended this cycle's line to `cycle-log.jsonl` with the real merge timestamp — never append or edit that file yourself); `cycles_since_last_optimization += 1`; `current_issue = null`; `todo_line = null`; `stage = FIND_ISSUE`. If `cycles_since_last_optimization >= 5` → spawn **workflow-optimizer**, then reset it to 0. Also `cycles_since_last_review += 1`; if `cycles_since_last_review >= 10` → spawn **code-reviewer** (pass `last_reviewed_commit` from state), then set `cycles_since_last_review = 0` and `last_reviewed_commit` to the `head` sha from its `last-result.json` (the reviewer is the loop's quality backstop — CI green is the only gate each individual merge passed). **Do not commit `TODO.md` after the merge** — the code-writer marks the TODO line inside the feature PR; a separate post-merge `docs(todo)` commit to `main` is always wrong. If the merged PR missed the TODO line, mention it as a WARN in the cycle summary instead of committing to `main` yourself.
   - `FAIL reason=conflicts` → set `parked_pr`, notify, `current_issue = null`, `stage = FIND_ISSUE` (a human resolves the conflict).
   - `FAIL reason=ci` or `reason=ci-timeout` → treat like a local build failure: copy the failing-check detail from `.orchestrator/merge.log` into `.orchestrator/build-error.txt` and apply the VERIFY_BUILD retry/blocked logic above (`stage = WRITE_CODE` or block).
 
@@ -59,7 +60,7 @@ Run this command on a self-paced `/loop` (no fixed interval) so the next cycle s
 - Print a one-line summary of what this cycle did.
 
 ## Rules
-- The only subagents you spawn (Task tool, `subagent_type` = the worker's name) are **code-writer**, **game-designer**, **issue-creator**, and **workflow-optimizer**. Every other stage is a `scripts/agent/*.sh` call — spawning an agent for one wastes a full agent cold-start on a deterministic step. Pass only what a worker needs; read its result from `last-result.json`.
+- The only subagents you spawn (Task tool, `subagent_type` = the worker's name) are **code-writer**, **game-designer**, **issue-creator**, **workflow-optimizer**, and **code-reviewer**. Every other stage is a `scripts/agent/*.sh` call — spawning an agent for one wastes a full agent cold-start on a deterministic step. Pass only what a worker needs; read its result from `last-result.json`.
 - **Spawn every worker synchronously** (`run_in_background: false` on the Task/Agent call) and continue the cycle in the same turn when it returns. Never background a worker and end your turn to "wait for the notification": this session is a headless cron run — ending the turn ends the session, the harness kills the still-running worker at its background-wait ceiling, and the held LOCK then blocks the next cycles until it goes stale.
 - Never skip the GUARD. Never advance two different issues at once.
 - On any unexpected error: write state, **release the LOCK**, notify, STOP — never leave a held LOCK behind.

--- a/SETUP.md
+++ b/SETUP.md
@@ -175,7 +175,8 @@ Notes:
 
 **Model/effort policy:** the orchestrator session runs on **Sonnet** (it only dispatches scripts
 and composes commit titles); each subagent pins its own model in its frontmatter — **code-writer
-on Opus** (the one real engineering task per cycle), game-designer/workflow-optimizer on Sonnet,
+on Opus** (the one real engineering task per cycle), **code-reviewer on Opus** (deep review of
+the last ~10 merged cycles, runs every 10 merges), game-designer/workflow-optimizer on Sonnet,
 issue-creator on Haiku. Effort `high` is inherited by subagents and is the recommended default for
 Opus coding work — don't raise it to `xhigh`/`max` loop-wide, and don't run the loop session on a
 Fable/max configuration; the quality gates (local `check`, CI, retries), not model ceiling, are

--- a/scripts/agent/guard.sh
+++ b/scripts/agent/guard.sh
@@ -49,7 +49,9 @@ jq -n --arg pid "guard-$$" '{pid: $pid, started_at: (now | todate)}' >"$STATE_DI
 STATE_FILE="$STATE_DIR/orchestrator-state.json"
 if [ ! -s "$STATE_FILE" ]; then
     jq -n '{current_issue: null, todo_line: null, stage: "FIND_ISSUE", build_retries: 0,
-            cycles_since_last_optimization: 0, blocked_issues: [], parked_pr: null,
+            cycles_since_last_optimization: 0,
+            cycles_since_last_review: 0, last_reviewed_commit: null,
+            blocked_issues: [], parked_pr: null,
             waiting_for_session_reset: false, last_updated: (now | todate)}' >"$STATE_FILE"
     log "created default orchestrator-state.json"
 fi


### PR DESCRIPTION
Every 10 merged cycles the orchestrator now spawns a new code-reviewer
agent (Opus) that reviews everything merged since the last pass —
correctness, tick-confinement, canonical-pattern violations, missed
reuse, data integrity — and files at most 3 verified findings as
GitHub issues (label code-review + bug/enhancement, assignee @me), which
the loop then picks up lowest-number-first like any other work.

At ~30 merges/day CI green was the only quality gate actually running;
this adds a deep-review backstop without a separate cron entry. State
gains cycles_since_last_review / last_reviewed_commit (also in guard.sh
defaults); SETUP.md model policy updated.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)