### PR TITLE
chore(agents): harden loop scripts — cycle metrics, issue-close check, arg validation, log cap

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -169,7 +169,7 @@ Notes:
   `LOCK`/`PAUSE` guards remain the second line of defense.
 - Unattended runs need the §1.4 permission allow-list in `.claude/settings.local.json`, including
   `Bash(scripts/agent/*)` for the step scripts — headless tool calls fail instead of prompting.
-- `cron.log` grows unbounded; truncate it occasionally (`: > .orchestrator/cron.log`).
+- `cron.log` is auto-trimmed by `guard.sh` (kept to its last 500 lines once it passes 1 MB); no manual truncation needed.
 - Don't run cron and an interactive `/loop` at the same time — the LOCK guard serializes them,
   but there's no reason to pay for both.
 

--- a/scripts/agent/branch.sh
+++ b/scripts/agent/branch.sh
@@ -59,5 +59,9 @@ else
     run git checkout -b "$BRANCH" origin/main || fail branch "could not create $BRANCH"
 fi
 
+# 4. Reset the per-cycle verify counter (verify.sh increments it; merge.sh
+#    logs it as verify_runs — 1 means clean first pass, >1 means retries).
+echo 0 >"$STATE_DIR/verify-runs"
+
 ok "$(jq -n --arg b "$BRANCH" --argjson i "$ISSUE" '{branch: $b, issue: $i}')" \
    "branch=$BRANCH stashed=$STASHED autosave_stashes=$AUTOSAVES resumed=$RESUMED"

--- a/scripts/agent/guard.sh
+++ b/scripts/agent/guard.sh
@@ -56,6 +56,18 @@ if [ ! -s "$STATE_FILE" ]; then
     log "created default orchestrator-state.json"
 fi
 
+# Keep cron.log bounded (headless firings append to it forever; SETUP.md used
+# to ask a human to truncate it). Truncate IN PLACE via `cat >` — the running
+# cron session holds an O_APPEND fd on this file, so replacing it with mv/rename
+# would silently divert the session's remaining output to an orphaned inode.
+CRON_LOG="$STATE_DIR/cron.log"
+if [ -f "$CRON_LOG" ] && [ "$(stat -c%s "$CRON_LOG" 2>/dev/null || echo 0)" -gt 1048576 ]; then
+    tail -n 500 "$CRON_LOG" >"$CRON_LOG.trim.tmp" \
+        && cat "$CRON_LOG.trim.tmp" >"$CRON_LOG" \
+        && rm -f "$CRON_LOG.trim.tmp" \
+        && log "trimmed cron.log (>1 MB) to its last 500 lines"
+fi
+
 log "lock acquired"
 echo "OK lock=acquired replaced_stale_lock_age=$REPLACED_AGE"
 exit 0

--- a/scripts/agent/merge.sh
+++ b/scripts/agent/merge.sh
@@ -17,6 +17,20 @@ cd "$REPO_ROOT"
 ISSUE="${1-}"
 CI_WAIT_SECS=900   # give up on CI after ~15 min
 
+# The argument is the ISSUE number, never the PR number (the PR is found from
+# the current branch). A PR number here corrupts cycle-log.jsonl — it has
+# happened (issue #329 was logged as 330). GitHub numbers issues and PRs in
+# one sequence, so a numeric check can't catch it; the resolved URL can.
+if [ -n "$ISSUE" ]; then
+    [[ "$ISSUE" =~ ^[0-9]+$ ]] || fail usage "issue number must be numeric, got '$ISSUE'"
+    ISSUE_URL="$(gh issue view "$ISSUE" --json url -q .url 2>>"$STEP_LOG" || true)"
+    case "$ISSUE_URL" in
+        */issues/*) : ;;
+        */pull/*)   fail usage "#$ISSUE is a pull request, not an issue — pass the issue number (the PR is derived from the current branch)" ;;
+        *)          echo "WARN could not verify #$ISSUE is an issue (gh lookup failed) — proceeding, but check cycle-log.jsonl" ;;
+    esac
+fi
+
 PR_JSON="$(gh pr view --json number,url,state,mergeable 2>>"$STEP_LOG")" \
     || fail no-pr "no PR found for the current branch"
 PR_NUM="$(jq -r .number <<<"$PR_JSON")"
@@ -40,16 +54,44 @@ back_to_main() {
 append_cycle_log() {
     local cycle_log="$STATE_DIR/cycle-log.jsonl"
     grep -q "\"pr\":$PR_NUM[,}]" "$cycle_log" 2>/dev/null && return 0
-    local merged_at
+    local merged_at started_at verify_runs
     merged_at="$(gh pr view "$PR_NUM" --json mergedAt -q '.mergedAt // empty' 2>>"$STEP_LOG")"
     [ -n "$merged_at" ] || merged_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    # started_at = this session's guard time (a resumed cycle logs its last
+    # session's start, not the very first attempt — good enough for cadence
+    # metrics). verify_runs counts verify.sh invocations this cycle: 1 = clean
+    # first pass, >1 = build retries were needed.
+    started_at="$(jq -r '.started_at // empty' "$STATE_DIR/LOCK" 2>/dev/null || true)"
+    verify_runs="$(cat "$STATE_DIR/verify-runs" 2>/dev/null || true)"
+    [[ "$verify_runs" =~ ^[0-9]+$ ]] || verify_runs=null
     jq -cn --argjson p "$PR_NUM" --argjson i "${ISSUE:-null}" --arg m "$merged_at" \
-        '{issue: $i, pr: $p, merged_at: $m}' >>"$cycle_log"
+        --arg s "$started_at" --argjson v "$verify_runs" \
+        '{issue: $i, pr: $p, merged_at: $m,
+          started_at: (if $s == "" then null else $s end), verify_runs: $v}' >>"$cycle_log"
+}
+
+# GitHub auto-closes the linked issue only if the PR body carried a closing
+# keyword; that has silently failed before (issue #339 stayed open after its
+# PR merged). Verify and close explicitly — idempotent, skipped when no issue
+# number was passed.
+close_linked_issue() {
+    [ -n "$ISSUE" ] || return 0
+    sleep 3   # give GitHub's closes-keyword automation a moment to run first
+    local ist
+    ist="$(gh issue view "$ISSUE" --json state -q .state 2>>"$STEP_LOG" || true)"
+    if [ "$ist" = "OPEN" ]; then
+        if run gh issue close "$ISSUE" --comment "Closed by PR #$PR_NUM (merge.sh: auto-close did not fire)"; then
+            echo "WARN issue #$ISSUE was not auto-closed by the merge — closed it explicitly"
+        else
+            echo "WARN issue #$ISSUE is still open and the explicit close failed — close it manually"
+        fi
+    fi
 }
 
 # Idempotent: a crash after merging must not re-fail the cycle.
 if [ "$PR_STATE" = "MERGED" ]; then
     append_cycle_log
+    close_linked_issue
     back_to_main
     ok "$(result_json)" "merged=true pr=$PR_NUM (was already merged)"
 fi
@@ -88,6 +130,7 @@ fi
 
 run gh pr merge "$PR_NUM" --squash --delete-branch || fail merge "gh pr merge --squash failed"
 append_cycle_log
+close_linked_issue
 back_to_main
 
 ok "$(result_json)" "merged=true pr=$PR_NUM"

--- a/scripts/agent/verify.sh
+++ b/scripts/agent/verify.sh
@@ -26,6 +26,12 @@ done
 ERR_FILE="$STATE_DIR/build-error.txt"
 BRANCH="$(git branch --show-current)"
 
+# Count this invocation for the cycle log (reset by branch.sh, read by
+# merge.sh). Counted before the gate runs so a failed check still counts.
+VRUNS="$(cat "$STATE_DIR/verify-runs" 2>/dev/null || echo 0)"
+[[ "$VRUNS" =~ ^[0-9]+$ ]] || VRUNS=0
+echo $(( VRUNS + 1 )) >"$STATE_DIR/verify-runs"
+
 # Guard: never "verify" the wrong state and hand back a meaningless PASS.
 if [ -n "$EXPECT" ] && [ "$BRANCH" != "$EXPECT" ]; then
     fail branch-mismatch "on '$BRANCH' but orchestrator expected '$EXPECT'"


### PR DESCRIPTION
- merge.sh rejects a PR number passed as the issue argument (resolved
  issue URL must contain /issues/; a PR number corrupted cycle-log.jsonl
  once — issue #329 logged as 330). Verified live: PR number and
  non-numeric args both FAIL reason=usage.
- cycle-log.jsonl lines now carry started_at (from the LOCK lease) and
  verify_runs (1 = clean first pass, >1 = build retries), so throughput
  and retry metrics no longer need to be mined from cron.log prose.
  branch.sh resets the counter, verify.sh increments it.
- merge.sh verifies the linked issue actually closed after merge and
  closes it explicitly if GitHub's closes-keyword automation didn't
  fire (issue #339 case).
- guard.sh trims cron.log to its last 500 lines once it exceeds 1 MB,
  in place (cat >, never mv — the cron session holds an O_APPEND fd).
  SETUP.md manual-truncation note updated.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)