### PR TITLE
fix(session): defer world entry until character creation completes

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -24,6 +24,8 @@ SERVER_LOG="$OUT_DIR/server.log"
 TEST_USER="smoke$(date +%s)"
 TEST_ROGUE="rogue$(date +%s)"
 TEST_LINK="link$(date +%s)"
+TEST_CREA="crea$(date +%s)"
+TEST_CREB="creb$(date +%s)"
 TEST_PASS="smoketest123"
 STARTUP_TIMEOUT=90
 FAILURES=0
@@ -94,6 +96,8 @@ cleanup() {
     rm -f "data/users/$TEST_USER.json" "players/$TEST_USER.json"
     rm -f "data/users/$TEST_ROGUE.json" "players/$TEST_ROGUE.json"
     rm -f "data/users/$TEST_LINK.json" "players/$TEST_LINK.json"
+    rm -f "data/users/$TEST_CREA.json" "players/$TEST_CREA.json"
+    rm -f "data/users/$TEST_CREB.json" "players/$TEST_CREB.json"
     # Restore the committed bulletin board so the smoke test leaves no trace.
     if [ -f "$BOARD_BACKUP" ]; then
         cp "$BOARD_BACKUP" "$BOARD_FILE"
@@ -380,6 +384,55 @@ LINKDEAD_LOG="$OUT_DIR/server-linkdead-window.log"
 tail -c "+$((LINKDEAD_LOG_OFFSET + 1))" "$SERVER_LOG" > "$LINKDEAD_LOG"
 expect "$LINKDEAD_LOG" "server marked the dropped session linkdead" 'went linkdead'
 expect "$LINKDEAD_LOG" "server reattached the reconnecting client"  'reattached to linkdead session'
+
+# ── phase 3c: mid-creation world isolation (issues #253/#512) ────────────────
+# A player still answering the race/class prompts must not be in the world yet:
+# no room occupancy (invisible to LOOK), no WHO entry, and no game broadcasts or
+# prompts interrupting the creation flow. World entry happens only when creation
+# completes (SocketClient.finishCharacterCreation).
+log "Phase 3c: mid-creation player is isolated from the world"
+T3C_A="$OUT_DIR/phase3c-observer.txt"
+T3C_B="$OUT_DIR/phase3c-creation.txt"
+
+# B: new user who parks at the race prompt for ~20s, then completes creation.
+{
+    sleep 1.5
+    printf '%s\r\n' "$TEST_CREB"; sleep 1.5
+    printf '%s\r\n' "$TEST_PASS"; sleep 1.5
+    printf '%s\r\n' "$TEST_PASS"
+    sleep 20                      # parked at the race prompt while A observes
+    printf '%s\r\n' "human";   sleep 1.5
+    printf '%s\r\n' "warrior"; sleep 3
+    printf '%s\r\n' "quit";    sleep 1
+} | timeout 60 nc 127.0.0.1 "$TELNET_PORT" | tr -d '\r' > "$T3C_B" &
+CREB_PID=$!
+
+sleep 8   # B is authenticated and parked at the race prompt
+
+# A: existing user; observes the world and talks while B is mid-creation.
+# A finishes well inside B's 20s parked window, so everything A sees (and says)
+# happens while B is still choosing a race.
+run_session "$T3C_A" "$TEST_USER" "$TEST_PASS" \
+    "look" "who" "gossip smoke-creation-leak-check" "quit"
+
+wait "$CREB_PID" 2>/dev/null
+
+if grep -q "$TEST_CREB" "$T3C_A"; then
+    fail "mid-creation player is visible to LOOK/WHO"
+else
+    pass "mid-creation player hidden from LOOK and WHO"
+fi
+
+# Everything B received before "Welcome to the realm!" is creation-flow output:
+# it must contain no game prompt and no broadcast/mob text.
+PRE_CREATION=$(sed '/Welcome to the realm!/,$d' "$T3C_B")
+if printf '%s' "$PRE_CREATION" | grep -qE '\[[0-9]+/[0-9]+hp |wanders|smoke-creation-leak-check'; then
+    fail "game output leaked into the character-creation flow"
+else
+    pass "no game output during character creation"
+fi
+expect "$T3C_B" "creation completes and enters the world" 'Welcome to the realm!'
+expect "$T3C_B" "post-creation prompt rendered"           '\[[0-9]+/[0-9]+hp .*\]'
 
 # ── phase 4: graceful shutdown on SIGTERM ────────────────────────────────────
 # SIGTERM (the default kill signal) must trigger ShutdownCoordinator's orderly

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -243,7 +243,11 @@ public class SocketClient implements Client {
             commandContext.emitAudit(eventType, AuditSubject.player(player.getUsername()),
                 null, commandContext.resolveRoomId(player), "success",
                 Map.of("reason", reason));
-            commandContext.notifyFriendsOfLogout(player);
+            // A player who disconnected mid character-creation never entered the world, so
+            // friends were never told they arrived — don't announce a departure (issue #512).
+            if (isInWorld()) {
+                commandContext.notifyFriendsOfLogout(player);
+            }
         }
         if (sessionRegistry != null && player != null) {
             sessionRegistry.removeIf(player.getUsername(), session);
@@ -298,7 +302,11 @@ public class SocketClient implements Client {
             });
         session.setPlayer(player);
         session.setTextStyler(TextStylers.forEnabled(player.isAnsiEnabled()));
-        if (player.isDead()) {
+        boolean entersCreation = created.get() && context.characterCreationService() != null;
+        if (entersCreation) {
+            // World entry is deferred until finishCharacterCreation (issue #512): a player still
+            // choosing race/class must not be a room occupant, broadcast recipient, or mob target.
+        } else if (player.isDead()) {
             context.roomService().clearPlayerLocation(player.getUsername());
         } else {
             context.roomService().ensurePlayerLocation(player.getUsername());
@@ -308,7 +316,7 @@ public class SocketClient implements Client {
         }
         commandContext.emitAudit("player.login", AuditSubject.player(player.getUsername()),
             null, commandContext.resolveRoomId(player), "success", Map.of("newPlayer", created.get()));
-        commandContext.registerPostLoginCallbacks(created.get(), false);
+        commandContext.registerPostLoginCallbacks(entersCreation, false);
     }
 
     /**
@@ -428,6 +436,11 @@ public class SocketClient implements Client {
         }
         session.setPlayer(player);
         context.persistenceQueue().enqueueSave(player);
+        // Creation is complete: only now does the player enter the world — room placement plus the
+        // in-world wiring (event bus, effect/healing/sustenance ticks, friend notify) that was
+        // deferred by completeAuthentication (issue #512).
+        context.roomService().ensurePlayerLocation(player.getUsername());
+        commandContext.completeWorldEntry();
         connection.writeLine("You are now a " + player.getRace().getValue()
             + " " + player.getClassId().getValue() + ". Welcome to the realm!");
         String cid = auditService.newCorrelationId();

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
@@ -267,6 +267,9 @@ class SocketCommandContextImpl implements SocketCommandContext {
             // Linkdead players are still in the world (attackable, occupying their room) but are
             // unresponsive, so they are omitted from the WHO roster (issue #343).
             .filter(sc -> !sc.session().isLinkdead())
+            // Players still answering the race/class prompts have not entered the world yet and
+            // must not be visible to WHO or targetable by TELL/WHISPER/GIVE (issue #512).
+            .filter(Client::isInWorld)
             .map(SocketClient::authenticatedUsername)
             .flatMap(Optional::stream)
             .toList();
@@ -5780,16 +5783,57 @@ class SocketCommandContextImpl implements SocketCommandContext {
     // ── Post-login wiring (called once after a player authenticates) ───
 
     /**
-     * Registers event-bus, effect, and healing callbacks on the session, enqueues the
-     * initial death-state check, and either starts character creation (for new players) or
-     * dispatches an immediate {@code look} command.
+     * Either starts character creation (for brand-new players, deferring all in-world wiring
+     * to {@link #completeWorldEntry()} — issue #512) or wires world presence and dispatches an
+     * immediate {@code look} command.
      *
      * <p>Must be called on the reader thread immediately after authentication completes, before
      * the main read loop continues.
      *
-     * @param isNew {@code true} when this is the player's very first login (new character)
+     * @param entersCreation {@code true} when the player is brand-new and about to answer the
+     *                       race/class creation prompts instead of entering the world
+     * @param isReattach     {@code true} when adopting a linkdead session (issue #343)
      */
-    void registerPostLoginCallbacks(boolean isNew, boolean isReattach) {
+    void registerPostLoginCallbacks(boolean entersCreation, boolean isReattach) {
+        // A brand-new player answers the race/class prompts before entering the world: show the
+        // gossip history banner, start creation, and defer every piece of in-world wiring to
+        // completeWorldEntry(), invoked by SocketClient.finishCharacterCreation (issue #512).
+        // Until then the player has no room location, receives no event-bus deliveries, and is
+        // invisible to WHO/mob AI.
+        if (entersCreation) {
+            sendGossipHistory();
+            client.beginCharacterCreation();
+            return;
+        }
+        wireWorldPresence(isReattach);
+        // Show recent gossip history exactly once, before any other post-login output.
+        sendGossipHistory();
+        // Notify of any unread mail waiting in the player's mailbox.
+        sendMailNotice();
+        String correlationId = auditService.newCorrelationId();
+        session.enqueueCommand(() -> dispatcher.dispatch(this, "look", correlationId));
+    }
+
+    /**
+     * Completes deferred world entry for a player who has just finished character creation
+     * (issue #512): performs the in-world wiring that {@link #registerPostLoginCallbacks} skips
+     * while the creation prompts are active. The caller ({@code SocketClient.finishCharacterCreation})
+     * is responsible for room placement beforehand and for dispatching the initial {@code look}.
+     */
+    void completeWorldEntry() {
+        wireWorldPresence(false);
+    }
+
+    /**
+     * Registers everything that makes this connection a live participant in the game world:
+     * the player-event-bus listener (mob-initiated combat results), effect and healing/sustenance
+     * tick callbacks, the death-state check, tamed-pet respawn, and the friend login notice.
+     * Must only run once the player is actually in-world (issue #512).
+     *
+     * @param isReattach {@code true} when adopting a linkdead session — the player never left,
+     *                   so friends are not re-notified of a login
+     */
+    private void wireWorldPresence(boolean isReattach) {
         // Register player-event-bus listener for mob-initiated combat results
         if (context.playerEventBus() != null && session.getPlayer() != null) {
             context.playerEventBus().register(session.getPlayer().getUsername(), result ->
@@ -5838,21 +5882,10 @@ class SocketCommandContextImpl implements SocketCommandContext {
                     .ifPresent(room -> context.mobRegistry().spawnTamedPets(current, room));
             });
         }
-        // Show recent gossip history exactly once, before any other post-login output.
-        sendGossipHistory();
-        // Notify of any unread mail waiting in the player's mailbox.
-        sendMailNotice();
         // On a genuine login (never a linkdead reattach — that player was already online), tell every
         // online player who has this player friended that they have entered the game.
         if (!isReattach && session.getPlayer() != null) {
             notifyFriendsOfLogin(session.getPlayer());
-        }
-        // Start character creation for brand-new players; dispatch look for returning ones
-        if (isNew && context.characterCreationService() != null) {
-            client.beginCharacterCreation();
-        } else {
-            String correlationId = auditService.newCorrelationId();
-            session.enqueueCommand(() -> dispatcher.dispatch(this, "look", correlationId));
         }
     }
 


### PR DESCRIPTION
Fixes #512 (follow-up to #253 / PR #255).

## Problem

A brand-new player entered the world before choosing race/class: `completeAuthentication` placed them in the starting room and registered all in-world callbacks before `beginCharacterCreation()` ran. As a room occupant they received `MobRegistry`'s occupant fan-outs (wander/aggro/combat/death + a game prompt after each), which go through the player event bus and bypass the `isInWorld()` broadcaster gate from PR #255 — reproducing the symptom of #253. They were also visible in LOOK/WHO, targetable by TELL/WHISPER/GIVE and mob AI, all while having no race or class yet.

## Fix (delivery decided in #512: defer world entry, don't gate messages)

- `SocketClient.completeAuthentication`: skips room placement for a player entering creation.
- `SocketCommandContextImpl.registerPostLoginCallbacks`: for the creation path, only shows the gossip history and starts creation; all in-world wiring (event-bus listener, effect/healing/sustenance ticks, death-state check, tamed pets, friend login notice) moved to `wireWorldPresence`, invoked either immediately (normal login / linkdead reattach, unchanged) or via `completeWorldEntry()` from `finishCharacterCreation` once race/class are chosen.
- `SocketClient.finishCharacterCreation`: performs `ensurePlayerLocation` + `completeWorldEntry()` before the welcome line and initial `look`.
- `onlinePlayerNames()`: filters on `Client::isInWorld`, so WHO/TELL/WHISPER/REPLY/GIVE treat a mid-creation player as offline.
- `fullClose`: no friend-logout notice for a player who never entered the world.

## Verification

- `./gradlew check` passes.
- Live two-client repro (before: a client parked at the race prompt was spammed with `A Giant Rat wanders in from the east.` + prompts; after: clean creation prompts, sender's LOOK shows `Occupants: none`).
- `scripts/smoke-test.sh` passes (46 checks), extended with **phase 3c**: while one client is parked at the race prompt, an in-world observer LOOKs/WHOs/gossips — asserts the creation client is invisible and receives no game output, then completes creation and enters the world normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
