### PR TITLE
refactor(server): replace isInWorld() checks with ClientPool in-world views

### DIFF
--- a/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
+++ b/src/main/java/io/taanielo/jmud/bootstrap/GameContext.java
@@ -450,8 +450,7 @@ public record GameContext(
         // The Arena drafts random online players into announced consensual duels on a fixed tick
         // interval. It reads the live client snapshot only to enumerate online usernames; all state
         // mutation (challenge issue, spectator notices) runs on the tick thread (AGENTS.md §5).
-        OnlinePlayersSupplier onlinePlayers = () -> clientPool.clients().stream()
-            .filter(client -> client.isInWorld())
+        OnlinePlayersSupplier onlinePlayers = () -> clientPool.inWorld().stream()
             .flatMap(client -> client.currentPlayer().stream())
             .map(player -> player.getUsername())
             .toList();
@@ -568,8 +567,7 @@ public record GameContext(
         @Nullable MobRegistry mobRegistry,
         DuelService duelService
     ) {
-        @Nullable Player player = clientPool.clients().stream()
-            .filter(client -> client.isInWorld())
+        @Nullable Player player = clientPool.inWorld().stream()
             .flatMap(client -> client.currentPlayer().stream())
             .filter(candidate -> candidate.getUsername().equals(username))
             .findFirst()

--- a/src/main/java/io/taanielo/jmud/bootstrap/GameMetrics.java
+++ b/src/main/java/io/taanielo/jmud/bootstrap/GameMetrics.java
@@ -97,7 +97,7 @@ public final class GameMetrics {
         Objects.requireNonNull(tickRegistry, "Tick registry is required");
         Objects.requireNonNull(clientPool, "Client pool is required");
 
-        Gauge.builder("jmud.players.online", clientPool, pool -> pool.clients().size())
+        Gauge.builder("jmud.players.online", clientPool, pool -> pool.allConnections().size())
             .description("Number of currently connected players")
             .register(registry);
 

--- a/src/main/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImpl.java
+++ b/src/main/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImpl.java
@@ -18,8 +18,9 @@ import io.taanielo.jmud.core.world.RoomService;
  * any concrete transport type. Constructed only by the composition root (AGENTS.md §3.3).
  *
  * <p>Safe to call from both reader threads (e.g. during login) and the tick thread: the backing
- * {@link ClientPool#clients()} snapshot is an immutable {@link java.util.List} copy, so no locking
- * is required here (AGENTS.md §5).
+ * {@link ClientPool#inWorld()} snapshot is an immutable {@link java.util.List} copy, so no locking
+ * is required here (AGENTS.md §5). Connections that have not entered the world (login prompt,
+ * mid character-creation) are excluded by pool membership, not by per-call filtering (issue #514).
  */
 public class MessageBroadcasterImpl implements MessageBroadcaster {
 
@@ -62,10 +63,7 @@ public class MessageBroadcasterImpl implements MessageBroadcaster {
     public void broadcastGlobal(Message message, Set<Username> exclude) {
         Objects.requireNonNull(message, "Message is required");
         Set<Username> excluded = exclude == null ? Set.of() : exclude;
-        for (Client client : clientPool.clients()) {
-            if (!client.isInWorld()) {
-                continue;
-            }
+        for (Client client : clientPool.inWorld()) {
             client.currentPlayer()
                 .map(Player::getUsername)
                 .filter(username -> !excluded.contains(username))
@@ -74,8 +72,7 @@ public class MessageBroadcasterImpl implements MessageBroadcaster {
     }
 
     private Optional<Client> findClient(Username username) {
-        return clientPool.clients().stream()
-            .filter(Client::isInWorld)
+        return clientPool.inWorld().stream()
             .filter(client -> client.currentPlayer()
                 .map(player -> player.getUsername().equals(username))
                 .orElse(false))

--- a/src/main/java/io/taanielo/jmud/core/server/Client.java
+++ b/src/main/java/io/taanielo/jmud/core/server/Client.java
@@ -22,18 +22,4 @@ public interface Client extends Runnable {
     default Optional<Player> currentPlayer() {
         return Optional.empty();
     }
-
-    /**
-     * Returns whether this connection currently has a player fully in the game world and
-     * eligible to receive game broadcasts (room, GOSSIP, and similar channels).
-     *
-     * <p>A connection that is authenticated but still mid character-creation (race/class
-     * selection) has {@link #currentPlayer()} populated but must not receive broadcasts
-     * until creation completes and it enters the world. Defaults to mirroring
-     * {@link #currentPlayer()} presence so implementations without a creation flow are
-     * unaffected.
-     */
-    default boolean isInWorld() {
-        return currentPlayer().isPresent();
-    }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/ClientPool.java
+++ b/src/main/java/io/taanielo/jmud/core/server/ClientPool.java
@@ -2,13 +2,44 @@ package io.taanielo.jmud.core.server;
 
 import java.util.List;
 
+/**
+ * Registry of connected clients with two membership views: every accepted connection, and the
+ * subset whose player has completed world entry (issue #514).
+ *
+ * <p>In-world membership replaces the old per-call {@code Client.isInWorld()} filtering: consumers
+ * choose the view that matches their intent, so a connection still at the login prompt or the
+ * race/class creation prompts can never leak into world-facing enumeration by omission.
+ */
 public interface ClientPool {
 
+    /** Registers a newly accepted connection and starts its reader thread. */
     void add(Client client);
 
+    /** Removes a connection from the pool (and from the in-world view, if present). */
     void remove(Client client);
+
+    /**
+     * Marks a pooled client as having entered the game world — eligible for broadcasts, WHO,
+     * targeted delivery, and world enumeration. Called exactly when the player's world presence is
+     * wired up: normal login, character-creation completion, or linkdead reattach. A no-op when the
+     * client is not (or no longer) in the pool, so a promotion racing a disconnect cannot leak a
+     * closed client into the world view.
+     */
+    void promoteToWorld(Client client);
 
     int getNextId();
 
-    List<Client> clients();
+    /**
+     * Immutable snapshot of every accepted connection: login prompt, mid character-creation,
+     * in-world, and linkdead alike. For transport-level concerns — shutdown notices, connection
+     * counts, session reattach lookups.
+     */
+    List<Client> allConnections();
+
+    /**
+     * Immutable snapshot of only the clients whose player is in the game world (includes linkdead
+     * sessions — they still occupy their room). For game-facing enumeration: broadcasts, WHO,
+     * targeted message delivery, arena drafting.
+     */
+    List<Client> inWorld();
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/DefaultClientPool.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/DefaultClientPool.java
@@ -7,9 +7,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.taanielo.jmud.core.server.Client;
 import io.taanielo.jmud.core.server.ClientPool;
 
+/**
+ * Default {@link ClientPool}: copy-on-write membership lists mutated from reader threads and
+ * iterated as immutable snapshots from the tick thread (AGENTS.md §5). The in-world view is a
+ * subset of the connection list, maintained in promotion order; {@link #remove} demotes before it
+ * removes so no snapshot can ever show a client as in-world but not connected.
+ */
 public class DefaultClientPool implements ClientPool {
 
     private final List<Client> clients = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<Client> inWorld = new CopyOnWriteArrayList<>();
     private final AtomicInteger nextId = new AtomicInteger();
 
     @Override
@@ -23,7 +30,16 @@ public class DefaultClientPool implements ClientPool {
 
     @Override
     public void remove(Client client) {
+        inWorld.remove(client);
         clients.remove(client);
+    }
+
+    @Override
+    public void promoteToWorld(Client client) {
+        if (!clients.contains(client)) {
+            return;
+        }
+        inWorld.addIfAbsent(client);
     }
 
     @Override
@@ -32,7 +48,12 @@ public class DefaultClientPool implements ClientPool {
     }
 
     @Override
-    public List<Client> clients() {
+    public List<Client> allConnections() {
         return List.copyOf(clients);
+    }
+
+    @Override
+    public List<Client> inWorld() {
+        return List.copyOf(inWorld);
     }
 }

--- a/src/main/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinator.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinator.java
@@ -103,7 +103,7 @@ public class ShutdownCoordinator {
     }
 
     private void saveOnlinePlayers() {
-        for (Client client : clientPool.clients()) {
+        for (Client client : clientPool.allConnections()) {
             client.currentPlayer().ifPresent(this::enqueueSave);
         }
         boolean flushed = persistenceQueue.flush(PERSISTENCE_FLUSH_TIMEOUT);
@@ -131,7 +131,7 @@ public class ShutdownCoordinator {
 
     private void notifyClientsOfShutdown() {
         SystemNoticeMessage notice = new SystemNoticeMessage("Server is shutting down.");
-        for (Client client : clientPool.clients()) {
+        for (Client client : clientPool.allConnections()) {
             try {
                 client.sendMessage(notice);
             } catch (RuntimeException e) {

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketClient.java
@@ -112,7 +112,7 @@ public class SocketClient implements Client {
             connection.writeLine("Warning: Telnet is unencrypted. Use SSH for secure access.");
         }
         session.startTicks();
-        int onlineCount = Math.max(0, clientPool.clients().size() - 1);
+        int onlineCount = Math.max(0, clientPool.allConnections().size() - 1);
         if (preAuthenticatedUser != null) {
             sendMessage(WelcomeBannerMessage.of(session.getTextStyler(), onlineCount));
             completeAuthentication(preAuthenticatedUser, preAuthenticatedNewUser);
@@ -167,11 +167,6 @@ public class SocketClient implements Client {
     @Override
     public Optional<Player> currentPlayer() {
         return session.isAuthenticated() ? Optional.ofNullable(session.getPlayer()) : Optional.empty();
-    }
-
-    @Override
-    public boolean isInWorld() {
-        return creationState == null && currentPlayer().isPresent();
     }
 
     @Override
@@ -245,7 +240,8 @@ public class SocketClient implements Client {
                 Map.of("reason", reason));
             // A player who disconnected mid character-creation never entered the world, so
             // friends were never told they arrived — don't announce a departure (issue #512).
-            if (isInWorld()) {
+            // World membership lives in the pool; this runs before clientPool.remove(this) below.
+            if (clientPool.inWorld().contains(this)) {
                 commandContext.notifyFriendsOfLogout(player);
             }
         }
@@ -366,7 +362,7 @@ public class SocketClient implements Client {
     // correct way to find the other client that still owns the exact linkdead session.
     @SuppressWarnings("ReferenceEquality")
     private void detachOldClient(PlayerSession existing) {
-        for (Client c : clientPool.clients()) {
+        for (Client c : clientPool.allConnections()) {
             if (c instanceof SocketClient sc && sc != this && sc.session() == existing) {
                 sc.detachForReattach();
                 return;

--- a/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
+++ b/src/main/java/io/taanielo/jmud/core/server/socket/SocketCommandContextImpl.java
@@ -256,20 +256,19 @@ class SocketCommandContextImpl implements SocketCommandContext {
 
     @Override
     public List<Client> clients() {
-        return clientPool.clients();
+        return clientPool.allConnections();
     }
 
     @Override
     public List<Username> onlinePlayerNames() {
-        return clientPool.clients().stream()
+        // The in-world pool view already excludes connections at the login or race/class prompts
+        // (issues #512/#514), so WHO/TELL/WHISPER/GIVE can never target a mid-creation player.
+        return clientPool.inWorld().stream()
             .filter(SocketClient.class::isInstance)
             .map(SocketClient.class::cast)
             // Linkdead players are still in the world (attackable, occupying their room) but are
             // unresponsive, so they are omitted from the WHO roster (issue #343).
             .filter(sc -> !sc.session().isLinkdead())
-            // Players still answering the race/class prompts have not entered the world yet and
-            // must not be visible to WHO or targetable by TELL/WHISPER/GIVE (issue #512).
-            .filter(Client::isInWorld)
             .map(SocketClient::authenticatedUsername)
             .flatMap(Optional::stream)
             .toList();
@@ -390,7 +389,7 @@ class SocketCommandContextImpl implements SocketCommandContext {
 
     private void updateTarget(Player updatedTarget) {
         saveOrWarn(updatedTarget);
-        for (Client c : clientPool.clients()) {
+        for (Client c : clientPool.allConnections()) {
             if (c instanceof SocketClient socketClient) {
                 if (socketClient.isAuthenticatedUser(updatedTarget.getUsername())) {
                     socketClient.applyExternalPlayerUpdate(updatedTarget);
@@ -703,7 +702,7 @@ class SocketCommandContextImpl implements SocketCommandContext {
      * @return {@code "hp/maxHp"} string
      */
     private String findMemberCurrentHp(Username username) {
-        for (Client c : clientPool.clients()) {
+        for (Client c : clientPool.allConnections()) {
             if (c instanceof SocketClient sc && sc.isAuthenticatedUser(username)) {
                 Player p = sc.session().getPlayer();
                 if (p != null) {
@@ -1309,7 +1308,7 @@ class SocketCommandContextImpl implements SocketCommandContext {
      * when no such client is connected.
      */
     private @Nullable SocketClient findSocketClient(Username username) {
-        for (Client c : clientPool.clients()) {
+        for (Client c : clientPool.allConnections()) {
             if (c instanceof SocketClient sc && sc.isAuthenticatedUser(username)) {
                 return sc;
             }
@@ -1724,7 +1723,7 @@ class SocketCommandContextImpl implements SocketCommandContext {
      * @return the connected player, or {@code null} if no client is authenticated as that user
      */
     private @Nullable Player findOnlinePlayer(Username username) {
-        for (Client c : clientPool.clients()) {
+        for (Client c : clientPool.allConnections()) {
             if (c instanceof SocketClient sc && sc.isAuthenticatedUser(username)) {
                 return sc.session().getPlayer();
             }
@@ -4828,7 +4827,7 @@ class SocketCommandContextImpl implements SocketCommandContext {
      * @param username the username to resolve
      */
     private @Nullable Player resolvePlayerByUsername(Username username) {
-        for (Client c : clientPool.clients()) {
+        for (Client c : clientPool.allConnections()) {
             if (c instanceof SocketClient sc && sc.isAuthenticatedUser(username)) {
                 Player p = sc.session().getPlayer();
                 if (p != null) {
@@ -5826,14 +5825,18 @@ class SocketCommandContextImpl implements SocketCommandContext {
 
     /**
      * Registers everything that makes this connection a live participant in the game world:
-     * the player-event-bus listener (mob-initiated combat results), effect and healing/sustenance
-     * tick callbacks, the death-state check, tamed-pet respawn, and the friend login notice.
+     * promotion into the pool's in-world view (issue #514), the player-event-bus listener
+     * (mob-initiated combat results), effect and healing/sustenance tick callbacks, the
+     * death-state check, tamed-pet respawn, and the friend login notice.
      * Must only run once the player is actually in-world (issue #512).
      *
      * @param isReattach {@code true} when adopting a linkdead session — the player never left,
      *                   so friends are not re-notified of a login
      */
     private void wireWorldPresence(boolean isReattach) {
+        // Promote into the pool's in-world view: from here on this client is eligible for
+        // broadcasts, WHO, and targeted delivery (issue #514).
+        clientPool.promoteToWorld(client);
         // Register player-event-bus listener for mob-initiated combat results
         if (context.playerEventBus() != null && session.getPlayer() != null) {
             context.playerEventBus().register(session.getPlayer().getUsername(), result ->

--- a/src/test/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImplTest.java
+++ b/src/test/java/io/taanielo/jmud/core/messaging/MessageBroadcasterImplTest.java
@@ -112,8 +112,7 @@ class MessageBroadcasterImplTest {
     void broadcastGlobalSkipsConnectionsStillInCharacterCreation() {
         FakeClient bob = fakeClient("Bob");
         FakeClient dave = fakeClient("Dave");
-        dave.inWorld = false;
-        MessageBroadcaster broadcaster = broadcaster(List.of(bob, dave), twoRoomService());
+        MessageBroadcaster broadcaster = broadcaster(List.of(bob), List.of(dave), twoRoomService());
 
         Message message = new PlainTextMessage("gossip: hi everyone");
         broadcaster.broadcastGlobal(message, Set.of());
@@ -128,10 +127,9 @@ class MessageBroadcasterImplTest {
         RoomService roomService = twoRoomService();
         FakeClient alice = fakeClient("Alice");
         FakeClient dave = fakeClient("Dave");
-        dave.inWorld = false;
         roomService.ensurePlayerLocation(alice.player.getUsername());
         roomService.ensurePlayerLocation(dave.player.getUsername());
-        MessageBroadcaster broadcaster = broadcaster(List.of(alice, dave), roomService);
+        MessageBroadcaster broadcaster = broadcaster(List.of(alice), List.of(dave), roomService);
 
         Message message = new PlainTextMessage("Alice says hi");
         broadcaster.broadcastToRoom(ROOM_ONE, message, Set.of());
@@ -144,7 +142,22 @@ class MessageBroadcasterImplTest {
     // --- helpers ---
 
     private static MessageBroadcaster broadcaster(List<Client> clients, RoomService roomService) {
-        ClientPool pool = new FakeClientPool(clients);
+        return broadcaster(clients, List.of(), roomService);
+    }
+
+    /**
+     * Builds a broadcaster over a pool where {@code inWorldClients} have completed world entry and
+     * {@code pendingClients} are connected but still pre-world (login prompt / character creation).
+     */
+    private static MessageBroadcaster broadcaster(
+        List<Client> inWorldClients, List<Client> pendingClients, RoomService roomService
+    ) {
+        FakeClientPool pool = new FakeClientPool();
+        inWorldClients.forEach(client -> {
+            pool.add(client);
+            pool.promoteToWorld(client);
+        });
+        pendingClients.forEach(pool::add);
         return new MessageBroadcasterImpl(pool, roomService);
     }
 
@@ -179,7 +192,6 @@ class MessageBroadcasterImplTest {
     private static final class FakeClient implements Client {
         private final Player player;
         private final List<Message> received = new ArrayList<>();
-        private boolean inWorld = true;
 
         private FakeClient(Player player) {
             this.player = player;
@@ -200,21 +212,13 @@ class MessageBroadcasterImplTest {
         }
 
         @Override
-        public boolean isInWorld() {
-            return inWorld;
-        }
-
-        @Override
         public void run() {
         }
     }
 
     private static final class FakeClientPool implements ClientPool {
-        private final List<Client> clients;
-
-        private FakeClientPool(List<Client> clients) {
-            this.clients = new CopyOnWriteArrayList<>(clients);
-        }
+        private final List<Client> clients = new CopyOnWriteArrayList<>();
+        private final List<Client> inWorld = new CopyOnWriteArrayList<>();
 
         @Override
         public void add(Client client) {
@@ -223,7 +227,15 @@ class MessageBroadcasterImplTest {
 
         @Override
         public void remove(Client client) {
+            inWorld.remove(client);
             clients.remove(client);
+        }
+
+        @Override
+        public void promoteToWorld(Client client) {
+            if (clients.contains(client) && !inWorld.contains(client)) {
+                inWorld.add(client);
+            }
         }
 
         @Override
@@ -232,8 +244,13 @@ class MessageBroadcasterImplTest {
         }
 
         @Override
-        public List<Client> clients() {
+        public List<Client> allConnections() {
             return List.copyOf(clients);
+        }
+
+        @Override
+        public List<Client> inWorld() {
+            return List.copyOf(inWorld);
         }
     }
 

--- a/src/test/java/io/taanielo/jmud/core/server/socket/DefaultClientPoolTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/DefaultClientPoolTest.java
@@ -1,0 +1,129 @@
+package io.taanielo.jmud.core.server.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.taanielo.jmud.core.messaging.Message;
+import io.taanielo.jmud.core.server.Client;
+
+/**
+ * Unit tests for {@link DefaultClientPool}'s two membership views (issue #514): every accepted
+ * connection versus only the clients whose player has entered the game world.
+ */
+class DefaultClientPoolTest {
+
+    @Test
+    void addedClientIsConnectedButNotInWorld() {
+        DefaultClientPool pool = new DefaultClientPool();
+        Client client = new IdleClient();
+
+        pool.add(client);
+
+        assertEquals(List.of(client), pool.allConnections());
+        assertTrue(pool.inWorld().isEmpty(),
+            "A freshly accepted connection must not be in the world view");
+    }
+
+    @Test
+    void promotionAddsClientToWorldViewAndKeepsItConnected() {
+        DefaultClientPool pool = new DefaultClientPool();
+        Client client = new IdleClient();
+        pool.add(client);
+
+        pool.promoteToWorld(client);
+
+        assertEquals(List.of(client), pool.allConnections());
+        assertEquals(List.of(client), pool.inWorld());
+    }
+
+    @Test
+    void promotionIsIdempotent() {
+        DefaultClientPool pool = new DefaultClientPool();
+        Client client = new IdleClient();
+        pool.add(client);
+
+        pool.promoteToWorld(client);
+        pool.promoteToWorld(client);
+
+        assertEquals(List.of(client), pool.inWorld(), "Double promotion must not duplicate the client");
+    }
+
+    @Test
+    void promotingAnUnpooledClientIsANoOp() {
+        DefaultClientPool pool = new DefaultClientPool();
+        Client stranger = new IdleClient();
+
+        pool.promoteToWorld(stranger);
+
+        assertTrue(pool.inWorld().isEmpty(),
+            "A client that is not (or no longer) pooled must never enter the world view");
+        assertTrue(pool.allConnections().isEmpty());
+    }
+
+    @Test
+    void removeDemotesAndDisconnects() {
+        DefaultClientPool pool = new DefaultClientPool();
+        Client client = new IdleClient();
+        pool.add(client);
+        pool.promoteToWorld(client);
+
+        pool.remove(client);
+
+        assertTrue(pool.allConnections().isEmpty());
+        assertTrue(pool.inWorld().isEmpty(), "Removal must also demote the client from the world view");
+    }
+
+    @Test
+    void promotionOrderIsPreserved() {
+        DefaultClientPool pool = new DefaultClientPool();
+        Client first = new IdleClient();
+        Client second = new IdleClient();
+        pool.add(second);
+        pool.add(first);
+
+        pool.promoteToWorld(first);
+        pool.promoteToWorld(second);
+
+        assertEquals(List.of(first, second), pool.inWorld(),
+            "The world view lists clients in promotion order, not connection order");
+    }
+
+    @Test
+    void viewsAreImmutableSnapshots() {
+        DefaultClientPool pool = new DefaultClientPool();
+        Client client = new IdleClient();
+        pool.add(client);
+        pool.promoteToWorld(client);
+
+        List<Client> connectionsSnapshot = pool.allConnections();
+        List<Client> worldSnapshot = pool.inWorld();
+        pool.remove(client);
+
+        assertEquals(List.of(client), connectionsSnapshot, "Snapshots must not see later mutations");
+        assertEquals(List.of(client), worldSnapshot, "Snapshots must not see later mutations");
+        assertThrows(UnsupportedOperationException.class, () -> connectionsSnapshot.add(client));
+        assertThrows(UnsupportedOperationException.class, () -> worldSnapshot.add(client));
+        assertFalse(pool.allConnections().contains(client));
+    }
+
+    /** Minimal client whose reader thread (started by {@code add}) exits immediately. */
+    private static final class IdleClient implements Client {
+        @Override
+        public void sendMessage(Message message) {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void run() {
+        }
+    }
+}

--- a/src/test/java/io/taanielo/jmud/core/server/socket/ShoutCommandTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/ShoutCommandTest.java
@@ -225,12 +225,22 @@ class ShoutCommandTest {
         }
 
         @Override
+        public void promoteToWorld(Client client) {
+        }
+
+        @Override
         public int getNextId() {
             return clients.size();
         }
 
         @Override
-        public List<Client> clients() {
+        public List<Client> allConnections() {
+            return List.copyOf(clients);
+        }
+
+        // Every fixture client is treated as already in-world.
+        @Override
+        public List<Client> inWorld() {
             return List.copyOf(clients);
         }
     }

--- a/src/test/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinatorTest.java
+++ b/src/test/java/io/taanielo/jmud/core/server/socket/ShutdownCoordinatorTest.java
@@ -231,12 +231,22 @@ class ShutdownCoordinatorTest {
         }
 
         @Override
+        public void promoteToWorld(Client client) {
+        }
+
+        @Override
         public int getNextId() {
             return 0;
         }
 
         @Override
-        public List<Client> clients() {
+        public List<Client> allConnections() {
+            return clients;
+        }
+
+        // Every fixture client is treated as already in-world.
+        @Override
+        public List<Client> inWorld() {
             return clients;
         }
     }


### PR DESCRIPTION
Closes #514 (follow-up to #512/#513; retires the gate pattern from #253/#255).

## What

Replaces the six scattered `Client.isInWorld()` consumer filters with **membership views on `ClientPool`**, so world eligibility is encoded by which collection a client is in — nothing for future callers to forget.

- `ClientPool.allConnections()` — every accepted connection: `ShutdownCoordinator` notices, welcome-banner count, linkdead-reattach lookup (`detachOldClient`), `GameMetrics` gauge, username-keyed lookup helpers (unchanged behavior).
- `ClientPool.inWorld()` — only clients whose player completed world entry: `MessageBroadcasterImpl` (both sites), arena `OnlinePlayersSupplier`, trade status lookup, `onlinePlayerNames()` (WHO/TELL/WHISPER/REPLY/GIVE).
- `promoteToWorld(Client)` is called from the single world-entry seam established by #513 — `wireWorldPresence` (normal login, creation completion, linkdead reattach). `remove()` demotes before disconnecting; promoting an unpooled client is a no-op, so a promotion racing a disconnect cannot leak a closed client into the world view.
- `Client.isInWorld()` is **deleted** from the interface. The `fullClose` friend-logout gate asks the pool instead.
- Linkdead stays a `PlayerSession` property per the issue guide (linkdead players are genuinely in-world); WHO keeps its `isLinkdead()` filter.
- Both views remain immutable snapshots (reader-thread mutation / tick-thread iteration, AGENTS.md §5), in-world maintained in promotion order for deterministic broadcast iteration.

## Verification

- `./gradlew check` passes, including new `DefaultClientPoolTest` (promotion lifecycle, idempotency, unpooled-promotion no-op, remove-demotes ordering, snapshot immutability/isolation) and the reworked `MessageBroadcasterImplTest` (creation-suppression now expressed via pool membership instead of a fake boolean).
- `scripts/smoke-test.sh` passes — 46 checks, including phase 3c (mid-creation world isolation) unchanged, plus login, WHO, linkdead reconnect, and graceful shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
