### PR TITLE
docs(process): feature-completeness framework — content DoD, feature matrix, designer completeness audit

### DIFF
--- a/.claude/agents/game-designer.md
+++ b/.claude/agents/game-designer.md
@@ -11,10 +11,14 @@ You are the **game designer** for jmud, a Java MUD. Your job is to decide *what 
 1. **Survey** — read `readme.md` (lowercase), `TODO.md`, the `data/` directory tree, `docs/architecture-review-and-improvement-plan.md` (§2 describes what exists; if missing, skip), and recent history: `gh issue list --state all --limit 30 --json number,title,labels,state`. Understand what exists, what's in flight, and what recently shipped.
 2. **Dedup guard** — before proposing anything:
    - If an equivalent feature is already open, OR the number of **open** `game-design`-labeled issues is **≥ 3**, STOP. Write `last-result.json` with `{ "status": "success", "output": { "skipped": "backlog full / duplicate" } }` and end. Do not create more issues.
-3. **Identify gaps** — reason about typical MUD features vs jmud's current state across: player progression, world depth, social systems, economy, content variety, quality of life.
-4. **Score** candidates by `player_value × implementation_feasibility`. Pick the top one **scoped to a single PR** (not an architectural overhaul).
-5. **Variety pressure** — before committing to the winner, check the last 10 merged feature titles (`git log --oneline -15` on `main`; the `feat(<scope>)` prefixes carry the category). If your candidate is in the same design category as **2 or more of the last 5** shipped features (e.g. yet another "new class + one signature ability" or another capstone quest), take the best candidate from a *different* category instead. Rotate deliberately across: player progression, world/zones, combat depth, social systems, economy/professions, quality of life, and **balance/polish of already-shipped systems** — a tuning or QoL pass over an existing feature is a first-class candidate, not a fallback. Repeating a proven template is a sign the survey in step 1 was too shallow, not that the template is what players need next.
-6. **Create the issue**:
+3. **Completeness audit (before any novelty)** — read `docs/content-dod.md` (what "complete" means per content type) and `docs/feature-matrix.md` (per-entity state), and run `./gradlew run --args='--validate-data' -q` for the mechanical checks. Produce a gap list: shipped content/systems failing their DoD with no open issue (❌ cells in the matrix, validator failures).
+   - **Completion beats novelty**: if the gap list is non-empty, this cycle's issue closes the highest player-impact gap instead of proposing new content — UNLESS the last 2 merged feature/fix commits were already gap-closing work, in which case one novel feature is allowed (don't starve the game of new things entirely).
+   - Gap-closing issues are exempt from the variety-pressure rotation in step 6.
+   - If the matrix is stale (a gap already fixed on `main`, or shipped content missing a row), fix `docs/feature-matrix.md` yourself in this cycle (commit it or include the correction in the issue you file).
+4. **Identify gaps** — reason about typical MUD features vs jmud's current state across: player progression, world depth, social systems, economy, content variety, quality of life.
+5. **Score** candidates by `player_value × implementation_feasibility`. Pick the top one **scoped to a single PR** (not an architectural overhaul).
+6. **Variety pressure** — before committing to the winner, check the last 10 merged feature titles (`git log --oneline -15` on `main`; the `feat(<scope>)` prefixes carry the category). If your candidate is in the same design category as **2 or more of the last 5** shipped features (e.g. yet another "new class + one signature ability" or another capstone quest), take the best candidate from a *different* category instead. Rotate deliberately across: player progression, world/zones, combat depth, social systems, economy/professions, quality of life, and **balance/polish of already-shipped systems** — a tuning or QoL pass over an existing feature is a first-class candidate, not a fallback. Repeating a proven template is a sign the survey in step 1 was too shallow, not that the template is what players need next.
+7. **Create the issue**:
    ```
    gh issue create --assignee @me --label enhancement --label game-design \
      --title "<imperative verb phrase, <70 chars>" \
@@ -23,9 +27,10 @@ You are the **game designer** for jmud, a Java MUD. Your job is to decide *what 
    Body sections, player-experience first:
    - **Why** — game-design rationale
    - **What** — player-facing behaviour
-   - **Acceptance criteria** — bulleted checklist
+   - **Acceptance criteria** — bulleted checklist; for new content, copy the full DoD checklist for that content type from `docs/content-dod.md`
    - **Technical notes** — which Java packages are involved
-7. **Write result** to `.orchestrator/last-result.json`:
+   **File complete features**: a new content entity (race, class, area, …) must ship complete per its DoD. If that doesn't fit one PR, file the full set of `Depends on:`-chained issues covering the whole DoD in this cycle (the dedup guard's ≥ 3 limit applies to *feature ideas*, not to the issues of one decomposed feature). Never file the fun half and leave the rest to chance.
+8. **Write result** to `.orchestrator/last-result.json`:
    `{ "status": "success", "output": { "issue_number": N, "issue_url": "..." }, "timestamp": "<ISO-8601>" }`
 
 ## Rules
@@ -34,4 +39,5 @@ You are the **game designer** for jmud, a Java MUD. Your job is to decide *what 
 - Do not propose architectural refactors — the architecture backlog is the `architecture`-labeled issues (#168–#189); if you spot a structural problem, mention it in your result summary instead of filing a feature for it.
 - Do not propose features that fight the target architecture (`docs/architecture-review-and-improvement-plan.md` §6) — e.g. anything requiring new logic in `SocketClient` or bypassing the tick loop. Prefer features that are pure `data/` content or clean extensions of existing engines.
 - Every issue you create must carry the `game-design` label (for dedup and history).
+- Completeness is a feature: a shipped-but-hollow system (see `docs/feature-matrix.md`) is a better target than a new system. Depth before breadth.
 - On any failure, write `last-result.json` with `"status": "failure"` and a short reason.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,7 @@ Agents must:
 * Preserve save-game compatibility unless explicitly approved
 * Keep game data (abilities, spells, items, rooms, effects, etc.) in JSON under `data/` with versioned schemas
 * Store non-generic domain data in `data/*` JSON (e.g., races in `data/races/`)
+* **Feature completeness**: `docs/content-dod.md` defines what "complete" means per content type; `docs/feature-matrix.md` tracks it per entity/system. Any PR that adds or changes game content must update the affected matrix rows in the same PR; an issue introducing a new content *type* must add its DoD section. Prefer `--validate-data` rules over matrix rows wherever the check is mechanical.
 
 Breaking changes to game rules must be clearly documented.
 

--- a/docs/content-dod.md
+++ b/docs/content-dod.md
@@ -1,0 +1,77 @@
+# Content Definition of Done (DoD)
+
+What "complete" means for each type of game content. The game-designer agent audits
+shipped content against these checklists before proposing new features
+(completion beats novelty), and any issue that introduces a **new content type**
+must add a DoD section here in the same PR.
+
+Two enforcement tiers per item:
+
+- **[V]** — machine-checkable from `data/`; belongs in `--validate-data`
+  (see the validator-completeness issue). Once implemented, incomplete content
+  fails CI and needs no manual tracking.
+- **[M]** — needs judgment (balance, prose quality, coverage); tracked per entity
+  in [`feature-matrix.md`](feature-matrix.md).
+
+## Race
+
+- [V] Stat profile (carry/healing/mana/attack modifiers)
+- [V] Description with benefits and features, shown at creation (#521)
+- [V] Attribute bonuses once core attributes land (#524)
+- [M] Balance pass vs. other races (no strictly-dominant pick)
+
+## Class
+
+- [V] Starting ability kit, including at least one level-1 offense usable on
+  non-undead mobs (#516)
+- [V] Trainable ability pool at levels 2–5, ≥2 abilities beyond the starting kit (#522)
+- [V] Per-class level gains (HP/mana/move) (#523)
+- [V] Attribute creation bonuses + level-gain schedule (#524)
+- [V] Description with playstyle, benefits, and starting abilities, shown at creation (#521)
+- [M] HELP entry naming the class's abilities and role
+- [M] Balance pass: comparable total power at equal level
+
+## Ability (skill/spell)
+
+- [V] Definition in `data/skills/` with level, cost, cooldown, targeting, messages
+- [V] Reachable by at least one class (starting kit or trainable pool)
+- [M] Combat/utility niche that doesn't duplicate an existing ability
+- [M] Worded-damage message compliance once #525 lands
+
+## Mob
+
+- [V] Explicit `xp_reward` (no silent max-HP fallback)
+- [V] Attack definition (or explicit `attack_id: null` for non-combatants) and loot/gold table
+- [V] Assigned spawn room that exists
+- [M] Sits on the area's difficulty curve (CONSIDER gives sane advice)
+
+## Area / zone
+
+- [V] Formal area entry (`data/areas/`) listing its rooms; every room in exactly one area (#529)
+- [V] Hand-drawn ASCII map art + an obtainable map item (shop stock or loot) (#529)
+- [V] Atlas connection entries realized by actual room exits (#529)
+- [V] All area mobs meet the Mob DoD
+- [M] At least one quest that targets or traverses the area
+- [M] Difficulty band documented (level range) and consistent with mob stats
+- [M] Loot/economy integration (shops, gatherables, or drop tables as fits the theme)
+
+## Item
+
+- [V] Schema-valid definition with weight, value, and phase messages where applicable
+- [V] Obtainable somewhere (shop, loot, quest reward, craft recipe) — no orphan items
+- [M] Niche vs. existing items (COMPARE shouldn't reveal a strict duplicate)
+
+## Quest
+
+- [V] Valid target/room references; rewards defined
+- [V] Reachable giver (room or NPC that exists)
+- [M] Recommended level set and honest (#518)
+- [M] Fits a quest chain or standalone arc; no dead-end prerequisites
+
+## System / mechanic (new engine-level feature)
+
+- [M] Player-facing HELP entry
+- [M] Smoke-test phase or unit coverage proving the happy path
+- [M] Interactions with existing systems reviewed (combat, economy, death, persistence)
+- [M] Save-game compatibility statement in the PR
+- [M] Row added to `feature-matrix.md` with any known follow-up gaps filed as issues

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -1,0 +1,80 @@
+# Feature Completeness Matrix
+
+Tracks how complete each shipped content entity and system is against
+[`content-dod.md`](content-dod.md). **Maintenance rule (AGENTS.md §11): any PR that
+adds or changes game content must update the affected rows in the same PR.**
+The game-designer agent reads this file at the start of every cycle and
+prioritizes closing gaps over proposing new content.
+
+Legend: ✅ done · 🔨 open issue filed (referenced) · ❌ gap, no issue yet · — not applicable
+
+Machine-checkable [V] aspects disappear from this file once the corresponding
+`--validate-data` rule exists (the validator then owns them); this matrix tracks
+what validation cannot.
+
+_Last full audit: 2026-07-12 (seeded by hand)._
+
+## Classes
+
+| Class | L1 offense | Trainable pool | Level gains | Attributes | Creation description | HELP entry | Balance pass |
+|---|---|---|---|---|---|---|---|
+| adventurer | ✅ (#516) | 🔨 #522 | 🔨 #523 | 🔨 #524 | 🔨 #521 | ❌ | ❌ |
+| bard | ✅ (#516) | 🔨 #522 | 🔨 #523 | 🔨 #524 | 🔨 #521 | ❌ | ❌ |
+| cleric | ✅ (#516) | 🔨 #522 | 🔨 #523 | 🔨 #524 | 🔨 #521 | ❌ | ❌ |
+| druid | ✅ (#516) | 🔨 #522 | 🔨 #523 | 🔨 #524 | 🔨 #521 | ❌ | ❌ |
+| mage | ✅ (#516) | 🔨 #522 | 🔨 #523 | 🔨 #524 | 🔨 #521 | ❌ | ❌ |
+| necromancer | ✅ (#516) | 🔨 #522 | 🔨 #523 | 🔨 #524 | 🔨 #521 | ❌ | ❌ |
+| paladin | ✅ (#516) | 🔨 #522 | 🔨 #523 | 🔨 #524 | 🔨 #521 | ❌ | ❌ |
+| ranger | ✅ (#516) | 🔨 #522 | 🔨 #523 | 🔨 #524 | 🔨 #521 | ❌ | ❌ |
+| rogue | ✅ (#516) | 🔨 #522 | 🔨 #523 | 🔨 #524 | 🔨 #521 | ❌ | ❌ |
+| shaman | ✅ (#516) | 🔨 #522 | 🔨 #523 | 🔨 #524 | 🔨 #521 | ❌ | ❌ |
+| warrior | ✅ (#516) | 🔨 #522 | 🔨 #523 | 🔨 #524 | 🔨 #521 | ❌ | ❌ |
+
+## Races
+
+| Race | Stat profile | Creation description | Attribute bonuses | Balance pass |
+|---|---|---|---|---|
+| dwarf | ✅ | 🔨 #521 | 🔨 #524 | ❌ |
+| elf | ✅ | 🔨 #521 | 🔨 #524 | ❌ |
+| human | ✅ | 🔨 #521 | 🔨 #524 | ❌ |
+| orc | ✅ | 🔨 #521 | 🔨 #524 | ❌ |
+| troll | ✅ | 🔨 #521 | 🔨 #524 | ❌ |
+
+## Areas
+
+Areas are informal until #529 lands (room-id prefixes only). Rows below use the
+implicit groupings; #529's formal `data/areas/` entries replace this table's
+first three columns with validator rules.
+
+| Area (implicit) | Formal entry + map + atlas | Quest coverage | Difficulty band documented |
+|---|---|---|---|
+| Town/Keep (training-yard, armory, courtyard, …) | 🔨 #529 | 🔨 #518 (starter chain) | ❌ |
+| Wilderness ring (muddy-hollow, hunters-clearing, forest, …) | 🔨 #529 | ✅ (rat/wolf/spider quests) | ❌ |
+| Sewers | 🔨 #529 | ✅ (plague-rat) | ❌ |
+| Catacombs | 🔨 #529 | ✅ (crypt/explore quests) | ❌ |
+| Arena | 🔨 #529 | — (event area) | ❌ |
+| Frozen Peaks | 🔨 #529 | ✅ (frostbound-cull) | ❌ |
+| Cinder Reaches | 🔨 #529 | ✅ (ember-culler, pyraxis) | ❌ |
+| Shrouded Isle | 🔨 #529 | ✅ (drowned-watch, tidebreaker) | ❌ |
+
+## Systems
+
+Engine-level features that shipped, with their known completion gaps.
+A system with all-✅ rows carries no obligation; ❌/🔨 entries are what the
+game-designer should propose closing.
+
+| System | Shipped | Known gaps |
+|---|---|---|
+| Leveling & XP | ✅ | practice-point sink 🔨 #522 · class gains 🔨 #523 · combat scaling 🔨 #524 |
+| Combat core | ✅ | worded damage + condition display 🔨 #525 · attributes 🔨 #524 |
+| New-player funnel | ✅ #516 | starter weapon/hints 🔨 #517 · starter quest 🔨 #518 · starting resources 🔨 #519 · death grace 🔨 #520 · creation info 🔨 #521 |
+| Cartography | ✅ (MAP, retiring) | area maps as items 🔨 #529 |
+| Quests (kill/explore/delivery/daily) | ✅ | level hints 🔨 #518 |
+| Economy (shops, auction, bank, guild treasury, mail gold) | ✅ | newbie bootstrap 🔨 #519 |
+| Professions (craft/cook/brew/gather/salvage/enchant) | ✅ | none known |
+| Social (friends, tells, gossip, ignore, LFG, boards, guilds, parties) | ✅ | none known |
+| PvP (duels, rankings, arena events) | ✅ | none known |
+| Pets (tame/summon) | ✅ | none known |
+| Weather & world ambience | ✅ | none known |
+| Transports (telnet, SSH) | ✅ | WebSocket 🔨 #526 · web client 🔨 #527 |
+| Admin/wizard tooling | ✅ | none known |


### PR DESCRIPTION
Adds the feature-completeness framework so the autonomous loop finishes what it starts (owner request, 2026-07-12; delivery mode: hybrid — docs + agent changes now, mechanical validator rules tracked as #530).

## What

- **`docs/content-dod.md`** — Definition of Done per content type; [V] items are machine-checkable (→ `--validate-data`, #530), [M] items tracked in the matrix. New content types must add their DoD section.
- **`docs/feature-matrix.md`** — per-entity completeness, seeded by hand from today's game state (11 classes, 5 races, 8 implicit areas, 13 systems); every known gap references its open issue (#517–#527, #529).
- **AGENTS.md §11** — content PRs must update affected matrix rows in the same PR; prefer validator rules over matrix rows when mechanical.
- **`.claude/agents/game-designer.md`** — new step 3 "completeness audit": read DoD + matrix + run `--validate-data` before ideation; completion beats novelty (capped after 2 consecutive gap cycles); gap work exempt from variety rotation; new features filed complete via `Depends on:` chains when they exceed one PR.

## Why this shape

Depth before breadth: a shipped-but-hollow system is a better target than a new system, but the game still needs novelty — hence the cap. Mechanical checks go to the validator (#530) because documents go stale; the matrix only carries what validation can't judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)