### PR TITLE
docs(matrix): flip class balance-pass cells to #556, fix stale gaps

### DIFF
--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -18,17 +18,17 @@ _Last full audit: 2026-07-13 (seeded by hand)._
 
 | Class | L1 offense | Trainable pool | Level gains | Attributes | Creation description | HELP entry | Balance pass |
 |---|---|---|---|---|---|---|---|
-| adventurer | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | ❌ |
-| bard | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | ❌ |
-| cleric | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | ❌ |
-| druid | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | ❌ |
-| mage | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | ❌ |
-| necromancer | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | ❌ |
-| paladin | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | ❌ |
-| ranger | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | ❌ |
-| rogue | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | ❌ |
-| shaman | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | ❌ |
-| warrior | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | ❌ |
+| adventurer | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | 🔨 #556 |
+| bard | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | 🔨 #556 |
+| cleric | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | 🔨 #556 |
+| druid | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | 🔨 #556 |
+| mage | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | 🔨 #556 |
+| necromancer | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | 🔨 #556 |
+| paladin | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | 🔨 #556 |
+| ranger | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | 🔨 #556 |
+| rogue | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | 🔨 #556 |
+| shaman | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | 🔨 #556 |
+| warrior | ✅ (#516) | ✅ #522 | ✅ #523 | ✅ #524 | ✅ #521 | ✅ #547 | 🔨 #556 |
 
 ## Races
 
@@ -83,8 +83,8 @@ game-designer should propose closing.
 
 | System | Shipped | Known gaps |
 |---|---|---|
-| Leveling & XP | ✅ | practice-point sink 🔨 #522 · class gains ✅ #523 · combat scaling ✅ #524 |
-| Combat core | ✅ | worded damage + condition display 🔨 #525 · attributes ✅ #524 |
+| Leveling & XP | ✅ | practice-point sink ✅ #522 · class gains ✅ #523 · combat scaling ✅ #524 |
+| Combat core | ✅ | worded damage + condition display ✅ #525 · attributes ✅ #524 |
 | New-player funnel | ✅ #516 | starter weapon/hints ✅ #517 · starter quest ✅ #518 · starting resources ✅ #519 · death grace ✅ #520 · creation info ✅ #521 |
 | Cartography | ✅ #529 (map items; MAP command retired) | difficulty bands ✅ #550 |
 | Quests (kill/explore/delivery/daily) | ✅ | level hints ✅ #518 |
@@ -96,3 +96,4 @@ game-designer should propose closing.
 | Weather & world ambience | ✅ | none known |
 | Transports (telnet, SSH, WebSocket, browser web client) | ✅ #526 #527 | none known |
 | Admin/wizard tooling | ✅ | none known |
+| Classes (kits, level gains, attributes, descriptions, HELP) | ✅ #516 #521 #522 #523 #524 #547 | balance pass 🔨 #556 |


### PR DESCRIPTION
## Summary
- Classes' "Balance pass" column now points at #556 (filed this cycle) instead of a bare ❌, per the game-designer cycle's completeness audit.
- Fixes stale Systems-table rows: #522 (practice-point sink) and #525 (worded damage/condition display) shipped and closed, but the matrix still listed them as open 🔨 gaps.

Docs-only change, no code/data touched.

## Test plan
- [x] N/A — markdown-only change, nothing to build or run

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>