### PR TITLE
docs(feature-matrix): correct stale #556 reference, log #612 gap

### DIFF
--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -12,7 +12,7 @@ Machine-checkable [V] aspects disappear from this file once the corresponding
 `--validate-data` rule exists (the validator then owns them); this matrix tracks
 what validation cannot.
 
-_Last full audit: 2026-07-13 (seeded by hand)._
+_Last full audit: 2026-07-17 (game-designer cycle, corrected stale #556 reference and filed #612)._
 
 ## Classes
 
@@ -164,5 +164,5 @@ game-designer should propose closing.
 | Weather & world ambience | ✅ | none known |
 | Transports (telnet, SSH, WebSocket, browser web client) | ✅ #526 #527 | none known |
 | Admin/wizard tooling | ✅ | none known |
-| Classes (kits, level gains, attributes, descriptions, HELP) | ✅ #516 #521 #522 #523 #524 #547 | balance pass 🔨 #556 |
-| Exploration (locked doors, hidden exits + SEARCH) | ✅ #587 | world-scoped discovery (in-memory, resets on restart); a rogue/skill-based bonus find chance is a possible future gap |
+| Classes (kits, level gains, attributes, descriptions, HELP) | ✅ #516 #521 #522 #523 #524 #547 | balance pass ✅ #556 |
+| Exploration (locked doors, hidden exits + SEARCH) | ✅ #587 | discovered-exit persistence across restarts 🔨 #612 (currently in-memory/world-scoped, resets on restart, contradicting SEARCH's own "permanent for everyone" promise); a rogue/skill-based bonus find chance remains a possible future gap |


### PR DESCRIPTION
## Summary
- The Classes system row in `feature-matrix.md` still showed the open-issue marker for #556 (class balance pass), which merged and closed; the per-class table already used the done marker for the same issue.
- Logs the newly-filed #612 (persist SEARCH's hidden-exit discoveries across restarts) against the Exploration system row, replacing the informal "in-memory, resets on restart" note.

## Test plan
- [x] Docs-only change, no build impact.