### PR TITLE
feat(world): add The Unsung, a level 57-64 zone beyond the Bonelight Choir

### DIFF
--- a/data/areas/atlas.json
+++ b/data/areas/atlas.json
@@ -29,6 +29,8 @@
     "                       [The Marrow Bloom]",
     "                              |",
     "                      [The Bonelight Choir]",
+    "                              |",
+    "                         [The Unsung]",
     "",
     "   Lines mark the roads and passages between",
     "   the great areas of the realm."

--- a/data/areas/the-unsung.json
+++ b/data/areas/the-unsung.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "id": "the-unsung",
+  "name": "The Unsung",
+  "room_ids": [
+    "unsung-threshold",
+    "unsung-hall-of-refusal",
+    "unsung-gallery-of-cut-throats",
+    "unsung-barricade",
+    "unsung-catacomb-of-dissent",
+    "unsung-last-stand"
+  ],
+  "connections": [
+    "bonelight-choir"
+  ],
+  "level_range": {
+    "min": 57,
+    "max": 64
+  },
+  "ascii_map": [
+    "          ... THE UNSUNG ...",
+    "",
+    "            The Bonelight Choir",
+    "                    ^",
+    "                    |",
+    "              [Threshold]",
+    "                    |",
+    "  [Gallery]--[Hall of Refusal]--[Barricade]",
+    "                    |",
+    "           [Catacomb of Dissent]",
+    "                    |",
+    "               [Last Stand]",
+    "",
+    "   Catacombs beneath the Choir's reliquary,",
+    "   held by every throat that refused the",
+    "   chord and cut its own voice out to fight",
+    "   the cathedral in weaponized silence."
+  ]
+}

--- a/data/attacks/attack.the-mute-edge.json
+++ b/data/attacks/attack.the-mute-edge.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 6,
+  "id": "attack.the-mute-edge",
+  "name": "the mute edge",
+  "weapon_type": "SLASHING",
+  "damage_type": "COLD",
+  "min_damage": 24,
+  "max_damage": 36,
+  "hit_bonus": 6,
+  "crit_bonus": 8,
+  "damage_bonus": 9,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "You draw the mute edge across {target} and it takes the sound of the cut before the blood, opening a wound of pure cold silence. Your strike {verb} them!"
+    },
+    {
+      "phase": "attack_hit",
+      "channel": "target",
+      "text": "{source} draws the mute edge across you and the wound arrives in perfect silence, the cold of it reaching the bone before the pain. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_hit",
+      "channel": "room",
+      "text": "{source} draws the mute edge across {target}, and the strike lands without a single sound, swallowed whole by the blade."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "You sweep the mute edge at {target} and it passes in total quiet, cutting only the cold air."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "target",
+      "text": "{source} sweeps the mute edge at you and the noiseless blade whispers past, trailing frost."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "room",
+      "text": "{source} sweeps the mute edge at {target} and the silent blade finds only air."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "You turn the mute edge into {target} and the whole refusal of the Unsung rides the stroke, dragging the sound and the warmth out of the wound at once! Your strike {verb} them!"
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "target",
+      "text": "{source} turns the mute edge into you and the cut takes your breath, your voice, and the cry you meant to make with it! The blow {verb} you!"
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "room",
+      "text": "{source} turns the mute edge into {target}, and the blade drinks the whole of the blow so that not even the impact makes a sound."
+    }
+  ]
+}

--- a/data/attacks/attack.throatless-marshal-hush.json
+++ b/data/attacks/attack.throatless-marshal-hush.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.throatless-marshal-hush",
+  "name": "The Great Refusal",
+  "min_damage": 74,
+  "max_damage": 100,
+  "hit_bonus": 7,
+  "crit_bonus": 7,
+  "damage_bonus": 18,
+  "weapon_type": "BLUNT",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 90
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The Throatless Marshal spreads its wrapped arms and gives, at last, its whole long silence at once — not a sound but the absence of one made into a weapon, the Great Refusal, and it falls over you like the pressure at the bottom of the sea, dragging every scrap of breath and warmth and voice out of you toward the perfect quiet it has kept since before the Choir was ever answered. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The Throatless Marshal looses the Great Refusal and the whole chamber's silence closes like a fist, and you fill your lungs and hold your own breath against it until the crushing quiet rolls past."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The Throatless Marshal bends the entire refusal of the Unsung down onto you alone, and for one drowning, airless moment your own throat clamps shut and refuses you your breath, refuses you your voice, refuses you even the mercy of a scream! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.throatless-marshal.json
+++ b/data/attacks/attack.throatless-marshal.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.throatless-marshal",
+  "name": "a noiseless cut",
+  "min_damage": 62,
+  "max_damage": 88,
+  "hit_bonus": 8,
+  "crit_bonus": 6,
+  "damage_bonus": 16,
+  "weapon_type": "SLASHING",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 60
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The Throatless Marshal moves without warning and without sound, its blade of silence-honed bone opening you before you register that it has closed the distance at all, and the cold of the wound arrives ahead of the pain. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The Throatless Marshal cuts for you in perfect quiet and you save yourself only by the frost of the passing edge, for there is no other warning it will ever give."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The Throatless Marshal steps inside your guard in total silence and draws its edge across you slow, deliberate, and mute, and the whole chamber's held quiet drives the cold of it to the bone! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.unsung-barricade-warden.json
+++ b/data/attacks/attack.unsung-barricade-warden.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.unsung-barricade-warden",
+  "name": "a crushing press",
+  "min_damage": 52,
+  "max_damage": 74,
+  "hit_bonus": 6,
+  "crit_bonus": 5,
+  "damage_bonus": 14,
+  "weapon_type": "BLUNT",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 55
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The barricade warden sets its shoulder like the rampart it keeps and drives you back into the stacked bone, and the packed silence there closes over you in a wave of breath-stealing cold. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The barricade warden throws its whole immovable weight at you and you slip aside from the sally-gap as it crashes past without a sound."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The barricade warden pins you against the rampart and leans, and the whole weight of the barricade's silence bears down through it, crushing the warmth and the air out of you at once! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.unsung-mute-sentry.json
+++ b/data/attacks/attack.unsung-mute-sentry.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.unsung-mute-sentry",
+  "name": "a smothering hold",
+  "min_damage": 44,
+  "max_damage": 64,
+  "hit_bonus": 7,
+  "crit_bonus": 4,
+  "damage_bonus": 11,
+  "weapon_type": "BLUNT",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 45
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The mute sentry folds its wrapped arms around you and presses, and the sound-drinking cloth pulls the warmth and the breath out of you at once in a numbing, smothering cold. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The mute sentry lunges to take you in its wrappings and you twist free of the cold, dead cloth before it can close."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The mute sentry closes its whole wrapped bulk over you and holds, and for a long airless moment there is no sound and no warmth and no breath anywhere in the world! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.unsung-silence-adept.json
+++ b/data/attacks/attack.unsung-silence-adept.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.unsung-silence-adept",
+  "name": "a held-breath curse",
+  "min_damage": 50,
+  "max_damage": 76,
+  "hit_bonus": 8,
+  "crit_bonus": 7,
+  "damage_bonus": 13,
+  "weapon_type": "BLUNT",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 60
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The silence adept lifts a wrapped hand and holds it toward you, and the held breath it will never let go reaches into your chest and takes yours instead, cold and total. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The silence adept turns its doctrine on you and the cold of a thousand held breaths sweeps the catacomb, and you gasp your own back before it can be taken."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The silence adept closes its hand, and every bound and mouth-cloth-gagged corpse on the shelves seems to exhale at once into you, filling your lungs with an airless, killing cold! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.unsung-throatless-partisan.json
+++ b/data/attacks/attack.unsung-throatless-partisan.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.unsung-throatless-partisan",
+  "name": "a silent stroke",
+  "min_damage": 48,
+  "max_damage": 70,
+  "hit_bonus": 8,
+  "crit_bonus": 6,
+  "damage_bonus": 12,
+  "weapon_type": "SLASHING",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 50
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The throatless partisan draws a blade honed on nothing but silence and cuts, and the edge takes not just skin but the sound of the wound, so that you feel the cold of it before you feel the pain. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The throatless partisan strikes for your throat with the mute fury of the wronged, and you throw yourself back from the noiseless blade."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The throatless partisan opens you throat to hip in one silent stroke, and the reliquary of cut voices seems to lean nearer, honoring the price it has made you pay! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/items/shroud-of-refusal.json
+++ b/data/items/shroud-of-refusal.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 14,
+  "id": "shroud-of-refusal",
+  "name": "the Shroud of Refusal",
+  "description": "A cloak cut and sewn from the sound-drinking cloth of the Unsung, the same weave they bind over the mouths of their dead, made whole and worn across the shoulders. It drinks every sound its wearer makes — the scuff of a boot, the rasp of a drawn breath, the whisper of the cloak itself — and gives it back as nothing, wrapping the one who wears it in a pocket of the same held silence the Unsung keep. The cold that lives in it turns the bite of frost and stolen breath aside, and there is a strange comfort in its quiet, the comfort of a thing that has decided, once and forever, to refuse.",
+  "attributes": {
+    "stats": {
+      "ac": 4,
+      "cold_resist": 20,
+      "dexterity": 4
+    }
+  },
+  "effects": [],
+  "messages": [],
+  "equip_slot": "back",
+  "weight": 2,
+  "value": 420,
+  "rarity": "epic",
+  "attack_ref": null
+}

--- a/data/items/the-mute-edge.json
+++ b/data/items/the-mute-edge.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 14,
+  "id": "the-mute-edge",
+  "name": "the Mute Edge",
+  "description": "The blade the Throatless Marshal carried, and the first weapon the Unsung ever made: a long, thin sword of silence-honed bone, its edge worked to a keenness that has nothing to do with metal and everything to do with refusal. It makes no sound. Drawn, swung, or driven home, it moves in perfect quiet, drinking the noise of its own passage and the cry of whatever it opens, and the cold that lives in the steel-that-is-not-steel is the cold of a held breath a hundred years long. It is light and quick and terribly patient in the hand, a weapon for one strike given without warning, and it asks of its bearer only that they, too, learn to be quiet.",
+  "attributes": {
+    "stats": {
+      "strength": 6,
+      "dexterity": 6,
+      "cold_resist": 10
+    }
+  },
+  "effects": [],
+  "messages": [],
+  "equip_slot": "weapon",
+  "weight": 4,
+  "value": 660,
+  "rarity": "epic",
+  "attack_ref": "attack.the-mute-edge"
+}

--- a/data/items/the-unsung-map.json
+++ b/data/items/the-unsung-map.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 14,
+  "id": "the-unsung-map",
+  "name": "Map of the Unsung",
+  "description": "A chart of the catacombs beneath the Choir, drawn not in ink but in absence: the passages are the places where the sound-drinking cloth has been cut away, so that the map is read by silence against silence, its routes traced in a quiet a shade deeper than the parchment around them. It is cold to hold and heavier than it looks, and when you bring it near your ear you hear nothing at all — a nothing so complete it has a shape, the shape of every voice the Unsung cut out rather than sing.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [],
+  "messages": [],
+  "weight": 1,
+  "value": 60,
+  "map_area_id": "the-unsung"
+}

--- a/data/items/woven-silence-skein.json
+++ b/data/items/woven-silence-skein.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 14,
+  "id": "woven-silence-skein",
+  "name": "a skein of woven silence",
+  "description": "A hank of the sound-drinking cloth the Unsung wrap themselves in, but this length is different — spun and woven not from any thread but from silence itself, from the held breath of every throat that refused the chord, drawn out into a fiber and worked on a loom of pure refusal. It weighs nothing and drinks every sound that comes near it, so that holding it is like holding a small pocket of the world with the volume turned all the way down, and the cold that comes off it is the cold of a breath held too long and never let go. Tanners and enchanters would give a great deal for it: a thing that could be worked into a ward against sound, or a cloak that swallows a footfall, or an edge honed on nothing but quiet — but only by a hand patient enough not to hum, not to breathe too loud, not to give it any note at all to unravel around.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [],
+  "messages": [],
+  "weight": 1,
+  "value": 165,
+  "rarity": "rare"
+}

--- a/data/mobs/the-throatless-marshal.json
+++ b/data/mobs/the-throatless-marshal.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 4,
+  "id": "the-throatless-marshal",
+  "name": "the Throatless Marshal",
+  "max_hp": 1320,
+  "attack_id": "attack.throatless-marshal",
+  "special_attack_id": "attack.throatless-marshal-hush",
+  "aggressive": true,
+  "world_boss": true,
+  "tags": ["undead", "silent", "boss", "the-unsung"],
+  "spawn_room_id": "unsung-last-stand",
+  "max_count": 1,
+  "respawn_ticks": 360,
+  "xp_reward": 3000,
+  "loot": [
+    {
+      "item_id": "the-mute-edge",
+      "drop_chance": 0.4
+    },
+    {
+      "item_id": "shroud-of-refusal",
+      "drop_chance": 0.4
+    },
+    {
+      "item_id": "woven-silence-skein",
+      "drop_chance": 1.0
+    },
+    {
+      "item_id": "the-unsung-map",
+      "drop_chance": 1.0
+    },
+    {
+      "item_id": "world-atlas",
+      "drop_chance": 0.1
+    }
+  ],
+  "gold_drop": {
+    "min": 620,
+    "max": 960
+  }
+}

--- a/data/mobs/unsung-barricade-warden.json
+++ b/data/mobs/unsung-barricade-warden.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "unsung-barricade-warden",
+  "name": "a barricade warden",
+  "max_hp": 640,
+  "attack_id": "attack.unsung-barricade-warden",
+  "aggressive": true,
+  "tags": ["undead", "silent", "the-unsung"],
+  "spawn_room_id": "unsung-barricade",
+  "max_count": 1,
+  "respawn_ticks": 90,
+  "xp_reward": 780,
+  "loot": [
+    {
+      "item_id": "woven-silence-skein",
+      "drop_chance": 0.25
+    }
+  ],
+  "gold_drop": {
+    "min": 170,
+    "max": 260
+  }
+}

--- a/data/mobs/unsung-mute-sentry.json
+++ b/data/mobs/unsung-mute-sentry.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "unsung-mute-sentry",
+  "name": "a mute sentry",
+  "max_hp": 480,
+  "attack_id": "attack.unsung-mute-sentry",
+  "aggressive": true,
+  "tags": ["undead", "silent", "the-unsung"],
+  "spawn_room_id": "unsung-hall-of-refusal",
+  "max_count": 2,
+  "respawn_ticks": 70,
+  "xp_reward": 640,
+  "loot": [
+    {
+      "item_id": "woven-silence-skein",
+      "drop_chance": 0.15
+    }
+  ],
+  "gold_drop": {
+    "min": 130,
+    "max": 210
+  }
+}

--- a/data/mobs/unsung-silence-adept.json
+++ b/data/mobs/unsung-silence-adept.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "unsung-silence-adept",
+  "name": "a silence adept",
+  "max_hp": 560,
+  "attack_id": "attack.unsung-silence-adept",
+  "aggressive": true,
+  "tags": ["undead", "silent", "the-unsung"],
+  "spawn_room_id": "unsung-catacomb-of-dissent",
+  "max_count": 2,
+  "respawn_ticks": 80,
+  "xp_reward": 760,
+  "loot": [
+    {
+      "item_id": "woven-silence-skein",
+      "drop_chance": 0.25
+    }
+  ],
+  "gold_drop": {
+    "min": 160,
+    "max": 250
+  }
+}

--- a/data/mobs/unsung-throatless-partisan.json
+++ b/data/mobs/unsung-throatless-partisan.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "unsung-throatless-partisan",
+  "name": "a throatless partisan",
+  "max_hp": 520,
+  "attack_id": "attack.unsung-throatless-partisan",
+  "aggressive": true,
+  "tags": ["undead", "silent", "the-unsung"],
+  "spawn_room_id": "unsung-gallery-of-cut-throats",
+  "max_count": 2,
+  "respawn_ticks": 75,
+  "xp_reward": 700,
+  "loot": [
+    {
+      "item_id": "woven-silence-skein",
+      "drop_chance": 0.2
+    }
+  ],
+  "gold_drop": {
+    "min": 150,
+    "max": 240
+  }
+}

--- a/data/rooms/bonelight-choir-nave.json
+++ b/data/rooms/bonelight-choir-nave.json
@@ -5,7 +5,8 @@
   "description": "The far arch lets you out into the nave itself, the great heart of the cathedral, and the single held note that has followed you down through every chamber finally resolves into what makes it: a choir. The whole vast space, floor to unseen vault, is one continuous body of fused bone arranged into rank on rising rank of throats — thousands upon thousands of skulls, jaws propped open, tiered like a congregation without end — and every one of them is singing. It is not a sound anymore at this range but a substance, a single unified voice woven from every throat the Marrow Bloom ever silenced, calcified and ordered and given back its breath, and it holds you where you stand. At the nave's focus, where all the ranks converge, the choir has grown itself a conductor: a towering figure of knitted spine and fused wing-bone and a corona of open, singing skulls, turning now, without hurry, its countless mouths bending their one note toward you until the whole cathedral is aimed at you like a struck chord. This is what the hunger built. It has been waiting to add your voice to it.",
   "item_ids": [],
   "exits": {
-    "up": "bonelight-bell-crypt"
+    "up": "bonelight-bell-crypt",
+    "down": "unsung-threshold"
   },
   "min_level": 54,
   "is_outdoor": false,

--- a/data/rooms/unsung-barricade.json
+++ b/data/rooms/unsung-barricade.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 8,
+  "id": "unsung-barricade",
+  "name": "The Barricade of Silence",
+  "description": "The west way is blocked, and the block is a work of grim ingenuity. Across the passage the Unsung have raised a barricade from the only two materials they have ever had: bone, hauled from the cathedral above and stacked into a rampart the height of two people, and silence, packed into every gap and joint of it like mortar. It should not hold — it is only stacked bone — but the silence in it is a structural thing, a refusal so dense it bears load, and where you press against it the barricade presses back with a numbing, breath-stealing cold that climbs your arm to the shoulder. A single low sally-gap has been left open, and it is guarded. The barricade warden that keeps it does not challenge you; it simply plants itself in the gap, wrapped and mute and immovable, and waits for you to be foolish enough to try the crossing.",
+  "item_ids": [],
+  "exits": {
+    "east": "unsung-hall-of-refusal"
+  },
+  "min_level": 60,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "The silence packed into the barricade shifts and settles, and a breath of numbing cold rolls out of the stacked bone across the floor.",
+    "The barricade warden adjusts its stance in the sally-gap without a sound, and the cold in the air deepens a degree.",
+    "A single bone works loose somewhere high in the rampart and falls — and lands, impossibly, without a sound, swallowed whole before it strikes."
+  ]
+}

--- a/data/rooms/unsung-catacomb-of-dissent.json
+++ b/data/rooms/unsung-catacomb-of-dissent.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 8,
+  "id": "unsung-catacomb-of-dissent",
+  "name": "The Catacomb of Dissent",
+  "description": "Below the hall the ways draw together again into a true catacomb, and here the silence has been made into something more than defense — it has been made into doctrine. The walls are shelved floor to ceiling with the dead of the Unsung, laid to rest each with a strip of the sound-drinking cloth bound over the mouth, so that even in death they hold their refusal, even in death they will not be made to sing. Between the shelves move the silence adepts, the keepers of the doctrine, and where the sentries above are merely mute these have made an art of it: the cold that leaks from them is the cold of a held breath that will never be let go, and it reaches for the warmth of yours. The catacomb slopes steadily downward toward a single sealed way at its far end, and from beyond that seal comes nothing at all — the deepest silence you have ever stood in, the silence of the one who leads them, who has never in the whole long refusal made a single sound.",
+  "item_ids": [],
+  "exits": {
+    "up": "unsung-hall-of-refusal",
+    "down": "unsung-last-stand"
+  },
+  "min_level": 61,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "A silence adept passes between the shelves, and the bound dead seem to lean fractionally toward it, held in the same long refusal.",
+    "A strip of mouth-cloth on one of the shelved dead has come loose, and an adept pauses to bind it fast again before moving on.",
+    "The cold from the sealed way at the catacomb's end reaches up the slope toward you, patient and total, and your breath frosts in the black air."
+  ]
+}

--- a/data/rooms/unsung-gallery-of-cut-throats.json
+++ b/data/rooms/unsung-gallery-of-cut-throats.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 8,
+  "id": "unsung-gallery-of-cut-throats",
+  "name": "The Gallery of Cut Throats",
+  "description": "The pale, small things the guttering light caught are relics, and the gallery is a reliquary of refusal. Set in niches along both walls, each on its own bed of dark cloth, are voices — or what is left of them: the excised throats of the Unsung, cut out by their own hands and kept, dried and dark and terribly quiet, as proof of a price paid and a song not sung. There are hundreds of them, and the oldest have gone to little more than knots of shadow, but every niche is tended, dusted, honored. This is not a charnel house; it is a shrine. The throatless partisans who keep it move between the niches with a devotion that has no words because it has renounced words, and they resent your intrusion into their reliquary with a cold, mute fury. To be here at all, breathing, throat intact, is an obscenity to them.",
+  "item_ids": [],
+  "exits": {
+    "west": "unsung-hall-of-refusal"
+  },
+  "min_level": 59,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "A throatless partisan pauses at a niche, lays a wrapped hand against a dried and darkened relic, and bows its head in a silence that is somehow a prayer.",
+    "The dark cloth beneath the relics drinks the last of the light near the far niches, and the shrine seems to lengthen away into black.",
+    "One of the excised throats, ancient and shrunken, shifts fractionally on its bed of cloth as though it had tried, and failed, to make a sound."
+  ]
+}

--- a/data/rooms/unsung-hall-of-refusal.json
+++ b/data/rooms/unsung-hall-of-refusal.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 8,
+  "id": "unsung-hall-of-refusal",
+  "name": "The Hall of Refusal",
+  "description": "The stair opens into a long, low hall whose vaulted ceiling has been hung so thick with muffling cloth that the dark seems to sag under its own weight. This is where the refusal is kept, where the Unsung first made their stand against the chord, and the walls remember it: gouged deep with the same word over and over in a hundred failing hands, a word you cannot read but understand at once to mean *no*. Mute sentries keep the hall, wrapped throat to crown in the sound-drinking cloth, and they turn toward you not at any noise you make but at the mere fact of you, an intrusion in the held quiet. Three ways lead on from here. East, a gallery where the guttering light catches on rows of something pale and small. West, a barricade thrown up from bone and silence together. And down, past both, where the dark thickens toward whatever the Unsung have set at the bottom of themselves to protect.",
+  "item_ids": [],
+  "exits": {
+    "up": "unsung-threshold",
+    "east": "unsung-gallery-of-cut-throats",
+    "west": "unsung-barricade",
+    "down": "unsung-catacomb-of-dissent"
+  },
+  "min_level": 58,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "A mute sentry shifts its weight from one foot to the other, its wrappings drinking even the whisper of cloth on cloth, and stills again.",
+    "The gouged word on the wall seems for a moment to deepen, as though a hundred silent hands were carving it anew.",
+    "Your own breathing sounds suddenly loud and wrong in the held quiet, and you find yourself trying, absurdly, to breathe softer."
+  ]
+}

--- a/data/rooms/unsung-last-stand.json
+++ b/data/rooms/unsung-last-stand.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 8,
+  "id": "unsung-last-stand",
+  "name": "The Last Stand",
+  "description": "The seal gives, and you step into the silence at the bottom of the Unsung. It is a round chamber, domed, and every surface of it — floor, wall, the curve of the vault overhead — is hung and packed and layered with the sound-drinking cloth until the room is a throat lined against all sound, a place built to hold one refusal so completely that nothing, not the Choir's whole held chord, could ever reach in and break it. In the center of that perfect quiet stands the Throatless Marshal. It is the oldest of them and the first, the one who cut its own voice out before any other and led the rest into the dark, and it has never in all the long refusal made a single sound — not a war-cry, not an order, not a scream. It gives none now. It simply turns its wrapped and eyeless head toward you, and the silence in the chamber tightens like a fist around your chest, dragging the breath and the warmth and the very sound out of you, because to the Marshal you are the Choir's voice come down the stair at last, the compulsion made flesh, and the whole long silence of the Unsung has been sharpened to a single point to answer you. This is the last stand. There is no song here. There is only the refusal, and it means to have you.",
+  "item_ids": [],
+  "exits": {
+    "up": "unsung-catacomb-of-dissent"
+  },
+  "min_level": 62,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "The Marshal shifts its weight in the perfect quiet, and the silence tightens a notch, pressing the breath flatter in your chest.",
+    "The layered cloth of the walls drinks the last small sound of your own heartbeat, and for a moment you cannot hear it at all.",
+    "The Throatless Marshal lifts one wrapped hand a fraction, giving an order no voice will ever carry, and the cold in the chamber answers it instead."
+  ]
+}

--- a/data/rooms/unsung-threshold.json
+++ b/data/rooms/unsung-threshold.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 8,
+  "id": "unsung-threshold",
+  "name": "The Unsung Threshold",
+  "description": "You expected the nave floor to be solid, and it is not. Where the ranks of the choir converge, the fused bone thins and cracks, and a stair falls away beneath the cathedral's own reliquary into a dark the held note cannot follow. You go down, and with every step the single overwhelming voice of the Choir grows fainter, not because you are moving away from it but because something down here is refusing it — pressing back against the chord with a silence so total it has weight. At the foot of the stair the note simply stops, cut off clean, and the quiet that replaces it is not empty. It is held, the way a breath is held, the way a scream is held behind clenched teeth. These are the catacombs of the Unsung: the ones the Bloom swallowed who would not join the song, who cut their own voices out rather than be made to sing, and who have been down here in the mute dark ever since, refusing. The walls are hung with dark cloth that drinks every sound, and the silence watches you as intently as any sentry.",
+  "item_ids": [],
+  "exits": {
+    "up": "bonelight-choir-nave",
+    "down": "unsung-hall-of-refusal"
+  },
+  "min_level": 57,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "The Choir's held note leaks faintly down the stair behind you and is swallowed whole by the muffling dark, gone as though it never sounded.",
+    "A length of sound-drinking cloth stirs on the wall, though no air moves, and the quiet deepens where it settles.",
+    "Somewhere ahead a footstep falls, deliberate and unhurried, and makes no sound at all — you feel it in the floor rather than hear it."
+  ]
+}

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -149,6 +149,7 @@ a validator rule, not a manual checkbox.
 | The Voidscar (`voidscar`) | ✅ #559 | ✅ (voidscar-cull, voidscar-unlight #561) | ✅ #559 |
 | The Marrow Bloom (`marrow-bloom`) | ✅ #579 | ✅ (marrow-cull, marrow-bloom #581) | ✅ #579 |
 | The Bonelight Choir (`bonelight-choir`) | ✅ #608 | ✅ (bonelight-cull, bonelight-choir #609) | ✅ #608 |
+| The Unsung (`the-unsung`) | ✅ #633 | 🔨 (#634) | ✅ #633 |
 
 ## Systems
 


### PR DESCRIPTION
Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)