### PR TITLE
feat(quest): add The Unsung quest chain closing the area's quest-coverage gap

### DIFF
--- a/data/quests/quest.unsung-cull.json
+++ b/data/quests/quest.unsung-cull.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "id": "unsung-cull",
+  "name": "Break the Held Quiet",
+  "description": "The stair down from the Bonelight Choir does not open into more song but into its opposite: a muffling dark that drinks every sound, held so tight it has weight. At the foot of the stair the Hall of Refusal is kept by mute sentries, wrapped throat to crown in sound-drinking cloth, and they turn toward you not at any noise you make but at the mere fact of you — a living intrusion in a silence the Unsung cut their own voices out to keep. Break eight of the sentries where they stand the hall, before the held quiet closes over your own breath, and the deeper catacombs may open before the refusal decides you are the Choir's voice come down the stair at last.",
+  "target_mob_id": "unsung-mute-sentry",
+  "required_kills": 8,
+  "gold_reward": 260,
+  "xp_reward": 650,
+  "recommended_level": 57
+}

--- a/data/quests/quest.unsung-last-stand.json
+++ b/data/quests/quest.unsung-last-stand.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "unsung-last-stand",
+  "name": "The Marshal's Refusal",
+  "description": "The sentries were only the outer wards. Down past the Catacomb of Dissent, in a domed chamber hung and packed and layered with sound-drinking cloth until the room is a throat lined against all sound, stands the oldest of the Unsung and the first: the Throatless Marshal, who cut its own voice out before any other and led the rest into the mute dark. It has never in all the long refusal made a single sound, and it gives none now — it simply turns its wrapped and eyeless head toward you, and the silence tightens like a fist around your chest, because to the Marshal you are the Choir's voice come down the stair at last, the compulsion made flesh. Cross the last stand, break the Marshal where it lifts its silence against you, and let the Unsung's refusal end on its own terms rather than the cathedral's.",
+  "target_mob_id": "the-throatless-marshal",
+  "required_kills": 1,
+  "gold_reward": 680,
+  "xp_reward": 1700,
+  "title_reward": "Silence-Ender",
+  "reputation_reward_faction_id": "militia",
+  "reputation_reward_delta": 35,
+  "recommended_level": 62,
+  "repeatable": false,
+  "prerequisite_quest_id": "unsung-cull"
+}

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -149,7 +149,7 @@ a validator rule, not a manual checkbox.
 | The Voidscar (`voidscar`) | ✅ #559 | ✅ (voidscar-cull, voidscar-unlight #561) | ✅ #559 |
 | The Marrow Bloom (`marrow-bloom`) | ✅ #579 | ✅ (marrow-cull, marrow-bloom #581) | ✅ #579 |
 | The Bonelight Choir (`bonelight-choir`) | ✅ #608 | ✅ (bonelight-cull, bonelight-choir #609) | ✅ #608 |
-| The Unsung (`the-unsung`) | ✅ #633 | 🔨 (#634) | ✅ #633 |
+| The Unsung (`the-unsung`) | ✅ #633 | ✅ (unsung-cull, unsung-last-stand #634) | ✅ #633 |
 
 ## Systems
 


### PR DESCRIPTION
Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)