### PR TITLE
feat(world): add The Coda, a level 81-88 zone beyond The Interval

### DIFF
--- a/data/areas/atlas.json
+++ b/data/areas/atlas.json
@@ -35,6 +35,8 @@
     "                        [The Undersong]",
     "                              |",
     "                         [The Interval]",
+    "                              |",
+    "                          [The Coda]",
     "",
     "   Lines mark the roads and passages between",
     "   the great areas of the realm."

--- a/data/areas/the-coda.json
+++ b/data/areas/the-coda.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "id": "the-coda",
+  "name": "The Coda",
+  "room_ids": [
+    "coda-threshold",
+    "coda-overtone-hall",
+    "coda-falling-stroke",
+    "coda-last-silence",
+    "coda-final-measure",
+    "coda-resolution"
+  ],
+  "connections": [
+    "the-interval"
+  ],
+  "level_range": {
+    "min": 81,
+    "max": 88
+  },
+  "ascii_map": [
+    "         ... THE CODA ...",
+    "",
+    "               The Interval",
+    "                    ^",
+    "                    |",
+    "               [Threshold]",
+    "                    |",
+    "  [Falling]--[Overtone Hall]--[Last Silence]",
+    "                    |",
+    "              [Final Measure]",
+    "                    |",
+    "               [Resolution]",
+    "",
+    "   Not a place deeper than the interval but after it,",
+    "   where the held stroke the Fermata refused to release",
+    "   has finally fallen — the released overtones, the last",
+    "   silence after the last measure, and the resolving",
+    "   chord the whole music has been building toward."
+  ]
+}

--- a/data/attacks/attack.coda-falling-stroke-wraith.json
+++ b/data/attacks/attack.coda-falling-stroke-wraith.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.coda-falling-stroke-wraith",
+  "name": "an unstoppable fall",
+  "min_damage": 84,
+  "max_damage": 112,
+  "hit_bonus": 13,
+  "crit_bonus": 10,
+  "damage_bonus": 22,
+  "weapon_type": "BLUNT",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 66
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The falling-stroke wraith drops onto you the whole stored weight of the Fermata's withheld motion, an age of held stillness spent in a single unstoppable descent, and the cold of it lands with the crushing force of a beat too long deferred. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The falling-stroke wraith plunges its released weight toward you and the cold of the whole spent measure comes down with it, and you throw yourself clear of the fall and let the crushing stroke land where you were and slide on past."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The falling-stroke wraith brings the entire released stroke down onto you alone, every hair of the eternity the Fermata held it back gathered into one plunging beat, and the cold of it drives so deep that your heart lurches to fall with it! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.coda-hollow-chord.json
+++ b/data/attacks/attack.coda-hollow-chord.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.coda-hollow-chord",
+  "name": "a hungry absence",
+  "min_damage": 82,
+  "max_damage": 110,
+  "hit_bonus": 12,
+  "crit_bonus": 10,
+  "damage_bonus": 21,
+  "weapon_type": "BLUNT",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 68
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The hollow chord closes the exact shape of a missing note around you, an absence with edges, and where the sound should be there is only a cold so complete it pulls the warmth out of you to fill itself. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The hollow chord opens its hungry absence toward you and the cold rushes in to be filled, and you press back out of the shape of the missing note until it closes on empty air and finds nothing to swallow."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The hollow chord collapses the whole shape of its absence onto your heart at once, and the emptiness pulls so hard and so cold that for a moment it feels as though the beat itself were being drawn out of you to fill the silence where a note should be! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.coda-last-silence-wisp.json
+++ b/data/attacks/attack.coda-last-silence-wisp.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.coda-last-silence-wisp",
+  "name": "a swallowing quiet",
+  "min_damage": 78,
+  "max_damage": 106,
+  "hit_bonus": 12,
+  "crit_bonus": 9,
+  "damage_bonus": 19,
+  "weapon_type": "BLUNT",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 64
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The last-silence wisp folds the quiet that comes after the final note around your throat, and the swallowing stillness of it drives in cold and total, hungry for the one pulse still sounding in all that finished silence. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The last-silence wisp reaches its swallowing quiet toward you and the finished cold gathers to close, and you keep your heartbeat moving and slip through the stillness before it can settle around you."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The last-silence wisp wraps the whole of its finished quiet around your single pulse at once, and the swallowing cold drives so deep that for one drowning instant even the sound of your own blood seems about to be taken into the silence! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.coda-loosed-overtone.json
+++ b/data/attacks/attack.coda-loosed-overtone.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.coda-loosed-overtone",
+  "name": "a released ring",
+  "min_damage": 80,
+  "max_damage": 108,
+  "hit_bonus": 12,
+  "crit_bonus": 9,
+  "damage_bonus": 20,
+  "weapon_type": "BLUNT",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 70
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The loosed overtone spreads its released ring straight through you, a higher voice climbing loose from some struck note and passing as pure cold vibration that rings the bones of you against one another as it goes. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The loosed overtone lifts its thin bright ring toward you and the cold of the decaying note rushes in with it, and you step through the space between two spreading rings where the sound thins to nothing."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The loosed overtone narrows its whole released ring down to the width of your heart, and the climbing cold drives so high and so deep that for one long moment every bone in you rings a single thin killing note in answer! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.the-coda-final-chord.json
+++ b/data/attacks/attack.the-coda-final-chord.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.the-coda-final-chord",
+  "name": "The Final Chord",
+  "min_damage": 104,
+  "max_damage": 136,
+  "hit_bonus": 10,
+  "crit_bonus": 9,
+  "damage_bonus": 26,
+  "weapon_type": "BLUNT",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 96
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The Coda sounds the whole of itself at last — the Final Chord, the resolution the Choir began and the Unsung refused and the Undersong sustained and the Interval suspended and the Fermata held one instant short of falling, the entire withheld music of the world coming down in a single closing beat, and it lands on your borrowed heartbeat like the end of everything, folding breath and warmth and count under the last chord the phrase was ever building toward. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The Coda unleashes the Final Chord and the whole chamber resolves with it, an eternity of withheld music coming down in one cold closing stroke, and you press flat to the frost-sheeted floor and let the ending crash over you until the last of the chord spends itself and the silence after begins."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The Coda bends the entire Final Chord down onto you alone, every note the music ever held back since the world's first breath falling on your single pulse at once, and for one endless drowning instant your borrowed rhythm is seized and resolved and spent, your own heart tolling the last beat of the last measure the world will ever count! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.the-coda.json
+++ b/data/attacks/attack.the-coda.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.the-coda",
+  "name": "a closing chord",
+  "min_damage": 92,
+  "max_damage": 122,
+  "hit_bonus": 13,
+  "crit_bonus": 10,
+  "damage_bonus": 24,
+  "weapon_type": "BLUNT",
+  "damage_type": "COLD",
+  "applies_effect": {
+    "effect_id": "freeze",
+    "chance_percent": 74
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The Coda lets a fraction of its closing chord fall onto you, no more than a hair of the resolution it is gathering, and even that sliver of released cold drives through flesh and bone and folds your pulse a little further under the ending it means to complete. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The Coda tips its resolving chord toward you and the cold of the whole gathering close comes with it — and you break your rhythm and step off the beat, and the chord draws itself back short of you, unresolved, refusing to spend its ending early."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The Coda narrows its closing chord down to the width of your heart and lets a single beat of it land, and the cold of that one resolving instant drives so deep that every bone in you rings once with the ending it has been building toward since the world's first note! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/items/resolved-overtone.json
+++ b/data/items/resolved-overtone.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 15,
+  "id": "resolved-overtone",
+  "name": "a resolved overtone",
+  "description": "A single released overtone caught at the instant of its resolution and somehow kept from ending — a bead of the higher voice that lifts loose from a struck note as it decays, drawn out of the Coda's closing chord and held in a lattice of finished cold that rings one last unhurried tone against the palm, always a hair short of the silence it is falling toward and never quite reaching it. It is rarer than a mote of underhum resonance and stranger than a splinter of held breath: where the mote rings a note that outlasts silence and the splinter holds a stillness that outlasts sound, this is the resolution itself, the released ending of the world's oldest chord, kept from completing so that a hand might work it before it decays to nothing. Bonewrights and rune-singers speak of it in the hushed way of people naming a thing they are not sure should exist, certain it could be worked into a ward that ends every blow the way a chord ends a phrase, or an edge that resolves whatever it strikes — but only by a hand willing to let a little of itself resolve along with the note it means to shape.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [],
+  "messages": [],
+  "weight": 1,
+  "value": 220,
+  "rarity": "epic"
+}

--- a/data/items/the-coda-map.json
+++ b/data/items/the-coda-map.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 15,
+  "id": "the-coda-map",
+  "name": "Map of the Coda",
+  "description": "Not a chart of any place with extent, but a rendering of an ending — the last bar of a piece of music scored onto a leaf of frost-clouded vellum, its final measure closed off by a thin double line ruled the way a composer rules the end of a score, past which there is nothing because there is meant to be nothing. The route through is read the way a musician reads the close of a phrase: not as somewhere to go but as a resolution to arrive at, threshold to the resolving chord, each measure a step nearer the last one the world will ever count. It is colder than the map of the Interval and it does not wait the way that one waits; it resolves, faintly and continuously, a leaf of vellum forever in the act of ending and never quite finished, so that to hold it is to feel your own pulse counted down against its closing bars toward the double line beyond which the map, like the music, simply stops.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [],
+  "messages": [],
+  "weight": 1,
+  "value": 80,
+  "map_area_id": "the-coda"
+}

--- a/data/mobs/coda-falling-stroke-wraith.json
+++ b/data/mobs/coda-falling-stroke-wraith.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "coda-falling-stroke-wraith",
+  "name": "a falling-stroke wraith",
+  "max_hp": 1150,
+  "attack_id": "attack.coda-falling-stroke-wraith",
+  "aggressive": true,
+  "tags": ["construct", "resonant", "the-coda"],
+  "spawn_room_id": "coda-falling-stroke",
+  "max_count": 2,
+  "respawn_ticks": 88,
+  "xp_reward": 1680,
+  "loot": [
+    {
+      "item_id": "resolved-overtone",
+      "drop_chance": 0.35
+    }
+  ],
+  "gold_drop": {
+    "min": 320,
+    "max": 470
+  }
+}

--- a/data/mobs/coda-hollow-chord.json
+++ b/data/mobs/coda-hollow-chord.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "coda-hollow-chord",
+  "name": "a hollow chord",
+  "max_hp": 1120,
+  "attack_id": "attack.coda-hollow-chord",
+  "aggressive": true,
+  "tags": ["construct", "resonant", "the-coda"],
+  "spawn_room_id": "coda-last-silence",
+  "max_count": 2,
+  "respawn_ticks": 86,
+  "xp_reward": 1620,
+  "loot": [
+    {
+      "item_id": "resolved-overtone",
+      "drop_chance": 0.35
+    }
+  ],
+  "gold_drop": {
+    "min": 310,
+    "max": 460
+  }
+}

--- a/data/mobs/coda-last-silence-wisp.json
+++ b/data/mobs/coda-last-silence-wisp.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "coda-last-silence-wisp",
+  "name": "a last-silence wisp",
+  "max_hp": 1180,
+  "attack_id": "attack.coda-last-silence-wisp",
+  "aggressive": true,
+  "tags": ["construct", "resonant", "the-coda"],
+  "spawn_room_id": "coda-final-measure",
+  "max_count": 1,
+  "respawn_ticks": 95,
+  "xp_reward": 1720,
+  "loot": [
+    {
+      "item_id": "resolved-overtone",
+      "drop_chance": 0.4
+    }
+  ],
+  "gold_drop": {
+    "min": 330,
+    "max": 490
+  }
+}

--- a/data/mobs/coda-loosed-overtone.json
+++ b/data/mobs/coda-loosed-overtone.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "coda-loosed-overtone",
+  "name": "a loosed overtone",
+  "max_hp": 1060,
+  "attack_id": "attack.coda-loosed-overtone",
+  "aggressive": true,
+  "tags": ["construct", "resonant", "the-coda"],
+  "spawn_room_id": "coda-overtone-hall",
+  "max_count": 3,
+  "respawn_ticks": 84,
+  "xp_reward": 1520,
+  "loot": [
+    {
+      "item_id": "resolved-overtone",
+      "drop_chance": 0.3
+    }
+  ],
+  "gold_drop": {
+    "min": 300,
+    "max": 440
+  }
+}

--- a/data/mobs/the-coda.json
+++ b/data/mobs/the-coda.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 4,
+  "id": "the-coda",
+  "name": "the Coda",
+  "max_hp": 2200,
+  "attack_id": "attack.the-coda",
+  "special_attack_id": "attack.the-coda-final-chord",
+  "aggressive": true,
+  "world_boss": true,
+  "tags": ["construct", "resonant", "boss", "the-coda"],
+  "spawn_room_id": "coda-resolution",
+  "max_count": 1,
+  "respawn_ticks": 360,
+  "xp_reward": 4700,
+  "loot": [
+    {
+      "item_id": "resolved-overtone",
+      "drop_chance": 1.0
+    },
+    {
+      "item_id": "the-coda-map",
+      "drop_chance": 1.0
+    },
+    {
+      "item_id": "world-atlas",
+      "drop_chance": 0.1
+    }
+  ],
+  "gold_drop": {
+    "min": 950,
+    "max": 1450
+  }
+}

--- a/data/rooms/coda-falling-stroke.json
+++ b/data/rooms/coda-falling-stroke.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 8,
+  "id": "coda-falling-stroke",
+  "name": "The Falling",
+  "description": "East of the hall the released ring narrows into a long steep gallery where the Fermata's withheld motion, finally let go, is still falling. The whole room is downward: the ruled lines of the floor pitch away ahead of you, the frost slides, the loosed overtones here do not spread but plunge, and everything the Interval held poised and unmoving for an eternity is here spending that stored stillness all at once in a single unstoppable descent. This is what a held stroke becomes the instant it is released — not gentle, not finished, but momentum, the accumulated weight of an age of withholding coming down with nothing left to catch it. Things move in the falling: shapes wrung out of the released stroke, all of them dropping, all of them carrying the crushing downward force of a beat too long deferred, and they fall toward you the way the Fermata meant to, except that these have already been let go and cannot be called back. There is no arresting them and no waiting them out; a fall does not pause. The only way onward loops back west to the ringing hall, because a falling stroke was never meant to arrive anywhere but the bottom.",
+  "item_ids": [],
+  "exits": {
+    "west": "coda-overtone-hall"
+  },
+  "min_level": 82,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "A loosed shape drops past you down the pitched floor, trailing the crushing weight of the whole withheld measure, and does not slow.",
+    "Frost slides in a long unstoppable sheet down the gallery, gathering speed, spending an eternity of held stillness in a single fall.",
+    "The room tilts a fraction steeper, and everything in it — cold, sound, the wrung-loose shapes of the stroke — leans further into the fall that will not end until it lands."
+  ]
+}

--- a/data/rooms/coda-final-measure.json
+++ b/data/rooms/coda-final-measure.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 8,
+  "id": "coda-final-measure",
+  "name": "The Final Measure",
+  "description": "The hall steps down a last time into a long narrow corridor scored with a single bar of music that has only one thing left to do. This is the final measure, the last counted length of the whole piece, and unlike every measure of the Interval above it this one is not empty and not waiting — it is closing, the ruled lines crowding forward toward a single point ahead where the last chord means to fall and, this time, will. You can feel the difference in your chest: the beat here is not held back, it is arriving, the count running down toward its resolution one step at a time with the awful certainty of a thing that has finally decided to end. The cold gathers ahead rather than around you, drawn toward the far chamber where something is lifting into the last chord of the entire music-that-refused-to-end, the resolution the Choir demanded and the Unsung denied and the Undersong sustained and the Interval suspended and the Fermata held motionless above your head until you broke it. Now it falls. Ahead, where the measure closes, a wide chamber opens and a great resolving shape gathers toward its final note. The way back leads up to the ringing hall; the way onward, down, is the last step the phrase has left to take.",
+  "item_ids": [],
+  "exits": {
+    "up": "coda-overtone-hall",
+    "down": "coda-resolution"
+  },
+  "min_level": 85,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "The count runs down another step toward the point where the last chord means to land, and this time nothing draws it back.",
+    "Frost cracks in a long line down the crowding corridor, racing forward toward the resolving chamber, and does not stop short of it.",
+    "A pressure builds ahead, the sense of an enormous chord gathering toward its close, and unlike the Fermata's withheld stroke it does not settle again — it comes on."
+  ]
+}

--- a/data/rooms/coda-last-silence.json
+++ b/data/rooms/coda-last-silence.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 8,
+  "id": "coda-last-silence",
+  "name": "The Last Silence",
+  "description": "West of the hall the ringing thins and thins and finally stops, and you step into the silence that comes after the last measure — not the Unsung's cut silence, the absence of a throat that could have sung, and not the Interval's held silence, the breath drawn in and never let go, but the true one, the quiet a piece of music leaves behind it once the last note has finished ending. It is the most complete stillness in the whole descent, and it is not empty. Something lives in the space where the sound has stopped, a shape made of the exact absence the last chord leaves when it finally decays to nothing, and it is hungry in the particular way of a silence that has learned it can be filled. The cold here does not move at all; it has finished moving. Your heartbeat is very loud against it, the only sound left in the room, and the shapes of the last silence turn toward that one remaining pulse the way a starving thing turns toward the only food in an empty house. This is the beat between the coda's opening and its resolving chord, the held-open quiet before the end is allowed to close, and it means to fill itself with you before the chord can fall. The way back lies east to the hall; the silence itself goes nowhere, because silence, once arrived at, has already stopped.",
+  "item_ids": [],
+  "exits": {
+    "east": "coda-overtone-hall"
+  },
+  "min_level": 82,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "The silence deepens by a degree, and for a moment even the sound of your own blood seems about to be swallowed into it.",
+    "A shape of pure absence drifts across the stilled room, shaped like the hole a chord leaves behind it, and turns its hunger toward the one pulse still sounding.",
+    "The cold here does not roll or fall; it simply waits, finished and patient, the quiet of a house after the last guest has gone and before anyone new has come."
+  ]
+}

--- a/data/rooms/coda-overtone-hall.json
+++ b/data/rooms/coda-overtone-hall.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 8,
+  "id": "coda-overtone-hall",
+  "name": "The Hall of Loosed Overtones",
+  "description": "The threshold opens into a vast resonant hall where all the overtones the music kept locked inside its held notes are finally coming free. Where the Interval was a place of poised, arrested stillness, this is the opposite motion made visible: the released ring of a struck thing spreading outward in slow bright rings, the higher voices that live above every sounded note lifting loose one after another now that the note is at last permitted to decay. The air is full of them, faint overlapping tones climbing and thinning and letting go, and the cold that carries them no longer holds anything back — it simply moves, unhurried, the way sound moves through a hall built to let it die beautifully. This is the body of the ending, the space a chord fills in the instant after it is struck for the last time, when everything it was is spreading out and coming apart into its own overtones. Your heartbeat is one more voice among the loosed ring here, and for the first time in the whole descent nothing reaches to seize it; the place has no need to borrow your rhythm, because it is not waiting to begin. It is ending, and it is taking you with it toward the close. Passages break the ringing walls east and west, and at the hall's far end the floor falls away toward a final measure, and past that, the resolving chord.",
+  "item_ids": [],
+  "exits": {
+    "up": "coda-threshold",
+    "east": "coda-falling-stroke",
+    "west": "coda-last-silence",
+    "down": "coda-final-measure"
+  },
+  "min_level": 81,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "A single overtone lifts loose from the ringing air, climbs impossibly high and thin, and lets go, and the whole hall seems to exhale after it.",
+    "The slow bright rings of a released note spread out across the floor, pass through you without seizing anything, and thin away into the cold.",
+    "For a moment the loosed voices overlap into something almost like a chord, then drift apart again, each one taking its own unhurried time to end."
+  ]
+}

--- a/data/rooms/coda-resolution.json
+++ b/data/rooms/coda-resolution.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 8,
+  "id": "coda-resolution",
+  "name": "The Resolution",
+  "description": "The final measure lets you through into a vast closing chamber where the whole withheld music of the world at last has a body, and it is called the Coda — the resolving chord itself, the ending the Choir began and the Unsung refused and the Undersong sustained and the Interval suspended and the Fermata held one arrested instant short of falling for as long as there has been a world to hold it over. It fills the chamber the way the First Hum filled the source and the Fermata filled the gap: not resting and not floating, simply resolving, an enormous slow-closing shape of overtone and released cold and finished silence gathering itself toward the single chord that ends everything the music was ever building toward. It is not sound and it is not the absence of sound. It is the close, the last chord given just enough shape to defend the resolution it has waited an eternity to sound — and it will sound it through you, because a coda needs a final beat to fall on and yours is the living pulse that broke the Fermata and carried the released stroke down here to complete it. As you cross into the chamber the Coda turns the whole closing weight of the world's last chord onto you, and you understand that the phrase does not end when the Coda resolves. It ends when it resolves on something with a heartbeat, and you have brought it the only one there is. There is nothing beyond this. There is only the resolving chord, and it means to end on you.",
+  "item_ids": [],
+  "exits": {
+    "up": "coda-final-measure"
+  },
+  "min_level": 87,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "The Coda gathers a fraction further toward its close, and every loosed overtone in the chamber bends inward toward the single chord it is about to become.",
+    "A ring of finished cold spreads out from the resolving shape and rolls over the floor to break, silent and complete, against your feet.",
+    "For one vast moment the whole chamber seems about to resolve at last, the last chord swelling to the very edge of the final beat — and then it draws breath, and gathers, and leans toward your heartbeat to fall."
+  ]
+}

--- a/data/rooms/coda-threshold.json
+++ b/data/rooms/coda-threshold.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 8,
+  "id": "coda-threshold",
+  "name": "The Falling Stroke",
+  "description": "The Fermata is broken, and the enormous held stroke it kept drawn back since before the first breath of the world finally falls — and you fall with it, not down but forward, carried through the collapsing pause the way a released note is carried out of the instant that held it. This is not deeper than the gap. There was nothing beneath the source and nothing beside the interval; there is only after, the place a piece of music becomes in the instant it is at last allowed to end. The cold here does not grip and does not drown; it lets go. The whole chamber rings faintly with the downbeat that has just landed, the resolving weight of a stroke an eternity in the withholding coming down all at once and, having come down, beginning — slowly, hugely — to resolve. You did not survive the Fermata. You completed it: the living pulse it had waited an age to fall upon, and in falling it did not end you but spent itself, and now the beat it was holding rolls onward through you into whatever the phrase was always meant to reach. Ahead the released sound gathers into a great hall of overtones, and somewhere past it a chord is drawing toward its close. The way back leads up, into the emptied place where the Fermata used to hang.",
+  "item_ids": [],
+  "exits": {
+    "up": "interval-the-fermata",
+    "down": "coda-overtone-hall"
+  },
+  "min_level": 81,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "The last of the Fermata's fallen stroke rolls through the chamber overhead and keeps going, a downbeat that has finally landed and cannot be called back.",
+    "Frost that once held its shape here loosens and drifts, no longer poised, sliding at last toward the floor the way a held breath slides out of the chest.",
+    "Somewhere below, a released overtone rings once, low and vast and unhurried, the sound of a note that has all the time in the world now that it is finally ending."
+  ]
+}

--- a/data/rooms/interval-the-fermata.json
+++ b/data/rooms/interval-the-fermata.json
@@ -5,7 +5,8 @@
   "description": "The last beat lets you through into a great arrested chamber where the pause the whole Interval was made of finally has a body, and it is called the Fermata — the held sign that hangs over a note and commands it to sustain beyond all counting, drawn out for as long as the one who holds it wills. It fills the chamber the way the First Hum filled the source: neither resting nor floating, simply sustained, a vast slow-turning shape of frost and arrested motion caught in the exact instant before a gesture completes, one enormous stroke lifted and held and never allowed to fall. It is not silence and it is not sound. It is the pause itself given just enough shape to defend the beat it refuses to release, the presence that has been living in the gap between every pulse of the Hum since the world drew its first breath, patient and unheard, waiting for something with a rhythm to finish what it has held open for an eternity. As you cross into the chamber the Fermata turns the whole weight of its arrested attention onto you, and you feel your own heartbeat seized and held against the enormous poised stroke like a fly against a drawn bow — and you understand, too late, that it has not been waiting to release the beat. It has been waiting for a living pulse near enough to fall on. There is nothing beside this, as there was nothing beneath the source. There is only the held stroke, and it means to complete itself through you.",
   "item_ids": [],
   "exits": {
-    "up": "interval-last-beat"
+    "up": "interval-last-beat",
+    "down": "coda-threshold"
   },
   "min_level": 78,
   "is_outdoor": false,

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -202,6 +202,7 @@ a validator rule, not a manual checkbox.
 | The Unsung (`the-unsung`) | ✅ #633 | ✅ (unsung-cull, unsung-last-stand #634) | ✅ #633 |
 | The Undersong (`the-undersong`) | ✅ #655 | ✅ (undersong-cull, undersong-source #656) · signature boss loot: the First Hum drops the Underhum Knell + Standing Tone Torc #677 | ✅ #655 |
 | The Interval (`the-interval`) | ✅ #671 | ✅ (interval-cull, interval-fermata #672) · signature boss loot: the Fermata drops the Caesura Stroke + Crown of the Held Beat #677 | ✅ #671 |
+| The Coda (`the-coda`) | ✅ #697 | 🔨 #698 | ✅ #697 (81-88) |
 
 ## Systems
 


### PR DESCRIPTION
Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)