### PR TITLE
feat(world): add The Encore zone beyond The Coda

### DIFF
--- a/data/areas/atlas.json
+++ b/data/areas/atlas.json
@@ -37,6 +37,8 @@
     "                         [The Interval]",
     "                              |",
     "                          [The Coda]",
+    "                              |",
+    "                         [The Encore]",
     "",
     "   Lines mark the roads and passages between",
     "   the great areas of the realm."

--- a/data/areas/the-encore.json
+++ b/data/areas/the-encore.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "id": "the-encore",
+  "name": "The Encore",
+  "room_ids": [
+    "encore-threshold",
+    "encore-empty-seats",
+    "encore-echo-chamber",
+    "encore-standing-call",
+    "encore-final-bow",
+    "encore-ovation"
+  ],
+  "connections": [
+    "the-coda"
+  ],
+  "level_range": {
+    "min": 89,
+    "max": 96
+  },
+  "ascii_map": [
+    "        ... THE ENCORE ...",
+    "",
+    "                The Coda",
+    "                   ^",
+    "                   |",
+    "               [Threshold]",
+    "                   |",
+    "  [Standing]--[Empty Seats]--[Echo]",
+    "                   |",
+    "               [Final Bow]",
+    "                   |",
+    "                [Ovation]",
+    "",
+    "   Not a place deeper than the Coda but against it,",
+    "   the one ending the world would not accept — a hall",
+    "   of empty seats still applauding, every note the",
+    "   music ever played echoing without a source, and at",
+    "   the center the demand for one more piece given form."
+  ]
+}

--- a/data/attacks/attack.encore-clamoring-echo.json
+++ b/data/attacks/attack.encore-clamoring-echo.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.encore-clamoring-echo",
+  "name": "a battering repeat",
+  "min_damage": 92,
+  "max_damage": 122,
+  "hit_bonus": 14,
+  "crit_bonus": 10,
+  "damage_bonus": 23,
+  "weapon_type": "BLUNT",
+  "damage_type": "PHYSICAL",
+  "applies_effect": {
+    "effect_id": "dazed",
+    "chance_percent": 70
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The clamoring echo throws a note the world played an age ago back at you one more time, and another, and another, each repeat harder than the last, hammering the same struck sound into you until your skull rings with it. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The clamoring echo flings its battering repeat toward you and the same old note comes around again to land — and you step through the gap between two reflections where the sound thins to nothing, and it crashes into the wall behind you."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The clamoring echo folds every repeat of the whole worn-out note onto you at once, an age of a sound played back and back and back arriving in a single crash, and for one ringing instant your own heartbeat is drowned under the battering of it! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.encore-hollow-ovation.json
+++ b/data/attacks/attack.encore-hollow-ovation.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.encore-hollow-ovation",
+  "name": "a hollow applause",
+  "min_damage": 90,
+  "max_damage": 120,
+  "hit_bonus": 13,
+  "crit_bonus": 9,
+  "damage_bonus": 22,
+  "weapon_type": "BLUNT",
+  "damage_type": "PHYSICAL",
+  "applies_effect": {
+    "effect_id": "dazed",
+    "chance_percent": 66
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The hollow ovation claps its bodiless applause shut around you, tier on tier of empty seats roaring approval for no performance at all, and the concussion of that praise-without-hands drives into you like a struck drum. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The hollow ovation opens its clapping roar toward you and the wave of empty applause rushes in to break — and you drop beneath the crest of it and let the roar close on the space where you were."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The hollow ovation collapses the whole roar of the empty hall onto your heart at once, a standing ovation for a music that ended long ago crashing down with nothing behind it and everything in it, and for one deafened instant even the sound of your own blood is lost under the clapping! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.encore-standing-call-wraith.json
+++ b/data/attacks/attack.encore-standing-call-wraith.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.encore-standing-call-wraith",
+  "name": "an implacable demand",
+  "min_damage": 94,
+  "max_damage": 124,
+  "hit_bonus": 14,
+  "crit_bonus": 10,
+  "damage_bonus": 24,
+  "weapon_type": "BLUNT",
+  "damage_type": "PHYSICAL",
+  "applies_effect": {
+    "effect_id": "dazed",
+    "chance_percent": 68
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The standing-call wraith drives the whole flat weight of a hall's refusal into you, a wall of insistence with no words in it, the demand for one more piece landing as pure pressure that will not let you be finished. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The standing-call wraith presses its implacable demand toward you and the roaring weight of the refusal comes down with it, and you give way before it and let the insistence drive past you into empty air."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The standing-call wraith brings the entire standing tier's refusal down onto you alone, the whole will of a hall that will not accept an ending crashing onto your single pulse, and for one crushing instant it feels as though it means to wring the encore out of you by force! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.encore-wisp.json
+++ b/data/attacks/attack.encore-wisp.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.encore-wisp",
+  "name": "a wrung encore",
+  "min_damage": 96,
+  "max_damage": 126,
+  "hit_bonus": 14,
+  "crit_bonus": 10,
+  "damage_bonus": 25,
+  "weapon_type": "BLUNT",
+  "damage_type": "PHYSICAL",
+  "applies_effect": {
+    "effect_id": "dazed",
+    "chance_percent": 72
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The encore wisp reaches into your chest for one more measure and wrings it out of you, a piece the finished world never wrote, and the tearing of that unwilling music from your pulse lands with the force of a whole hall's demand made sharp. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The encore wisp reaches for the unspent measure in you and the wrenching demand comes with it, and you keep your heartbeat moving and slip past the grasp before it can tear the next piece loose."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The encore wisp wrings the whole of one more piece out of you at once, playing your borrowed pulse out onto the stage against everything in you, and for one wrenching instant it feels as though it means to take every measure you have left before it lets you stop! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.the-final-encore.json
+++ b/data/attacks/attack.the-final-encore.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 6,
+  "id": "attack.the-final-encore",
+  "name": "the final encore",
+  "weapon_type": "BLUNT",
+  "damage_type": "PHYSICAL",
+  "min_damage": 44,
+  "max_damage": 62,
+  "hit_bonus": 13,
+  "crit_bonus": 14,
+  "damage_bonus": 18,
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "You bring the final encore down on {target}, and the whole roar the Ovation could never spend crashes out of it at once, a hall's worth of refused applause landing in a single hammering demand. Your strike {verb} them!"
+    },
+    {
+      "phase": "attack_hit",
+      "channel": "target",
+      "text": "{source} brings the final encore down on you and the blow arrives roaring, a wall of clapped demand crashing over you before it drives through. The strike {verb} you!"
+    },
+    {
+      "phase": "attack_hit",
+      "channel": "room",
+      "text": "{source} brings the final encore down on {target}, and the crash of it rings through the air like a hall roaring for one more piece."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "You swing the final encore down at {target} and the roar sweeps past, a hall's demand crashing on through empty air with no measure to wring out of it."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "target",
+      "text": "{source} swings the final encore down at you and the wall of applause passes by, dragging a wake of roaring demand where it should have struck."
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "room",
+      "text": "{source} swings the final encore down at {target} and the roaring blow finds only air, its crash thinning back into the dark unspent."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "You loose the whole final encore at once, and the roar the Ovation waited an eternity to spend crashes down on {target} entire, demanding one more measure of them and taking it! Your strike {verb} them!"
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "target",
+      "text": "{source} looses the final encore and the whole roar of a refused ending comes down on you at once, applause crashing over you from every side like a hall that will not let you stop! The strike {verb} you!"
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "room",
+      "text": "{source} looses the final encore into {target}, and the roar it releases hangs crashing in the air a moment too long, as if the whole hall were calling for one more piece."
+    }
+  ]
+}

--- a/data/attacks/attack.the-ovation-encore.json
+++ b/data/attacks/attack.the-ovation-encore.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 7,
+  "id": "attack.the-ovation-encore",
+  "name": "The Encore",
+  "min_damage": 120,
+  "max_damage": 156,
+  "hit_bonus": 12,
+  "crit_bonus": 10,
+  "damage_bonus": 29,
+  "weapon_type": "BLUNT",
+  "damage_type": "PHYSICAL",
+  "telegraph_ticks": 3,
+  "applies_effect": {
+    "effect_id": "dazed",
+    "chance_percent": 96
+  },
+  "messages": [
+    {
+      "phase": "telegraph",
+      "channel": "self",
+      "text": "The Ovation gathers the whole hall into the Encore — every empty seat, every clamoring echo, every standing call drawing back at once into one indrawn breath of applause before it demands the extra piece the world was never meant to play. You have a heartbeat, perhaps two, before the roar comes down on you."
+    },
+    {
+      "phase": "telegraph",
+      "channel": "room",
+      "text": "The Ovation gathers the whole roaring hall into the Encore, the refused ending drawing back into one terrible indrawn breath of applause before the demand for more crashes down."
+    },
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The Ovation sounds the whole of itself at last — the Encore, the one more piece the finished world was never written to play, every empty seat and clamoring echo and standing call crashing down in a single wall of applause that wrings the extra measure out of you by force, playing your borrowed pulse out onto the stage past the point your music was ever meant to stop. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The Ovation unleashes the Encore and the whole hall roars down with it, an eternity of refused ending crashing onto the stage at once, and you press flat beneath the wall of applause and let the demand break over you until the last of the roar spends itself and the calling begins again."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The Ovation bends the entire Encore down onto you alone, the whole refusal of a hall that will not let the world end crashing onto your single pulse at once, and for one drowning instant your borrowed rhythm is seized and wrung and played out onto the stage, your own heart hammering out the extra measure the finished song was never supposed to have! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/attacks/attack.the-ovation.json
+++ b/data/attacks/attack.the-ovation.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 6,
+  "id": "attack.the-ovation",
+  "name": "a rolling ovation",
+  "min_damage": 108,
+  "max_damage": 140,
+  "hit_bonus": 15,
+  "crit_bonus": 11,
+  "damage_bonus": 27,
+  "weapon_type": "BLUNT",
+  "damage_type": "PHYSICAL",
+  "applies_effect": {
+    "effect_id": "dazed",
+    "chance_percent": 78
+  },
+  "messages": [
+    {
+      "phase": "attack_hit",
+      "channel": "self",
+      "text": "The Ovation lets a fraction of its endless applause roll off itself and onto you, no more than a sliver of the roar it is gathering, and even that scrap of clapped demand crashes through flesh and bone and drives one more measure out of your reeling pulse. The blow {verb} you!"
+    },
+    {
+      "phase": "attack_miss",
+      "channel": "self",
+      "text": "The Ovation tips a wave of its rolling applause toward you and the whole demand for more comes with it — and you break your rhythm and step off the beat, and the roar sweeps past you unanswered, calling for an encore you did not give."
+    },
+    {
+      "phase": "attack_crit",
+      "channel": "self",
+      "text": "The Ovation narrows the whole roar of the hall down to the width of your heart and claps it shut, and the concussion of that one demand drives so deep that every bone in you rings once with the single word it is calling — again! The blow {verb} you!"
+    }
+  ]
+}

--- a/data/items/medal-of-the-standing-ovation.json
+++ b/data/items/medal-of-the-standing-ovation.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 15,
+  "id": "medal-of-the-standing-ovation",
+  "name": "the Medal of the Standing Ovation",
+  "description": "A broad disc worn at the throat of the Ovation across the whole length of its endless calling, worked from a single unspent measure drawn out at the instant of its demand and set in clapped air so that it presses one low insistent beat against the collarbone and never quite lets the wearer be finished. Worn, it lays that same refusal across the wearer: the pulse steadies not to the close of a phrase but to the demand for one more, the will to answer every ending with another measure, so that a blow that should have been the last one finds the wearer already calling for the next. It never falls silent, and it never quite lets go, always one beat past the point the music was meant to stop — and there is a deep, roaring steadiness in it, the steadiness of a hall that has stood up and decided the performance is not over and will not, under any ending, sit back down.",
+  "attributes": {
+    "stats": {
+      "ac": 9,
+      "hp": 30
+    }
+  },
+  "effects": [],
+  "messages": [],
+  "equip_slot": "neck",
+  "weight": 1,
+  "value": 860,
+  "rarity": "epic",
+  "attack_ref": null
+}

--- a/data/items/the-encore-map.json
+++ b/data/items/the-encore-map.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 15,
+  "id": "the-encore-map",
+  "name": "Map of the Encore",
+  "description": "Not a chart of a place but a rendering of a refusal — the closing double bar of a finished score, ruled the way a composer rules the end of a work, and then, scrawled past it in a hand that should not have kept writing, one more measure that was never meant to be there. The route through is read the way a musician reads a piece called back after its ending: not as somewhere to go but as a demand to answer, threshold to a hall that would not empty, each measure a step further past the point the song was allowed to stop. It is not colder than the map of the Coda and it does not resolve the way that one resolves; it insists, faintly and continuously, a leaf of vellum forever in the act of being called back for one more piece, so that to hold it is to feel your own pulse pressed onward past the double line into music the world was never written to play, toward the roaring stage where the map, unlike the song, simply refuses to end.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [],
+  "messages": [],
+  "weight": 1,
+  "value": 80,
+  "map_area_id": "the-encore"
+}

--- a/data/items/the-final-encore.json
+++ b/data/items/the-final-encore.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 15,
+  "id": "the-final-encore",
+  "name": "the Final Encore",
+  "description": "The great two-handed maul the Ovation swung to demand one more piece of a finished world — a weapon of refusal made solid, its head a roar of applause caught at the instant it crashed down and grown to killing weight, bound in a lattice of clapped air that presses one low insistent beat against the hand and never quite falls silent. Where the Coda's Closing Chord held the ending after the last beat, this holds the refusal of it: the demand that will not let a phrase be over, kept from spending itself so that it might be spent on something else instead. Drawn back, it gathers the whole unspent roar of the hall into its head; brought down, it does not merely strike but calls for more, ending the note of the thing it hits only to demand another, the way an audience refuses to let a performance close — insistently, and with a crash that rings on after the blow like a hall roaring for one last piece. It is the loudest and most restless weapon yet drawn from the deep song, and it lands hardest for the hand willing to keep swinging, to answer every ending with one more measure.",
+  "attributes": {
+    "stats": {
+      "strength": 14,
+      "dexterity": 11,
+      "hp": 26
+    }
+  },
+  "effects": [],
+  "messages": [],
+  "equip_slot": "weapon",
+  "weight": 6,
+  "value": 1240,
+  "rarity": "epic",
+  "attack_ref": "attack.the-final-encore",
+  "two_handed": true
+}

--- a/data/items/unspent-encore.json
+++ b/data/items/unspent-encore.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 15,
+  "id": "unspent-encore",
+  "name": "an unspent encore",
+  "description": "A single measure of music that was never written and never played — the one more piece the Ovation demanded of a finished world, wrung out of the roaring hall and caught at the instant before it could be forced to sound, held in a lattice of clapped air that presses one low insistent beat against the palm and never quite lets go. It is stranger than a resolved overtone and more restless than any material yet drawn from the deep song: where the overtone was the released ending of the world's oldest chord, this is the refusal of that ending, the extra measure that should not exist, a scrap of pure demand for more kept from spending itself. Bonewrights and rune-singers name it warily, uncertain a thing can be worked from a piece of music the world was never meant to play, yet certain it could be forged into an edge that never lets a blow be the last one, or a ward that answers every ending with a demand for one more beat — but only by a hand willing to keep giving, measure after measure, the way the hall keeps calling and will not stop.",
+  "attributes": {
+    "stats": {}
+  },
+  "effects": [],
+  "messages": [],
+  "weight": 1,
+  "value": 240,
+  "rarity": "epic"
+}

--- a/data/mobs/encore-clamoring-echo.json
+++ b/data/mobs/encore-clamoring-echo.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "encore-clamoring-echo",
+  "name": "a clamoring echo",
+  "max_hp": 1320,
+  "attack_id": "attack.encore-clamoring-echo",
+  "aggressive": true,
+  "tags": ["construct", "resonant", "the-encore"],
+  "spawn_room_id": "encore-echo-chamber",
+  "max_count": 3,
+  "respawn_ticks": 84,
+  "xp_reward": 1920,
+  "loot": [
+    {
+      "item_id": "unspent-encore",
+      "drop_chance": 0.32
+    }
+  ],
+  "gold_drop": {
+    "min": 380,
+    "max": 540
+  }
+}

--- a/data/mobs/encore-hollow-ovation.json
+++ b/data/mobs/encore-hollow-ovation.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "encore-hollow-ovation",
+  "name": "a hollow ovation",
+  "max_hp": 1300,
+  "attack_id": "attack.encore-hollow-ovation",
+  "aggressive": true,
+  "tags": ["construct", "resonant", "the-encore"],
+  "spawn_room_id": "encore-empty-seats",
+  "max_count": 2,
+  "respawn_ticks": 86,
+  "xp_reward": 1900,
+  "loot": [
+    {
+      "item_id": "unspent-encore",
+      "drop_chance": 0.3
+    }
+  ],
+  "gold_drop": {
+    "min": 380,
+    "max": 530
+  }
+}

--- a/data/mobs/encore-standing-call-wraith.json
+++ b/data/mobs/encore-standing-call-wraith.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "encore-standing-call-wraith",
+  "name": "a standing-call wraith",
+  "max_hp": 1360,
+  "attack_id": "attack.encore-standing-call-wraith",
+  "aggressive": true,
+  "tags": ["construct", "resonant", "the-encore"],
+  "spawn_room_id": "encore-standing-call",
+  "max_count": 2,
+  "respawn_ticks": 88,
+  "xp_reward": 1980,
+  "loot": [
+    {
+      "item_id": "unspent-encore",
+      "drop_chance": 0.36
+    }
+  ],
+  "gold_drop": {
+    "min": 400,
+    "max": 560
+  }
+}

--- a/data/mobs/encore-wisp.json
+++ b/data/mobs/encore-wisp.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 4,
+  "id": "encore-wisp",
+  "name": "an encore wisp",
+  "max_hp": 1420,
+  "attack_id": "attack.encore-wisp",
+  "aggressive": true,
+  "tags": ["construct", "resonant", "the-encore"],
+  "spawn_room_id": "encore-final-bow",
+  "max_count": 1,
+  "respawn_ticks": 95,
+  "xp_reward": 2160,
+  "loot": [
+    {
+      "item_id": "unspent-encore",
+      "drop_chance": 0.4
+    }
+  ],
+  "gold_drop": {
+    "min": 420,
+    "max": 580
+  }
+}

--- a/data/mobs/the-ovation.json
+++ b/data/mobs/the-ovation.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 4,
+  "id": "the-ovation",
+  "name": "the Ovation",
+  "max_hp": 2600,
+  "attack_id": "attack.the-ovation",
+  "special_attack_id": "attack.the-ovation-encore",
+  "aggressive": true,
+  "world_boss": true,
+  "tags": ["construct", "resonant", "boss", "the-encore"],
+  "spawn_room_id": "encore-ovation",
+  "max_count": 1,
+  "respawn_ticks": 360,
+  "xp_reward": 5600,
+  "loot": [
+    {
+      "item_id": "unspent-encore",
+      "drop_chance": 1.0
+    },
+    {
+      "item_id": "the-final-encore",
+      "drop_chance": 0.5
+    },
+    {
+      "item_id": "medal-of-the-standing-ovation",
+      "drop_chance": 0.45
+    },
+    {
+      "item_id": "the-encore-map",
+      "drop_chance": 1.0
+    },
+    {
+      "item_id": "world-atlas",
+      "drop_chance": 0.1
+    }
+  ],
+  "gold_drop": {
+    "min": 1150,
+    "max": 1700
+  }
+}

--- a/data/rooms/coda-resolution.json
+++ b/data/rooms/coda-resolution.json
@@ -5,7 +5,8 @@
   "description": "The final measure lets you through into a vast closing chamber where the whole withheld music of the world at last has a body, and it is called the Coda — the resolving chord itself, the ending the Choir began and the Unsung refused and the Undersong sustained and the Interval suspended and the Fermata held one arrested instant short of falling for as long as there has been a world to hold it over. It fills the chamber the way the First Hum filled the source and the Fermata filled the gap: not resting and not floating, simply resolving, an enormous slow-closing shape of overtone and released cold and finished silence gathering itself toward the single chord that ends everything the music was ever building toward. It is not sound and it is not the absence of sound. It is the close, the last chord given just enough shape to defend the resolution it has waited an eternity to sound — and it will sound it through you, because a coda needs a final beat to fall on and yours is the living pulse that broke the Fermata and carried the released stroke down here to complete it. As you cross into the chamber the Coda turns the whole closing weight of the world's last chord onto you, and you understand that the phrase does not end when the Coda resolves. It ends when it resolves on something with a heartbeat, and you have brought it the only one there is. There is nothing beyond this. There is only the resolving chord, and it means to end on you.",
   "item_ids": [],
   "exits": {
-    "up": "coda-final-measure"
+    "up": "coda-final-measure",
+    "north": "encore-threshold"
   },
   "min_level": 87,
   "is_outdoor": false,

--- a/data/rooms/encore-echo-chamber.json
+++ b/data/rooms/encore-echo-chamber.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 8,
+  "id": "encore-echo-chamber",
+  "name": "The Echo Chamber",
+  "description": "East of the applauding hall the seats fall away into a curved chamber of black stone shaped to hold sound and never let it leave, and it is full of every note the music ever played. They come without a source. The First Hum's low founding drone, the Choir's demanded resolution, the Undersong's sustaining, the Interval's arrested breath, the Fermata's withheld stroke, the Coda's closing chord — all of it is here at once, reverberating off walls built to feed an echo back into itself forever, a piece that has ended reduced to nothing but its own reflections, playing on with no one sounding it. The echoes have been repeating so long that they have grown hungry the way a repeated word grows strange, worn smooth of meaning and left with only the shape of wanting more. They gather out of the overlapping reverberation, shapes wrung from a note played back one time too many, and they turn toward the one sound in the chamber that is not an echo of something already ended: your heartbeat, new, unrepeated, the single fresh measure in a room that has run out of anything else to play. There is no waiting them out; an echo does not tire, it only repeats, and these have decided to repeat themselves through you. The only way onward loops back west to the hall of empty seats.",
+  "item_ids": [],
+  "exits": {
+    "west": "encore-empty-seats"
+  },
+  "min_level": 90,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "A note the world played an age ago comes around again off the curved walls, thinner and hungrier each pass, worn down to the pure shape of wanting to be played once more.",
+    "The overlapping echoes fold together for a moment into something almost like the whole song, then come apart again, each reflection reaching for a fresh sound to feed on.",
+    "Your own heartbeat catches in the chamber and begins, faintly, to echo — and the echoes turn toward the sound of it, hungry for a measure that has not yet been repeated to nothing."
+  ]
+}

--- a/data/rooms/encore-empty-seats.json
+++ b/data/rooms/encore-empty-seats.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 8,
+  "id": "encore-empty-seats",
+  "name": "The Hall of Empty Seats",
+  "description": "The threshold opens into a vast dark hall banked on every side with rows upon rows of empty seats, and every one of them is applauding. There are no hands. There is no audience. There has not been an audience since before the first note of the world, if there ever was one at all — and still the seats clap, tier on tier of them rising into a dark that has no ceiling, a roar of ovation pouring down onto a stage where the piece has already ended and taken its final bow. This is the body of the refusal: a hall that will not let the performance be over, applauding a music that has stopped, and the longer it applauds the more the applause stops being praise and becomes a summons. The sound has weight here. It presses on the chest the way the Coda's cold pressed, except that the Coda pressed toward an ending and this presses against one, driving the stopped music to start again whether it has anything left to play or not. Your own pulse answers the clapping without meaning to, and you understand that the hall has mistaken your living heartbeat for the encore it is demanding, the one unspent measure left in a finished world. Passages break the banked seats east and west, and beyond the stage the rows narrow toward a final bow, and past that, the thing that leads the applause.",
+  "item_ids": [],
+  "exits": {
+    "south": "encore-threshold",
+    "east": "encore-echo-chamber",
+    "west": "encore-standing-call",
+    "north": "encore-final-bow"
+  },
+  "min_level": 89,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "A whole tier of empty seats rises as one in a standing ovation, clapping harder, and the roar of it rolls down over the stage and does not stop.",
+    "The applause gathers into a rhythm for a moment, a clapped demand for one more measure, and your heartbeat stumbles into time with it before you can catch it.",
+    "Somewhere in the unlit upper rows a single seat begins to clap, and then a hundred, and then all of them, calling the ended music back to sound."
+  ]
+}

--- a/data/rooms/encore-final-bow.json
+++ b/data/rooms/encore-final-bow.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 8,
+  "id": "encore-final-bow",
+  "name": "The Final Bow",
+  "description": "The hall narrows past the stage into a long approach where the rows of empty seats lean in from both sides, close and steep and roaring, funneling every scrap of the ovation toward a single point ahead. This is the final bow, the moment the players step out to meet the applause one last time — except that here the bow never finishes and the players never leave, because the hall will not let them. The roar is a physical thing now, a pressure driving down the narrowing corridor with the whole weight of a refused ending behind it, and you can feel the difference from the Coda's final measure in your chest: the measure counted down toward a close, and this counts up, swelling, gathering, driving toward not an ending but a beginning that should never come, the impossible extra piece the hall has decided to have. Ahead the corridor opens into a wide stage drowned in applause, and something stands at the center of it with the whole ovation pouring into it and out of it at once, taller and louder the nearer you come, the demand for more given a body and a will. The way back leads south to the hall of empty seats; ahead, north, is the ovation itself, and it has been waiting for an encore since before the world learned how to end.",
+  "item_ids": [],
+  "exits": {
+    "south": "encore-empty-seats",
+    "north": "encore-ovation"
+  },
+  "min_level": 93,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "The applause funneling down the narrowing corridor swells another degree, driving forward, gathering toward the stage where the encore means to begin.",
+    "The leaning seats roar louder on both sides at once, and the pressure of the refused ending presses you onward toward the thing that leads the call.",
+    "Ahead, the ovation gathers a fraction higher, the demand for one more piece swelling toward the moment it will have you step out and be it."
+  ]
+}

--- a/data/rooms/encore-ovation.json
+++ b/data/rooms/encore-ovation.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 8,
+  "id": "encore-ovation",
+  "name": "The Ovation",
+  "description": "The corridor opens onto a wide dark stage, and standing at the center of it, with the whole roar of the empty hall pouring into it and back out again without pause, is the thing that has refused to let the world end — the Ovation, the applause given a body, the demand for one more piece made hostile and enormous and awake. It does not sit and it does not float and it does not resolve the way the Coda resolved; it applauds, endlessly, a towering shape of clapped insistence and repeating echo and standing call gathered into one will, and every measure of ovation it takes in it drives back out as a single wordless command: again. It has been calling for an encore since before there was a world to end, and now the ended music has come to it wearing your face and carrying the one thing the whole finished song ran out of — a living, unrepeated heartbeat, the last unspent measure, the encore it has waited an eternity to wring out of a work that had already taken its final bow. The Choir demanded a resolution and the Coda gave it; but the Ovation will not accept that any resolution is final, and it means to have one more piece out of you, and another, and another, playing your borrowed pulse out onto its stage over and over until there is nothing left of you to call back. There is nothing beyond this stage. There is only the applause, and it will not stop, and it means to play its encore on you.",
+  "item_ids": [],
+  "exits": {
+    "south": "encore-final-bow"
+  },
+  "min_level": 95,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "The Ovation takes in the whole roar of the hall and drives it back out as one wordless demand — again, again — and the stage shakes with the refusal to let the music end.",
+    "A wall of applause rolls off the towering shape and breaks over the stage, and in the crash of it you can hear the single word the whole ovation is clapping: more.",
+    "For one vast moment the calling seems about to spend itself and fall at last into the silence the Coda earned — and then the Ovation lifts, and swells, and refuses, and calls the encore out of your heartbeat again."
+  ]
+}

--- a/data/rooms/encore-standing-call.json
+++ b/data/rooms/encore-standing-call.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 8,
+  "id": "encore-standing-call",
+  "name": "The Standing Call",
+  "description": "West of the applauding hall the seats climb into a single unbroken tier that has risen to its feet and will not sit down, and the demand pouring off it is no longer applause at all — it is a call, the wordless roar a hall makes when it has decided the performance is not allowed to be over and means to have another piece whether one exists or not. The Choir demanded a resolution and was answered; the Unsung refused to sing and was overruled; but this is neither demand nor refusal, it is insistence, the flat implacable will of an audience that has stood up and started calling for an encore and simply will not stop calling, not when the players have gone, not when the score has ended, not when there is nothing left in the whole finished world to bring back out onto the stage. The insistence has taken shape here, wrung solid out of the standing roar, forms made of pure refusal-to-let-go that press toward you with the whole weight of a hall's demand behind them. They do not want to end you. They want you to continue — to be the encore, to give the one more measure they are calling for, to play on past the point your own music was ever meant to stop, until there is nothing left of you to call back. The way out lies east to the hall of empty seats.",
+  "item_ids": [],
+  "exits": {
+    "east": "encore-empty-seats"
+  },
+  "min_level": 90,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "The standing tier calls louder, a wall of insistence with no words in it, refusing to let the ended music go, refusing to sit, refusing to be finished.",
+    "A shape of pure demand peels loose from the roaring tier and presses toward you, carrying the whole implacable will of a hall that will not accept an ending.",
+    "The calling gathers to a single flat note of insistence, and for a moment it is not asking for more music but for you, the last unspent measure it means to wring the encore out of."
+  ]
+}

--- a/data/rooms/encore-threshold.json
+++ b/data/rooms/encore-threshold.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 8,
+  "id": "encore-threshold",
+  "name": "The Refused Ending",
+  "description": "The Coda resolved. The last chord fell, and the phrase the whole world had been building toward since its first note came, at last, to its end — and then the hall would not empty. You feel it before you understand it: the resolving weight that meant to close on your heartbeat has closed, and instead of silence there is a sound rising on the far side of the ending, faint and enormous and impossible, the sound of a room that has been told the piece is over and refuses to accept it. This is not deeper than the Coda and it is not after it in the way the Coda was after the Fermata; it is against it, the one motion the whole descending music never accounted for. A performance ends when the score ends. But a hall does not always let the score decide. Sometimes the seats keep applauding into a silence that was meant to be final, and the applause becomes a demand, and the demand calls the music back for one more piece that was never written — an encore, wrung out of a work that had already finished. You are standing in the first breath of that refusal, the threshold where the ended song is being called back to sound again, and the applause ahead is not glad. It is hungry. It wants more, and there is nothing left to give it but you. The way back leads south into the resolved chamber; ahead, north, the calling grows into a hall of empty seats.",
+  "item_ids": [],
+  "exits": {
+    "south": "coda-resolution",
+    "north": "encore-empty-seats"
+  },
+  "min_level": 89,
+  "is_outdoor": false,
+  "ambient_messages": [
+    "The applause on the far side of the ending swells a fraction louder, insistent, the sound of a hall that will not accept that the piece is done.",
+    "A wave of clapping rolls out of the dark ahead and breaks over you, coming from no hands you can see, demanding a music that has already ended.",
+    "For a moment the calling seems about to fade into the silence the Coda earned — and then it gathers instead, and lifts, and refuses, and comes on."
+  ]
+}

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -224,6 +224,7 @@ a validator rule, not a manual checkbox.
 | The Undersong (`the-undersong`) | ✅ #655 | ✅ (undersong-cull, undersong-source #656) · signature boss loot: the First Hum drops the Underhum Knell + Standing Tone Torc #677 | ✅ #655 |
 | The Interval (`the-interval`) | ✅ #671 | ✅ (interval-cull, interval-fermata #672) · signature boss loot: the Fermata drops the Caesura Stroke + Crown of the Held Beat #677 | ✅ #671 |
 | The Coda (`the-coda`) | ✅ #697 | ✅ (coda-cull, coda-resolution #698) · signature boss loot: the Coda drops the Closing Chord + Signet of Final Resolution #703 | ✅ #697 (81-88) |
+| The Encore (`the-encore`) | ✅ #727 · signature boss loot: the Ovation drops the Final Encore + Medal of the Standing Ovation | 🔨 #728 (quest chain follow-up) | ✅ #727 (89-96) |
 
 ## Systems
 


### PR DESCRIPTION
Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)