### PR TITLE
chore(design-focus): close first-hour focus, open first-death-recovery

### DIFF
--- a/docs/design-focus.md
+++ b/docs/design-focus.md
@@ -27,46 +27,77 @@ it actually is, instead of drifting to the next novel feature.
 - If this file is missing or has no active focus, the game-designer falls back
   to its normal process (completeness audit, variety pressure).
 
-## Active focus: the new player's first hour
+## Active focus: first death & recovery
 
-_Declared 2026-07-19 after a manual testplay (human paladin): standard equip
-verbs missing, lethal aggressive mobs adjacent to spawn, death within minutes.
-The feature matrix was green while the first hour was not fun — this focus
-closes that gap._
+_Declared 2026-07-19 immediately after the "new player's first hour" focus
+closed out all its exit criteria. `docs/feature-matrix.md` § Player journeys
+shows every journey row green except `First death & recovery`, which is
+`❌` on both "Commands discoverable" and "Scripted playthrough" — the clearest
+remaining weak spot on the board. Code inspection turned up a concrete bug
+feeding the discoverability gap: the death message hardcodes
+`DeathSettings.RESPAWN_ROOM_ID` ("training-yard") as raw text instead of
+resolving the player's real (possibly `BIND`-anchored) respawn room, and never
+mentions the `CORPSE`/`RESURRECT` recovery tools or that `HELP` has nothing on
+death at all._
+
+**Goal**: a player who dies — for any reason, at any level — immediately
+understands what just happened, where they will wake up (correctly, matching
+where they actually respawn), what they lost and what they kept, and how to
+get back to their gear, entirely from in-game text, without needing to guess
+a command or consult a wiki.
+
+### Exit criteria
+
+- [ ] The death message names the player's real respawn room (respecting a
+      `BIND`-anchored `boundRoomId`) instead of a hardcoded raw room id, and
+      teaches the `CORPSE` command as the way back to a dropped corpse; the
+      grace-protected message states the grace level so a player understands
+      it is temporary (#802)
+- [ ] `HELP death` (aliases `HELP dying`, `HELP respawn`) explains what
+      happens at 0 HP, the grace mechanic, corpse decay, and `RESURRECT`,
+      mirroring the existing `HELP hazards`/`HELP combat` static topics
+      (#802)
+- [ ] A scripted playthrough (extension of `scripts/smoke-test.sh`) proves
+      the whole journey end-to-end: a character dies (combat or environmental),
+      the death message correctly names the real respawn room and mentions
+      recovery tools, the player respawns in that same room, and — for a
+      non-grace death — `CORPSE` walks them back to their remains
+- [ ] The `First death & recovery` row in
+      [`feature-matrix.md`](feature-matrix.md) § Player journeys is ✅ across
+      every column
+
+## History
+
+### The new player's first hour (2026-07-19 → 2026-07-19)
 
 **Goal**: a brand-new player who types plausible commands and explores
 naturally survives their first session, learns the core loop in-game, reaches
 level 5, and has a reason to keep playing.
 
-### Exit criteria
+All exit criteria merged:
 
-- [x] Standard MUD verbs work for arming/wearing gear: `WIELD`/`WEAR`/`HOLD`
-      equip, `REMOVE` unequips (#777, merged via #784)
-- [x] No unavoidable newbie death: no aggressive mob within 3 rooms of the
-      spawn room can kill a level-1 character faster than they can react, and
-      any remaining danger is telegraphed *before* the player commits
-      (#778 merged via #786, #779 merged via #787, #780 merged via #788)
-- [x] The player is armed from creation: newbie kit includes a starter weapon
-      (#781, merged via #789)
-- [x] Survival commands (`CONSIDER`, `FLEE`, `EQUIP`/`WIELD`) are taught
-      in-game before the first fight (#782, merged via #790)
-- [x] Every harmful effect a starter-area mob can apply has a counter
-      purchasable near the starter area (#783, merged via #792)
-- [x] The starter quest chain walks the player along the safe difficulty ramp
-      (training dummy → rat → kobold/goblin → spider), each completion hinting
-      at the next step (#795)
-- [x] A scripted golden-path playthrough (extension of `scripts/smoke-test.sh`)
-      proves it end-to-end: create character → read hints → win first fight →
-      complete first quest → still alive (#798 — phase 3e drives create → hints →
-      WIELD → accept rat-catcher → kill Giant Rats to 5/5 → QUEST COMPLETE →
-      SCORE shows positive HP + 30g/75xp reward + Rat Slayer title; also fixed
-      the rats wandering unbounded out of the hollow, `data/mobs/rat.json`
-      `wanders: false`)
-- [x] The `First session` and `Levels 1–5` rows in
-      [`feature-matrix.md`](feature-matrix.md) § Player journeys are all ✅
-      (both rows now ✅ across every column after #798 flipped Scripted
-      playthrough)
-
-## History
-
-_(none yet — first focus declared 2026-07-19)_
+- Standard MUD verbs work for arming/wearing gear: `WIELD`/`WEAR`/`HOLD`
+  equip, `REMOVE` unequips (#777, merged via #784)
+- No unavoidable newbie death: no aggressive mob within 3 rooms of the spawn
+  room can kill a level-1 character faster than they can react, and any
+  remaining danger is telegraphed *before* the player commits (#778 merged
+  via #786, #779 merged via #787, #780 merged via #788)
+- The player is armed from creation: newbie kit includes a starter weapon
+  (#781, merged via #789)
+- Survival commands (`CONSIDER`, `FLEE`, `EQUIP`/`WIELD`) are taught in-game
+  before the first fight (#782, merged via #790)
+- Every harmful effect a starter-area mob can apply has a counter purchasable
+  near the starter area (#783, merged via #792)
+- The starter quest chain walks the player along the safe difficulty ramp
+  (training dummy → rat → kobold/goblin → spider), each completion hinting at
+  the next step (#795)
+- A scripted golden-path playthrough (extension of `scripts/smoke-test.sh`)
+  proves it end-to-end: create character → read hints → win first fight →
+  complete first quest → still alive (#798 — phase 3e drives create → hints →
+  WIELD → accept rat-catcher → kill Giant Rats to 5/5 → QUEST COMPLETE →
+  SCORE shows positive HP + 30g/75xp reward + Rat Slayer title; also fixed the
+  rats wandering unbounded out of the hollow, `data/mobs/rat.json`
+  `wanders: false`)
+- The `First session` and `Levels 1–5` rows in
+  [`feature-matrix.md`](feature-matrix.md) § Player journeys are all ✅ (both
+  rows now ✅ across every column after #798 flipped Scripted playthrough)


### PR DESCRIPTION
## Summary
- The "new player's first hour" focus has all exit criteria merged and both `First session`/`Levels 1-5` matrix rows are fully green; move it to History.
- Declare the next focus: `First death & recovery`, the weakest remaining row in `docs/feature-matrix.md` § Player journeys (`❌` on Commands discoverable + Scripted playthrough).
- File its first focus-advancing issue: #802 (death message hardcodes the raw respawn room id instead of the real/`BIND`-anchored room, never mentions `CORPSE`/`RESURRECT`, and `HELP` has no death/respawn topic).

## Test plan
- [ ] N/A — documentation-only change (`docs/design-focus.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)